### PR TITLE
Add docs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "recovar/**"  # API docs pull from source
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install mkdocs
+        run: pip install mkdocs-material mkdocstrings[python]
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow that deploys mkdocs site to GitHub Pages on every push to dev that touches docs/, mkdocs.yml, or source files.

After merging, enable Pages at Settings → Pages → source: branch `gh-pages`, folder `/ (root)`.

## Test plan

- [ ] CI passes
- [ ] After merge + Pages enabled, https://ma-gilles.github.io/recovar/ loads