### PR TITLE
Restore LICENSE file deleted from dev

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2025 The Trustees of Princeton University. All rights reserved.
+
+Permission is hereby granted, free of charge, to non-profit academic and research institutions ("Academic Users") to use, reproduce, and modify this software for internal, non-commercial academic and research purposes only, subject to the following conditions:
+
+This license applies solely to internal use for academic research or educational purposes. Any other use, including but not limited to:
+   - use by or on behalf of a for-profit organization,
+   - incorporation into a commercial product or service,
+ - or use in connection with commercial research or fee-for-service activities, requires a separate commercial license. To inquire about a commercial license, please contact: Cortney Cavanaugh at ccavanaugh@princeton.edu or otl@princeton.edu
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+* Redistributions of source code must retain the above copyright notice, this list of conditions, and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* Neither The Trustees of Princeton University nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE TRUSTEES OF PRINCETON UNIVERSITY AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE TRUSTEES OF PRINCETON UNIVERSITY OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=====================================================================================
+NOTIFICATION OF COMMERCIAL USE
+=====================================================================================
+This software is intended for research and instructional purposes only.
+
+To use this software for commercial purposes, please contact: 
+Cortney Cavanaugh 
+New Ventures and Licensing Associate
+Technology Licensing & New Ventures, Princeton University
+ccavanaugh@princeton.edu or otl@princeton.edu
+=====================================================================================

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ RECOVAR analyzes conformational heterogeneity in cryo-EM and cryo-ET datasets. I
 
 **[Full Documentation](https://ma-gilles.github.io/recovar)** | **[Paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122)** | **[Talk](https://www.youtube.com/watch?v=cQBQlCCRp8Q&t=740s)**
 
+**License**: Princeton University Academic/Non-Commercial License (see [LICENSE](LICENSE)).
+
 ## Key features
 
 - **High resolution** — top performer on [CryoBench](https://cryobench.cs.princeton.edu)


### PR DESCRIPTION
## Summary
- Restores the Princeton Academic/Non-Commercial LICENSE file that was accidentally deleted in commit 8335b34 (first multi-gpu commit by Denis)
- Identical content to `main`
- `pyproject.toml` already references it on both branches

## Test plan
- [x] `diff <(git show origin/main:LICENSE) LICENSE` — identical