### PR TITLE
Pin CUDA JAX plugin/PJRT versions in pixi

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -54,8 +54,11 @@ pytest-cov = ">=5.0"
 [pypi-dependencies]
 # Documentation
 mkdocstrings = { extras = ["python"], version = "*" }
-# JAX 0.9.x with CUDA 12 support
+# JAX 0.9.x with CUDA 12 support. Pin plugin/PJRT to match jaxlib exactly
+# so fresh resolutions do not pull newer incompatible CUDA wheels.
 jax = { extras = ["cuda12"], version = "==0.9.0.1" }
+jax-cuda12-plugin = "==0.9.0.1"
+jax-cuda12-pjrt = "==0.9.0.1"
 # Build tools
 twine = "*"
 # Specialized packages not available in conda-forge


### PR DESCRIPTION
## Summary
- pin `jax-cuda12-plugin` to `0.9.0.1`
- pin `jax-cuda12-pjrt` to `0.9.0.1`
- keep the CUDA JAX plugin/PJRT wheels aligned with `jax`/`jaxlib` in fresh pixi resolutions

Closes #64.

## Validation
- `pixi lock`
- `pixi install`
- `pixi run install-recovar`
- `PIXI_PY=$(pixi run which python)`
- `"$PIXI_PY" -m pip uninstall -y recovar || true`
- `"$PIXI_PY" -m pip install -e . --no-deps --no-build-isolation --ignore-installed`
- `PYTHON="$PIXI_PY" make -C recovar/cuda clean all`
- `pixi run smoke-import-recovar`
- `"$PIXI_PY" -c "import importlib.metadata as md; print({name: md.version(name) for name in ['jax','jaxlib','jax-cuda12-plugin','jax-cuda12-pjrt']})"`

Observed installed versions:
- `jax==0.9.0.1`
- `jaxlib==0.9.0.1`
- `jax-cuda12-plugin==0.9.0.1`
- `jax-cuda12-pjrt==0.9.0.1`
