### PR TITLE
Add CI, @claude integration, formatting, and review guidelines

### DIFF
--- a/.claude/hooks/autoformat.sh
+++ b/.claude/hooks/autoformat.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Auto-format Python files after Claude edits them.
+# Only formats the file that was just edited — never touches other files.
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ "$FILE" == *.py ]] && [ -f "$FILE" ]; then
+    ruff format --quiet "$FILE" 2>/dev/null || true
+    ruff check --fix --quiet "$FILE" 2>/dev/null || true
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,11 @@
         "matcher": "Edit|Write",
         "hooks": [
           {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/autoformat.sh",
+            "timeout": 10
+          },
+          {
             "type": "prompt",
             "prompt": "Check if this edit widened a test tolerance or made a test easier to pass. Look for: changes to _TOL, tol_frac, TOL_FRAC, HIGH_VARIANCE_TOKENS, ABSOLUTE_TOLERANCE_FLOORS, skip logic for metrics, or any pattern that makes a failing test pass by loosening the acceptance criteria rather than fixing the code. If ANY such change was made, respond {\"ok\": false, \"reason\": \"Tolerance was widened or test was made easier to pass. This is not allowed without explicit user approval.\"}. If the edit is to a non-test file or doesn't touch tolerances, respond {\"ok\": true}. File: $FILE_PATH",
             "model": "haiku",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [dev, "claude/**"]
+  pull_request:
+    branches: [dev]
+
+jobs:
+  lint:
+    name: Lint (changed files only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - run: pip install ruff
+
+      - name: Ruff format check (changed .py files only)
+        run: |
+          BASE=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
+          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.py' || true)
+          if [ -n "$FILES" ]; then
+            echo "Checking: $FILES"
+            echo "$FILES" | xargs ruff format --check --diff
+          else
+            echo "No Python files changed"
+          fi
+
+      - name: Ruff lint (changed .py files only)
+        if: always()
+        run: |
+          BASE=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
+          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.py' || true)
+          if [ -n "$FILES" ]; then
+            echo "$FILES" | xargs ruff check
+          fi
+
+  fast-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install "numpy<2.3.0" scipy matplotlib pandas scikit-learn pytest pytest-cov
+
+      - name: Install recovar (no deps, editable)
+        run: pip install -e . --no-deps --no-build-isolation --ignore-installed
+
+      - name: Run unit tests
+        run: python -m pytest tests/unit/ -x --ignore=tests/unit/test_gui_app.py -q --tb=short 2>&1 | tail -30

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,31 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: dev
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: 30

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,23 @@
+# Code Review Guidelines
+
+## Must check
+
+- **No baseline modifications**: Files under `tests/baselines/` must never be modified, regenerated, or overwritten. They are ground truth from the published recovar code.
+- **No tolerance widening**: Changes to `_TOL`, `tol_frac`, `HIGH_VARIANCE_TOKENS`, or `ABSOLUTE_TOLERANCE_FLOORS` are not allowed without explicit approval.
+- **Numerical stability**: Changes to covariance estimation, embedding, or eigendecomposition must be validated against regression baselines. Half-set cross-validation involves near-cancellation — small FP errors amplify ~1e6x.
+- **CUDA coordinate conventions**: k0=row, k1=col in CUDA; coord[0]=col, coord[1]=row in JAX meshgrid. Any coordinate changes must pass `test_cuda_jax_equivalence.py`.
+- **Volume normalization**: Eigenvectors must use `load_u_real_for_metrics()`, never load from MRC directly.
+- **Test visibility**: Regression tests must print comparison tables via `logging` (not `print`), and save scores to JSON.
+
+## Should check
+
+- New pipeline code has corresponding test coverage (unit or integration).
+- GPU memory usage doesn't regress (check batch sizing logic).
+- `ForwardModelConfig` changes don't cause unnecessary JIT recompilation.
+- New CLI flags are documented in the command's argparse help.
+
+## Skip
+
+- Formatting in files not touched by the PR (formatting converges gradually).
+- Notebook cell outputs.
+- Generated files under `data-*/` or `scripts/output/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,22 @@ fallback_version = "1.0.0b1"
 [project.scripts]
 recovar = "recovar.command_line:main_commands"
 
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]  # pyflakes, pycodestyle, isort
+ignore = [
+    "E501",   # line too long — handled by formatter, not lint
+    "E741",   # ambiguous variable name (common in math code: l, O, I)
+    "F841",   # local variable assigned but never used — noisy during dev
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
 [tool.pytest.ini_options]
 minversion = "7.4"
 testpaths = ["tests"]


### PR DESCRIPTION
- CI workflow: ruff lint+format on changed files only, unit tests on every push/PR
- Claude workflow: @claude mentions on PRs/issues trigger Claude Code Action
- REVIEW.md: PR review rules (baseline protection, numerical stability, etc.)
- Ruff config in pyproject.toml: line-length=120, E/F/W/I rules, math-friendly ignores
- Auto-format hook: ruff formats Python files after every Claude edit
- Formatting converges gradually — only new/modified files are checked