### PR TITLE
Improve automatic mask generation (from_halfmaps)

### DIFF
--- a/docs/guide/masks.md
+++ b/docs/guide/masks.md
@@ -19,7 +19,7 @@ If you don't have a mask:
 
 | Option | Description |
 |--------|-------------|
-| `--mask=from_halfmaps` | Estimate mask from the two half-maps of the mean reconstruction |
+| `--mask=from_halfmaps` | Estimate mask from the mean reconstruction (averages half-maps, low-pass filters, Otsu thresholds, cleans up, and softens) |
 | `--mask=sphere` | Use a loose spherical mask |
 | `--mask=none` | No mask (not recommended) |
 

--- a/recovar/core/mask.py
+++ b/recovar/core/mask.py
@@ -2,7 +2,9 @@
 
 Provides masks for the reconstruction pipeline:
 
-- **Volume masks**: ``masking_options`` (pipeline entry point), ``make_mask_from_half_maps``,
+- **Volume masks**: ``make_mask`` (standalone, RELION-style),
+  ``make_mask_from_half_maps`` (averages half-maps then calls ``make_mask``),
+  ``masking_options`` (pipeline entry point),
   ``make_mask_from_gt``, ``make_union_gt_mask``
 - **Radial / spherical masks**: ``get_radial_mask``, ``raised_cosine_mask``,
   ``soft_mask_outside_map``
@@ -15,7 +17,7 @@ import logging
 import jax.numpy as jnp
 import numpy as np
 import skimage
-from scipy.ndimage import binary_dilation, distance_transform_edt
+from scipy.ndimage import binary_dilation, binary_fill_holes, distance_transform_edt, label
 
 import recovar.core.fourier_transform_utils as fourier_transform_utils
 import recovar.utils as utils
