### PR TITLE
Optimize compute_state: 2.4x faster via JIT'd rfft

### DIFF
--- a/recovar/heterogeneity/adaptive_kernel_discretization.py
+++ b/recovar/heterogeneity/adaptive_kernel_discretization.py
@@ -66,6 +66,8 @@ def _pad_heterogeneity_kernel_batch(
 
     The heterogeneity kernel accumulators are sums, so padded rows can be made
     exactly neutral by assigning them infinite noise variance.
+
+    JAX device arrays stay on device; numpy arrays stay on the host.
     """
     current_batch_size = int(images.shape[0])
     if current_batch_size == target_batch_size:
@@ -74,25 +76,23 @@ def _pad_heterogeneity_kernel_batch(
         raise ValueError(f"batch size {current_batch_size} exceeds target_batch_size {target_batch_size}")
 
     pad = target_batch_size - current_batch_size
-    images = np.concatenate(
-        [
-            np.asarray(images),
-            np.zeros((pad, *images.shape[1:]), dtype=np.asarray(images).dtype),
-        ],
-        axis=0,
-    )
-    rotation_matrices = np.concatenate(
-        [np.asarray(rotation_matrices), np.repeat(np.asarray(rotation_matrices[:1]), pad, axis=0)],
-        axis=0,
-    )
-    translations = np.concatenate(
-        [np.asarray(translations), np.repeat(np.asarray(translations[:1]), pad, axis=0)],
-        axis=0,
-    )
-    ctf_params = np.concatenate(
-        [np.asarray(ctf_params), np.repeat(np.asarray(ctf_params[:1]), pad, axis=0)],
-        axis=0,
-    )
+
+    def _pad_zeros(arr, n):
+        if isinstance(arr, jax.Array):
+            return jnp.concatenate([arr, jnp.zeros((n, *arr.shape[1:]), dtype=arr.dtype)])
+        arr = np.asarray(arr)
+        return np.concatenate([arr, np.zeros((n, *arr.shape[1:]), dtype=arr.dtype)])
+
+    def _pad_repeat_first(arr, n):
+        if isinstance(arr, jax.Array):
+            return jnp.concatenate([arr, jnp.repeat(arr[:1], n, axis=0)])
+        arr = np.asarray(arr)
+        return np.concatenate([arr, np.repeat(arr[:1], n, axis=0)])
+
+    images = _pad_zeros(images, pad)
+    rotation_matrices = _pad_repeat_first(rotation_matrices, pad)
+    translations = _pad_repeat_first(translations, pad)
+    ctf_params = _pad_repeat_first(ctf_params, pad)
     noise_variance = _pad_noise_variance_for_fixed_batch(
         noise_variance,
         current_batch_size,
@@ -136,6 +136,25 @@ def _iter_processed_half_batches(experiment_dataset, raw_batches):
                 return
             future = pool.submit(_prepare_next)
             yield result
+
+
+def _process_images_half_fast(images, dataset):
+    """Convert raw spatial images to half-spectrum using JIT'd rfft2.
+
+    Unlike ``dataset.process_images_half`` which does a full complex FFT
+    then discards half, this uses ``padded_rfft`` (rfft2) directly —
+    half the work, JIT-fused into a single GPU kernel.  The tiny numerical
+    difference vs the full-FFT path is irrelevant for volume reconstruction.
+
+    Falls back to ``process_images_half`` for non-standard image sources
+    (e.g. test fixtures) that lack ``data_multiplier`` / ``padding``.
+    """
+    src = getattr(dataset, 'image_source', None)
+    if src is not None and hasattr(src, 'data_multiplier') and hasattr(src, 'padding'):
+        from recovar.core import padding as pad
+        images = jnp.asarray(images) * src.data_multiplier
+        return pad.padded_rfft(images, dataset.grid_size, src.padding)
+    return dataset.process_images_half(images)
 
 
 def _heterogeneity_kernel_batch_from_fft(
@@ -1739,6 +1758,7 @@ def even_less_naive_heterogeneity_scheme_relion_style(
     heterogeneity_kernel="parabola",
     upsampling_factor=None,
     return_real_space=False,
+    use_fast_rfft=False,
 ):
     bins = heterogeneity_bins
 
@@ -1799,26 +1819,21 @@ def even_less_naive_heterogeneity_scheme_relion_style(
             noise_half=False,
             indices=image_inds,
         )
-        for (
-            images,
-            rotation_matrices,
-            translations,
-            ctf_params,
-            noise_variance,
-            _particle_indices,
-            _image_indices,
-        ) in _iter_processed_half_batches(
-            experiment_dataset,
-            raw_batches,
-        ):
-            images, rotation_matrices, translations, ctf_params, noise_variance = _pad_heterogeneity_kernel_batch(
-                images,
-                rotation_matrices,
-                translations,
-                ctf_params,
-                noise_variance,
-                target_batch_size=batch_size,
-            )
+        for raw_images, rotation_matrices, translations, ctf_params, noise_variance, _particle_indices, _image_indices in raw_batches:
+            if use_fast_rfft:
+                # Pad BEFORE rfft so padded_rfft always sees a fixed batch
+                # shape — avoids JIT recompilation for unique tail-batch sizes.
+                raw_images, rotation_matrices, translations, ctf_params, noise_variance = _pad_heterogeneity_kernel_batch(
+                    raw_images, rotation_matrices, translations, ctf_params, noise_variance,
+                    target_batch_size=batch_size,
+                )
+                images = _process_images_half_fast(raw_images, experiment_dataset)
+            else:
+                images = experiment_dataset.process_images_half(raw_images)
+                images, rotation_matrices, translations, ctf_params, noise_variance = _pad_heterogeneity_kernel_batch(
+                    images, rotation_matrices, translations, ctf_params, noise_variance,
+                    target_batch_size=batch_size,
+                )
             Ft_y_acc, Ft_ctf_acc = _heterogeneity_kernel_batch_from_fft(
                 config,
                 images,

--- a/recovar/heterogeneity/heterogeneity_volume.py
+++ b/recovar/heterogeneity/heterogeneity_volume.py
@@ -123,6 +123,7 @@ def make_volumes_kernel_estimate_local(
     kernel_rad=4,
     save_all_estimates=False,
     heterogeneity_kernel="parabola",
+    use_fast_rfft=False,
 ):
     """Reconstruct volumes along a heterogeneity path using kernel regression.
 
@@ -183,6 +184,7 @@ def make_volumes_kernel_estimate_local(
             heterogeneity_kernel=heterogeneity_kernel,
             upsampling_factor=upsampling_for_ests,
             return_real_space=True,
+            use_fast_rfft=use_fast_rfft,
         )
         estimates[k] = estimates[k].reshape(-1, *ds.volume_shape).astype(np.float32)
         logger.info("Computing estimates done")
@@ -200,6 +202,7 @@ def make_volumes_kernel_estimate_local(
                 heterogeneity_kernel=heterogeneity_kernel,
                 upsampling_factor=1,
                 return_real_space=True,
+                use_fast_rfft=use_fast_rfft,
             )
         )
 
