### PR TITLE
Respect --gpu-gb during pipeline downsample

### DIFF
--- a/recovar/commands/downsample.py
+++ b/recovar/commands/downsample.py
@@ -39,6 +39,7 @@ def downsample_to_disk(
     datadir: str = "",
     strip_prefix: Optional[str] = None,
     batch_size: int = 1000,
+    gpu_memory_gb: Optional[float] = None,
 ) -> Tuple[str, str]:
     """Pre-downsample particle images to disk via Fourier cropping.
 
@@ -59,6 +60,8 @@ def downsample_to_disk(
         Prefix to strip from paths in star/cs file.
     batch_size : int
         Number of images per batch.
+    gpu_memory_gb : float or None
+        Optional GPU memory budget in GB for auto batch sizing.
 
     Returns
     -------
@@ -107,7 +110,9 @@ def downsample_to_disk(
     if use_gpu:
         from recovar.utils import helpers
 
-        gpu_memory = helpers.get_gpu_memory_total()
+        gpu_memory = helpers.get_gpu_memory_total() if gpu_memory_gb is None else float(gpu_memory_gb)
+        if gpu_memory <= 0:
+            raise ValueError("gpu_memory_gb must be positive")
         batch_size = get_downsample_batch_size(orig_D, gpu_memory)
         logger.info("GPU downsampling: batch_size=%d (%.1f GB GPU)", batch_size, gpu_memory)
     else:
@@ -128,12 +133,26 @@ def downsample_to_disk(
         if new_apix:
             mrc.voxel_size = new_apix
 
-        for start in range(0, n_images, batch_size):
-            end = min(start + batch_size, n_images)
+        start = 0
+        current_batch_size = batch_size
+        while start < n_images:
+            end = min(start + current_batch_size, n_images)
             indices = np.arange(start, end)
 
             images = loader.get(indices)
-            images_ds = downsample_images(images, target_D, use_gpu=use_gpu)
+            try:
+                images_ds = downsample_images(images, target_D, use_gpu=use_gpu)
+            except Exception as exc:
+                if use_gpu and current_batch_size > 1 and _is_gpu_oom(exc):
+                    next_batch_size = max(1, current_batch_size // 2)
+                    logger.warning(
+                        "GPU OOM during downsampling at batch_size=%d; retrying with batch_size=%d",
+                        current_batch_size,
+                        next_batch_size,
+                    )
+                    current_batch_size = next_batch_size
+                    continue
+                raise
             mrc.data[start:end] = images_ds.astype(np.float32)
 
             elapsed = time.time() - t0
@@ -146,6 +165,7 @@ def downsample_to_disk(
                 rate,
                 eta,
             )
+            start = end
 
     elapsed = time.time() - t0
     logger.info("Done: %.1f seconds (%.1f images/sec)", elapsed, n_images / elapsed)
@@ -174,6 +194,14 @@ def main():
     parser.add_argument("--datadir", default=None, help="Path prefix for resolving relative image paths")
     parser.add_argument("--strip-prefix", default=None, help="Prefix to strip from paths in star file")
     parser.add_argument("--batch-size", type=int, default=1000, help="Number of images per batch (default: 1000)")
+    parser.add_argument(
+        "--gpu-gb",
+        "--gpu-memory",
+        dest="gpu_memory",
+        type=float,
+        default=None,
+        help="Cap GPU memory used for auto batch sizing during downsampling",
+    )
     parser.add_argument(
         "--chunk-size",
         type=int,
@@ -219,6 +247,7 @@ def main():
             datadir=args.datadir or "",
             strip_prefix=args.strip_prefix,
             batch_size=args.batch_size,
+            gpu_memory_gb=args.gpu_memory,
         )
 
         logger.info("")
@@ -440,6 +469,11 @@ def _write_minimal_star(star_path, mrcs_rel, target_D, new_apix, n_images):
 
     starfile.write({"optics": optics, "particles": particles}, star_path, overwrite=True)
     logger.info("Wrote minimal STAR file (no poses/CTF \u2014 use original file for pipeline)")
+
+
+def _is_gpu_oom(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "resource_exhausted" in message or "out of memory" in message or "allocator" in message
 
 
 if __name__ == "__main__":

--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -758,6 +758,10 @@ def standard_recovar_pipeline(args):
 
     logger.info(args)
 
+    if args.gpu_memory is not None:
+        utils.set_gpu_memory_limit(args.gpu_memory)
+        logger.info("GPU memory limited to %.1f GB (requested via --gpu-gb)", args.gpu_memory)
+
     # --- Resolve downsample target ---
     _resolve_downsample(args)
 
@@ -782,6 +786,7 @@ def standard_recovar_pipeline(args):
                 outdir=ds_dir,
                 datadir=getattr(args, "datadir", None) or "",
                 strip_prefix=getattr(args, "strip_prefix", None),
+                gpu_memory_gb=args.gpu_memory,
             )
 
         ds_star = os.path.join(ds_dir, f"particles.{args.downsample}.star")
@@ -814,9 +819,6 @@ def standard_recovar_pipeline(args):
 
     ## TODO: log this. Also document it better. Also I'd like a warning or something if I say "allocate this much" and peak gpu memory ends up being more than that
     ## So that it can be fixed in the future
-    if args.gpu_memory is not None:
-        utils.set_gpu_memory_limit(args.gpu_memory)
-        logger.info("GPU memory limited to %.1f GB (requested via --gpu-gb)", args.gpu_memory)
     gpu_memory = utils.get_gpu_memory_total()
     volume_shape = ds.volume_shape
 

--- a/tests/unit/test_commands_downsample.py
+++ b/tests/unit/test_commands_downsample.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from recovar.commands import downsample as ds_cmd
+from recovar.data_io import downsample as ds_io
 
 pytestmark = pytest.mark.unit
 
@@ -71,6 +72,78 @@ def test_downsample_to_disk_rejects_odd_target_D(tmp_path):
         )
 
 
+def test_downsample_to_disk_uses_explicit_gpu_memory_cap(monkeypatch, tmp_path):
+    class _FakeLoader:
+        num_images = 2
+        image_size = 64
+
+        def get(self, indices):
+            return np.zeros((len(indices), 64, 64), dtype=np.float32)
+
+    calls = {}
+
+    monkeypatch.setattr(ds_cmd, "_get_pixel_size", lambda _p: 1.5)
+    monkeypatch.setattr(ds_cmd, "_write_output_star", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ds_io, "_gpu_available", lambda: True)
+
+    def _record_batch_size(orig_D, gpu_memory_gb):
+        calls["batch_args"] = (orig_D, gpu_memory_gb)
+        return 4
+
+    monkeypatch.setattr(ds_io, "get_downsample_batch_size", _record_batch_size)
+    monkeypatch.setattr(ds_io, "downsample_images", lambda images, target_D, use_gpu=None: images[:, :target_D, :target_D])
+    monkeypatch.setattr("recovar.data_io.image_loader.load_images", lambda *args, **kwargs: _FakeLoader())
+
+    import recovar.utils.helpers as helpers
+
+    monkeypatch.setattr(helpers, "get_gpu_memory_total", lambda: (_ for _ in ()).throw(AssertionError("unexpected")))
+
+    ds_cmd.downsample_to_disk(
+        particles_file="particles.star",
+        target_D=32,
+        outdir=str(tmp_path),
+        gpu_memory_gb=12.0,
+    )
+
+    assert calls["batch_args"] == (64, 12.0)
+
+
+def test_downsample_to_disk_retries_with_smaller_batch_on_gpu_oom(monkeypatch, tmp_path):
+    class _FakeLoader:
+        num_images = 5
+        image_size = 64
+
+        def get(self, indices):
+            return np.zeros((len(indices), 64, 64), dtype=np.float32)
+
+    batch_sizes = []
+    state = {"failed": False}
+
+    monkeypatch.setattr(ds_cmd, "_get_pixel_size", lambda _p: 1.5)
+    monkeypatch.setattr(ds_cmd, "_write_output_star", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ds_io, "_gpu_available", lambda: True)
+    monkeypatch.setattr(ds_io, "get_downsample_batch_size", lambda _orig_D, _gpu_memory_gb: 4)
+    monkeypatch.setattr("recovar.data_io.image_loader.load_images", lambda *args, **kwargs: _FakeLoader())
+
+    def _fake_downsample_images(images, target_D, use_gpu=None):
+        batch_sizes.append(len(images))
+        if len(images) == 4 and not state["failed"]:
+            state["failed"] = True
+            raise RuntimeError("RESOURCE_EXHAUSTED: out of memory")
+        return images[:, :target_D, :target_D]
+
+    monkeypatch.setattr(ds_io, "downsample_images", _fake_downsample_images)
+
+    ds_cmd.downsample_to_disk(
+        particles_file="particles.star",
+        target_D=32,
+        outdir=str(tmp_path),
+        gpu_memory_gb=12.0,
+    )
+
+    assert batch_sizes == [4, 2, 2, 1]
+
+
 # ---------------------------------------------------------------------------
 # main – argument parsing
 # ---------------------------------------------------------------------------
@@ -112,6 +185,16 @@ def test_main_registers_batch_size_with_default():
     parser.add_argument("--batch-size", type=int, default=1000)
     action = parser._option_string_actions["--batch-size"]
     assert action.default == 1000
+
+
+def test_main_registers_gpu_memory_cap():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("particles")
+    parser.add_argument("-D", "--target-D", type=int, required=True)
+    parser.add_argument("-o", "--outdir", required=True)
+    parser.add_argument("--gpu-gb", "--gpu-memory", dest="gpu_memory", type=float, default=None)
+    action = parser._option_string_actions["--gpu-gb"]
+    assert action.dest == "gpu_memory"
 
 
 def test_main_exits_on_odd_target_D(monkeypatch, tmp_path):

--- a/tests/unit/test_commands_pipeline.py
+++ b/tests/unit/test_commands_pipeline.py
@@ -5,6 +5,7 @@ Only tests argument registration via add_args() – no actual EM execution.
 """
 
 import argparse
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -190,3 +191,52 @@ def test_standard_pipeline_estimates_initial_noise_from_halfset_zero(monkeypatch
 
     with pytest.raises(RuntimeError, match="noise-estimate-stop"):
         pipeline_cmd.standard_recovar_pipeline(args)
+
+
+def test_standard_pipeline_passes_gpu_limit_to_predownsample(monkeypatch, tmp_path):
+    captured = {}
+
+    monkeypatch.setattr(pipeline_cmd, "_resolve_downsample", lambda _args: None)
+    monkeypatch.setattr(
+        pipeline_cmd.utils,
+        "set_gpu_memory_limit",
+        lambda value: captured.setdefault("limits", []).append(value),
+    )
+    monkeypatch.setattr(pipeline_cmd.os.path, "exists", lambda _path: False)
+    monkeypatch.setitem(
+        sys.modules,
+        "recovar.commands.downsample",
+        SimpleNamespace(downsample_to_disk=lambda **kwargs: captured.setdefault("downsample_kwargs", kwargs)),
+    )
+    monkeypatch.setattr(
+        pipeline_cmd.halfsets,
+        "resolve_halfset_indices",
+        lambda _args: (_ for _ in ()).throw(RuntimeError("stop-after-downsample")),
+    )
+
+    args = SimpleNamespace(
+        outdir=str(tmp_path / "pipeline_out"),
+        particles="particles.star",
+        poses="poses.pkl",
+        ctf="ctf.pkl",
+        mask="mask.mrc",
+        datadir=None,
+        strip_prefix=None,
+        downsample=128,
+        accept_cpu=False,
+        tilt_series=False,
+        tilt_series_ctf=None,
+        dose_per_tilt=None,
+        angle_per_tilt=None,
+        do_over_with_contrast=False,
+        correct_contrast=False,
+        lazy=True,
+        gpu_memory=12.0,
+        noise_model="radial",
+    )
+
+    with pytest.raises(RuntimeError, match="stop-after-downsample"):
+        pipeline_cmd.standard_recovar_pipeline(args)
+
+    assert captured["limits"] == [12.0]
+    assert captured["downsample_kwargs"]["gpu_memory_gb"] == 12.0


### PR DESCRIPTION
## Summary
- forward `--gpu-gb` into the pre-downsample pipeline path so `downsample_to_disk` respects the user GPU cap
- apply the requested GPU memory limit before the pipeline auto-downsample stage runs
- retry GPU downsampling with smaller batches on GPU OOM instead of failing immediately
- add unit coverage for the forwarded GPU cap and OOM retry behavior

Closes #63.

## Validation
- `pixi install`
- `pixi run install-recovar`
- editable reinstall with the pixi Python
- `PYTHON="$PIXI_PY" make -C recovar/cuda clean all`
- `pixi run smoke-import-recovar`
- provenance gate: `provenance_ok`
- `pixi run pytest tests/unit/test_commands_downsample.py tests/unit/test_commands_pipeline.py`