@@ -114,18 +116,162 @@ def masking_options(
 # ---------------------------------------------------------------------------
 
 
-def make_mask_from_half_maps(halfmap1, halfmap2, smax=3):
-    """Generate a binary mask from two real-space half-maps via local correlation.
+def make_mask(volume, *, threshold="auto", lowpass_sigma=None, extend=None,
+              soft_edge=3, cleanup=True):
+    """Create a solvent mask from a 3-D real-space volume.
 
-    Computes a 3D local cross-correlation, thresholds it, dilates, and softens.
-    Adapted from EMDA (https://emda.readthedocs.io/).
+    Follows the same conceptual pipeline as RELION's ``relion_mask_create``:
+    low-pass filter → threshold → (optional cleanup) → extend → soft cosine edge.
+
+    Key differences from RELION:
+
+    * Gaussian low-pass in real space (RELION uses a Fourier-space raised-cosine).
+    * ``"auto"`` threshold via Otsu's method (RELION requires a user-specified
+      density threshold, default 0.02 in postprocessing).
+    * Optional morphological cleanup (fill holes, keep largest connected
+      component) — RELION does not do this.
+    * Extension uses ``distance_transform_edt`` for spherical (Euclidean)
+      dilation, matching RELION's brute-force Euclidean approach.
+    * Soft edge uses ``distance_transform_edt`` + cosine (RELION computes
+      min-Euclidean-distance per voxel — mathematically equivalent).
+
+    This function is the building block for :func:`make_mask_from_half_maps`
+    and can also be called directly on any volume (e.g. a consensus
+    reconstruction loaded from MRC).
+
+    Args:
+        volume: 3-D real-space array (e.g. averaged half-maps, or a single
+            reconstruction).
+        threshold: How to binarize.
+
+            * ``"auto"`` (default): Otsu's method on voxels inside the radial
+              mask.
+            * A ``float``: fixed density threshold (like RELION's
+              ``--ini_threshold``, default 0.02 in postprocessing).
+        lowpass_sigma: Gaussian sigma in **voxels** for low-pass smoothing
+            before thresholding.  ``None`` = auto (``max(2, N // 64)``).
+            Set to ``0`` to disable.
+        extend: Extension (dilation) of the binary mask in **voxels**.
+            ``None`` = auto (``ceil(6 * N / 128)``).
+            (RELION postprocessing default: 3 pixels.)
+        soft_edge: Width of the cosine soft edge in **voxels**.
+            (RELION postprocessing default: 6 pixels.)
+        cleanup: If ``True``, fill holes and keep only the largest connected
+            component after thresholding (RELION does not do this).
+
+    Returns:
+        Soft mask as a float32 array in [0, 1].
+
+    Example::
+
+        import mrcfile
+        from recovar.core.mask import make_mask
+
+        h1 = mrcfile.open("half1.mrc").data
+        h2 = mrcfile.open("half2.mrc").data
+        avg = (h1 + h2) / 2.0
+
+        # Automatic (recommended)
+        mask = make_mask(avg)
+
+        # RELION-like with manual parameters
+        mask = make_mask(avg, threshold=0.02, extend=3, soft_edge=6,
+                         lowpass_sigma=3, cleanup=False)
+    """
+    from scipy.ndimage import gaussian_filter
+    from skimage.filters import threshold_otsu
+
+    volume = np.asarray(volume, dtype=np.float64)
+    N = volume.shape[0]
+
+    # --- 1. Low-pass filter ---
+    if lowpass_sigma is None:
+        lowpass_sigma = max(2, N // 64)
+    if lowpass_sigma > 0:
+        filtered = gaussian_filter(volume, sigma=lowpass_sigma)
+    else:
+        filtered = volume
+
+    # --- 2. Threshold ---
+    radial = np.asarray(get_radial_mask(volume.shape)) > 0.5
+
+    if threshold == "auto":
+        vals_inside = filtered[radial]
+        try:
+            thresh_val = threshold_otsu(vals_inside)
+        except ValueError:
+            logger.warning("Otsu threshold failed, falling back to 99th percentile")
+            thresh_val = np.percentile(vals_inside, 99)
+    else:
+        thresh_val = float(threshold)
+
+    binary = (filtered > thresh_val) & radial
+    logger.info("Mask threshold: %.4g  (%.1f%% of voxels inside radial mask)",
+                thresh_val, 100.0 * binary.sum() / radial.sum())
+
+    # --- 3. Morphological cleanup ---
+    if cleanup:
+        filled = binary_fill_holes(binary)
+        labeled, n_components = label(filled)
+        if n_components > 1:
+            component_sizes = np.bincount(labeled.ravel())[1:]
+            largest = np.argmax(component_sizes) + 1
+            filled = labeled == largest
+            logger.info("Mask cleanup: kept largest of %d components", n_components)
+        elif n_components == 0:
+            logger.warning("No mask voxels found, returning empty mask")
+            return np.zeros(volume.shape, dtype=np.float32)
+        binary = filled
+
+    # --- 4. Extend (dilate) via Euclidean distance (spherical, like RELION) ---
+    if extend is None:
+        extend = int(np.ceil(6 * N / 128))
+    if extend > 0:
+        dist = distance_transform_edt(~np.asarray(binary, dtype=bool))
+        binary = dist <= extend
+
+    # --- 5. Soft cosine edge ---
+    if soft_edge > 0:
+        result = soften_volume_mask(binary, kern_rad=soft_edge)
+    else:
+        result = np.asarray(binary, dtype=np.float32)
+
+    return np.asarray(result * (result >= 1e-3), dtype=np.float32)
+
+
+def make_mask_from_half_maps(halfmap1, halfmap2, smax=3, method="auto", **kwargs):
+    """Generate a solvent mask from two real-space half-map volumes.
+
+    Averages the two half-maps and delegates to :func:`make_mask`.
+    All keyword arguments are forwarded to ``make_mask``.
+
+    For the legacy EMDA local-correlation method, pass
+    ``method="local_correlation"``.
 
     Args:
         halfmap1, halfmap2: Real-space half-map volumes (same shape).
-        smax: Kernel radius in pixels for the local correlation.
+        smax: Kernel radius in pixels (only for ``method="local_correlation"``).
+        method: ``"auto"`` or ``"local_correlation"``.
+        **kwargs: Forwarded to :func:`make_mask` (``threshold``,
+            ``lowpass_sigma``, ``extend``, ``soft_edge``, ``cleanup``).
 
     Returns:
         Soft mask as a float array in [0, 1].
+    """
+    if method == "local_correlation":
+        soft_edge = kwargs.get("soft_edge", 2)
+        return _make_mask_from_half_maps_local_corr(halfmap1, halfmap2, smax=smax,
+                                                     soft_edge=soft_edge)
+
+    avg = (np.asarray(halfmap1) + np.asarray(halfmap2)) / 2.0
+    return make_mask(avg, **kwargs)
+
+
+def _make_mask_from_half_maps_local_corr(halfmap1, halfmap2, smax=3, soft_edge=2):
+    """Original EMDA-style mask from half-maps via local cross-correlation.
+
+    Kept for backward compatibility and comparison.  See
+    ``make_mask_from_half_maps`` with ``method="local_correlation"``.
     """
     dilation_iters = int(6 * halfmap1.shape[0] // 128)
     kern = make_soft_edged_kernel(smax, halfmap1.shape)
@@ -137,8 +283,8 @@ def make_mask_from_half_maps(halfmap1, halfmap2, smax=3):
 
     ccmap_binary = (halfcc3d >= 1e-3).astype(int)
     dilated = binary_dilation(ccmap_binary, iterations=dilation_iters)
-    mask = soften_volume_mask(dilated, kern_rad=2)
-    return mask * (mask >= 1e-3)
+    result = soften_volume_mask(dilated, kern_rad=soft_edge)
+    return result * (result >= 1e-3)
 
 
 def make_mask_from_gt(gt_map, smax=3, iter=10, from_ft=True):
@@ -398,12 +544,12 @@ def smooth_circular_mask(image_size, radius, thickness):
 # ---------------------------------------------------------------------------
 
 
-def _mask_from_halfmaps(means, smax=3):
+def _mask_from_halfmaps(means, smax=3, method="auto"):
     """Generate mask from pipeline means object (Fourier-space half-maps)."""
     vol_shape = utils.guess_vol_shape_from_vol_size(means.corrected0.size)
     halfmap1 = fourier_transform_utils.get_idft3(means.corrected0reg.reshape(vol_shape)).real
     halfmap2 = fourier_transform_utils.get_idft3(means.corrected1reg.reshape(vol_shape)).real
-    return make_mask_from_half_maps(halfmap1, halfmap2, smax=smax)
+    return make_mask_from_half_maps(halfmap1, halfmap2, smax=smax, method=method)
 
 
 def make_soft_edged_kernel(r1, shape):

--- a/tests/unit/test_core_mask.py
+++ b/tests/unit/test_core_mask.py
@@ -436,6 +436,122 @@ class TestMakeUnionGtMask:
         assert soft.shape == vol_shape
 
 
+class TestMakeMask:
+    """Tests for the standalone make_mask function."""
+
+    def _make_test_volume(self, shape=(32, 32, 32), signal_range=(10, 22), noise=0.1, seed=42):
+        rng = np.random.RandomState(seed)
+        vol = np.zeros(shape, dtype=np.float32)
+        s = signal_range
+        vol[s[0]:s[1], s[0]:s[1], s[0]:s[1]] = 5.0
+        return vol + rng.randn(*shape).astype(np.float32) * noise
+
+    def test_output_shape_and_range(self):
+        vol = self._make_test_volume()
+        result = mask.make_mask(vol)
+        assert result.shape == (32, 32, 32)
+        assert result.dtype == np.float32
+        assert result.min() >= 0.0
+        assert result.max() <= 1.0 + 1e-5
+
+    def test_signal_region_is_masked(self):
+        vol = self._make_test_volume()
+        result = mask.make_mask(vol)
+        assert result[16, 16, 16] > 0.9
+
+    def test_corner_is_zero(self):
+        vol = self._make_test_volume(signal_range=(12, 20))
+        result = mask.make_mask(vol)
+        assert result[0, 0, 0] == 0.0
+
+    def test_fixed_threshold(self):
+        """A fixed threshold should give a different result than auto."""
+        vol = self._make_test_volume()
+        m_auto = mask.make_mask(vol, threshold="auto")
+        m_fixed = mask.make_mask(vol, threshold=0.5)
+        assert not np.allclose(m_auto, m_fixed)
+
+    def test_no_lowpass(self):
+        """lowpass_sigma=0 should skip filtering."""
+        vol = self._make_test_volume(noise=0.5)
+        m_filtered = mask.make_mask(vol, lowpass_sigma=3)
+        m_unfiltered = mask.make_mask(vol, lowpass_sigma=0)
+        assert not np.allclose(m_filtered, m_unfiltered)
+
+    def test_extend_parameter(self):
+        """Larger extend should produce a larger mask."""
+        vol = self._make_test_volume()
+        m_small = mask.make_mask(vol, extend=1, soft_edge=0)
+        m_large = mask.make_mask(vol, extend=5, soft_edge=0)
+        assert m_large.sum() > m_small.sum()
+
+    def test_soft_edge_parameter(self):
+        """soft_edge=0 should give a fully binary mask."""
+        vol = self._make_test_volume()
+        result = mask.make_mask(vol, soft_edge=0)
+        unique_vals = np.unique(result)
+        np.testing.assert_array_equal(np.sort(unique_vals), [0.0, 1.0])
+
+    def test_cleanup_false(self):
+        """cleanup=False should skip hole-filling and component selection."""
+        vol = self._make_test_volume()
+        m_clean = mask.make_mask(vol, cleanup=True)
+        m_raw = mask.make_mask(vol, cleanup=False)
+        # Both should be valid masks; raw may have more components
+        assert m_clean.shape == m_raw.shape
+        assert m_raw.min() >= 0.0
+
+    def test_empty_volume(self):
+        vol = np.zeros((16, 16, 16), dtype=np.float32)
+        result = mask.make_mask(vol)
+        assert result.shape == (16, 16, 16)
+        assert result.mean() < 0.5
+
+    def test_mask_is_connected_with_cleanup(self):
+        from scipy.ndimage import label as scipy_label
+        vol = self._make_test_volume()
+        result = mask.make_mask(vol, cleanup=True)
+        binary = result > 0.5
+        _, n_components = scipy_label(binary)
+        assert n_components <= 1, f"Expected <=1 component, got {n_components}"
+
+
+class TestMakeMaskFromHalfMapsAuto:
+    """Tests for make_mask_from_half_maps (auto method wrapping make_mask)."""
+
+    def test_averages_and_delegates_to_make_mask(self):
+        """make_mask_from_half_maps(h1,h2) should equal make_mask((h1+h2)/2)."""
+        rng = np.random.RandomState(42)
+        vol = np.zeros((32, 32, 32), dtype=np.float32)
+        vol[10:22, 10:22, 10:22] = 5.0
+        h1 = vol + rng.randn(32, 32, 32).astype(np.float32) * 0.1
+        h2 = vol + rng.randn(32, 32, 32).astype(np.float32) * 0.1
+        from_halfmaps = mask.make_mask_from_half_maps(h1, h2)
+        from_avg = mask.make_mask((h1 + h2) / 2.0)
+        np.testing.assert_array_equal(from_halfmaps, from_avg)
+
+    def test_default_method_is_auto(self):
+        rng = np.random.RandomState(42)
+        vol = np.zeros((32, 32, 32), dtype=np.float32)
+        vol[10:22, 10:22, 10:22] = 5.0
+        h1 = vol + rng.randn(32, 32, 32).astype(np.float32) * 0.1
+        h2 = vol + rng.randn(32, 32, 32).astype(np.float32) * 0.1
+        auto_result = mask.make_mask_from_half_maps(h1, h2, method="auto")
+        default_result = mask.make_mask_from_half_maps(h1, h2)
+        np.testing.assert_array_equal(auto_result, default_result)
+
+    def test_kwargs_forwarded(self):
+        """Keyword args should be forwarded to make_mask."""
+        rng = np.random.RandomState(42)
+        vol = np.zeros((32, 32, 32), dtype=np.float32)
+        vol[10:22, 10:22, 10:22] = 5.0
+        h1 = vol + rng.randn(32, 32, 32).astype(np.float32) * 0.5
+        h2 = vol + rng.randn(32, 32, 32).astype(np.float32) * 0.5
+        m1 = mask.make_mask_from_half_maps(h1, h2, lowpass_sigma=1)
+        m2 = mask.make_mask_from_half_maps(h1, h2, lowpass_sigma=5)
+        assert not np.allclose(m1, m2)
+
+
 class TestReferenceEquivalence:
     def test_make_mask_from_gt_matches_reference_impl(self):
         rng = np.random.RandomState(42)
@@ -444,11 +560,11 @@ class TestReferenceEquivalence:
         expected = _reference_make_mask_from_gt(vol, smax=3, iter=2, from_ft=False)
         np.testing.assert_allclose(got, expected)
 
-    def test_make_mask_from_half_maps_matches_reference_impl(self):
+    def test_make_mask_from_half_maps_local_corr_matches_reference_impl(self):
         rng = np.random.RandomState(42)
         h1 = rng.randn(16, 16, 16).astype(np.float32)
         h2 = h1 + rng.randn(16, 16, 16).astype(np.float32) * 0.1
-        got = mask.make_mask_from_half_maps(h1, h2, smax=3)
+        got = mask.make_mask_from_half_maps(h1, h2, smax=3, method="local_correlation")
         expected = _reference_make_mask_from_half_maps(h1, h2, smax=3)
         np.testing.assert_allclose(got, expected)
 


### PR DESCRIPTION
## Summary

Closes #42. Replaces the EMDA local-correlation mask generation with a RELION-inspired pipeline that is robust across both SPA and ET data.

- New `make_mask(volume, ...)` standalone function with tunable RELION-style parameters (`threshold`, `lowpass_sigma`, `extend`, `soft_edge`, `cleanup`)
- `make_mask_from_half_maps` becomes a thin wrapper (averages half-maps, delegates to `make_mask`)
- Old method preserved as `method="local_correlation"` for backward compatibility
- Euclidean dilation (matching RELION) replaces morphological dilation

### Algorithm (new default)
1. Average half-maps → Gaussian low-pass filter → Otsu threshold (inside radial mask)
2. Fill holes + keep largest connected component
3. Euclidean distance dilation (`ceil(6*N/128)` voxels)
4. Cosine soft edge (3 voxels)

### Key differences from RELION
| Step | RELION | recovar |
|------|--------|---------|
| Low-pass | Fourier raised-cosine, user specifies Å | Gaussian real-space, auto sigma |
| Threshold | User-specified (default 0.02) | Otsu (automatic, data-adaptive) |
| Cleanup | None | Fill holes + keep largest component |
| Extension | Euclidean distance | Euclidean distance (same) |
| Soft edge | Min-Euclidean + cosine | EDT + cosine (equivalent) |

### Why
The old local-correlation approach **fails on ET/tomo data** — producing fragmented checkerboard masks due to the missing wedge. Tested on 8 datasets (4 SPA, 4 ET):

| Dataset | Old mask | New mask |
|---------|----------|----------|
| EMPIAR-10049 (80S ribo, 192³) | 6.8% | 6.3% |
| EMPIAR-10076 (TRPV1, 128³) | 6.2% | 5.0% |
| EMPIAR-10028 (spliceosome, 256³) | 8.1% | 9.1% |
| EMPIAR-10180 (assembly, 256³) | 5.8% | 6.0% |
| Caitie ET no-dose (256³) | 15.5% (artifacts) | 19.8% (clean) |
| Caitie ET filt3+contrast (128³) | 17.4% (artifacts) | 20.4% (clean) |
| Caitie ET cont-sphere+dose (128³) | 16.4% (artifacts) | 19.6% (clean) |
| ET real pipeline (128³) | 22.2% (fragmented) | 31.5% (clean) |

### Quality baselines (long-test)

| Test group | Result |
|------------|--------|
| unit (2419) | PASS |
| smoke-tiny (13) | 12 pass, 1 fail (pre-existing outlier flake) |
| downstream (14) | PASS |
| metrics-spa | PASS |
| metrics-et | PASS |
| pdb-traj | PASS |
| indices | PASS |
| stress | PASS |
| outliers-long (4) | 3 pass, 1 fail (pre-existing on dev, uses GT mask not from_halfmaps) |

The 2 outlier failures are **pre-existing on dev** (confirmed from Slurm logs 6021633, 5733892) and use GT union masks, not `from_halfmaps`.

### Slurm job IDs
Jobs 6109890–6109899 (summary 6109900)

## Test plan
- [x] Unit tests (50 mask tests, all pass)
- [x] Fast tests (2183 pass)
- [x] Long-test parallel submission (all relevant groups pass)
- [x] Visual comparison on 8 real/realistic datasets
- [x] Verify outlier failures are pre-existing on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)