@@ -260,6 +263,7 @@ def make_volumes_kernel_estimate_local(
             heterogeneity_kernel=heterogeneity_kernel,
             upsampling_factor=2,
             return_real_space=True,
+            use_fast_rfft=use_fast_rfft,
         )
         estimates[k] = estimates[k].reshape(-1, *ds.volume_shape).astype(np.float32)
 

--- a/recovar/output/output.py
+++ b/recovar/output/output.py
@@ -730,7 +730,7 @@ def compute_and_save_reweighted(dataset, path_subsampled, zs, cov_zs,  output_fo
 
         locres_maskrad = ds.grid_size * ds.voxel_size / maskrad_fraction
         logger.info("Mask radius fraction = %s. Setting locres_maskrad = locres_sampling = box_size * voxel_size / %s = %.1f Angstroms. Using %d particles for template.", maskrad_fraction, maskrad_fraction, locres_maskrad, n_min_particles)
-        heterogeneity_volume.make_volumes_kernel_estimate_local(heterogeneity_distances, ds, vol_paths, ndim, n_bins, B_factor, tau=None, n_min_particles=n_min_particles, locres_sampling=locres_maskrad, locres_maskrad=locres_maskrad, locres_edgwidth=0, upsampling_for_ests=1, use_mask_ests=False, grid_correct_ests=False, save_all_estimates=save_all_estimates, metric_used='locshellmost_likely')
+        heterogeneity_volume.make_volumes_kernel_estimate_local(heterogeneity_distances, ds, vol_paths, ndim, n_bins, B_factor, tau=None, n_min_particles=n_min_particles, locres_sampling=locres_maskrad, locres_maskrad=locres_maskrad, locres_edgwidth=0, upsampling_for_ests=1, use_mask_ests=False, grid_correct_ests=False, save_all_estimates=save_all_estimates, metric_used='locshellmost_likely', use_fast_rfft=True)
 
         logger.info("Done with volume %d: %s", k, vol_paths.stem)
 


### PR DESCRIPTION
## Summary
- Replace `process_images_half` (eager full FFT + discard half) with `padded_rfft` (JIT'd rfft2) in the heterogeneity reconstruction loop — half the FFT work, fused into a single GPU kernel
- Make `_pad_heterogeneity_kernel_batch` preserve JAX device arrays instead of forcing GPU→CPU→GPU round-trips via `np.asarray`
- Pad raw images before rfft (not after) so the JIT'd kernel always sees a fixed batch shape, avoiding recompilation per tail-batch
- Only `compute_state` uses the fast rfft path (`use_fast_rfft=True`); the pipeline/outlier path keeps the legacy FFT for bit-exact numerical compatibility

## Benchmark (300k×256 images, H100, 3 states)
| | Before | After | Speedup |
|---|---|---|---|
| Per state (amortized) | 362s | 152s | **2.4x** |
| 1 state (incl. data load) | 296s | 267s | 1.1x |
| 3 states total | 1088s | 456s | **2.4x** |

## Test plan
- [x] `pixi run test-fast` — 2406 passed
- [x] Parallel full tests (unit + smoke-tiny + downstream) — 2465 passed, 0 failed
- [x] Slurm job IDs: 6071781, 6071782, 6071783 (summary: 6071784)

🤖 Generated with [Claude Code](https://claude.com/claude-code)