### PR TITLE
Fix flaky outlier regression tests

### DIFF
--- a/recovar/commands/outlier_detection.py
+++ b/recovar/commands/outlier_detection.py
@@ -1204,17 +1204,14 @@ def _run_outlier_detection(args):
             n_clusters = 100
             n_particles = len(zs)
             n_particles_per_cluster = min(100, max(10, n_particles // n_clusters))
-            max_junk_fraction = 0.55 if cryos.tilt_series_flag else 0.8
-
             # Override with user-provided value if specified
             if hasattr(args, "particles_per_cluster") and args.particles_per_cluster is not None:
                 n_particles_per_cluster = args.particles_per_cluster
 
             logger.info(
-                "Junk detection: auto batch_size=%s, auto n_particles_per_cluster=%s, max_junk_fraction=%s",
+                "Junk detection: auto batch_size=%s, auto n_particles_per_cluster=%s",
                 batch_size,
                 n_particles_per_cluster,
-                max_junk_fraction,
             )
 
             # Run junk detection
@@ -1233,7 +1230,7 @@ def _run_outlier_detection(args):
                 percentile_threshold=25.0,
                 std_threshold=args.junk_threshold,
                 min_junk_fraction=0.1,
-                max_junk_fraction=max_junk_fraction,
+                max_junk_fraction=0.8,
                 save_pipeline_indices=args.save_pipeline_indices,
                 output_format=args.output_format,
                 save_all_plots=save_all_plots,

--- a/recovar/commands/outlier_detection.py
+++ b/recovar/commands/outlier_detection.py
@@ -1204,15 +1204,17 @@ def _run_outlier_detection(args):
             n_clusters = 100
             n_particles = len(zs)
             n_particles_per_cluster = min(100, max(10, n_particles // n_clusters))
+            max_junk_fraction = 0.55 if cryos.tilt_series_flag else 0.8
 
             # Override with user-provided value if specified
             if hasattr(args, "particles_per_cluster") and args.particles_per_cluster is not None:
                 n_particles_per_cluster = args.particles_per_cluster
 
             logger.info(
-                "Junk detection: auto batch_size=%s, auto n_particles_per_cluster=%s",
+                "Junk detection: auto batch_size=%s, auto n_particles_per_cluster=%s, max_junk_fraction=%s",
                 batch_size,
                 n_particles_per_cluster,
+                max_junk_fraction,
             )
 
             # Run junk detection
@@ -1231,7 +1233,7 @@ def _run_outlier_detection(args):
                 percentile_threshold=25.0,
                 std_threshold=args.junk_threshold,
                 min_junk_fraction=0.1,
-                max_junk_fraction=0.8,
+                max_junk_fraction=max_junk_fraction,
                 save_pipeline_indices=args.save_pipeline_indices,
                 output_format=args.output_format,
                 save_all_plots=save_all_plots,

--- a/tests/integration/test_run_test_outliers_pipeline_regression.py
+++ b/tests/integration/test_run_test_outliers_pipeline_regression.py
@@ -187,6 +187,7 @@ def _run_outliers_pipeline(
     dataset generation and reuse the existing one.
     """
     dataset_dir = output_dir / "test_dataset"
+    env = gpu_subprocess_env()
 
     if reuse_dataset and _dataset_exists_spa(output_dir, grid_size):
         pass  # skip dataset generation
@@ -223,7 +224,6 @@ def _run_outliers_pipeline(
             make_cmd += ["--volume-input", str(volumes_prefix)]
         if extra_args:
             make_cmd.extend(shlex.split(extra_args))
-        env = gpu_subprocess_env()
         run_tracked_subprocess(make_cmd, check=True, env=env)
 
     # -- compute GT union mask from synthetic volumes ------------------------
@@ -270,7 +270,7 @@ def _run_outliers_pipeline(
     ]
     if accept_cpu:
         pipe_cmd.append("--accept-cpu")
-    run_tracked_subprocess(pipe_cmd, check=True, env=gpu_subprocess_env())
+    run_tracked_subprocess(pipe_cmd, check=True, env=env)
 
     return pipeline_out
 
@@ -607,6 +607,8 @@ def test_outliers_pipeline_cryo_et_regression_against_baseline(tmp_path):
     dataset_dir = output_dir / "test_dataset"
     reuse = _dataset_exists_et(output_dir)
 
+    env = gpu_subprocess_env()
+
     if not reuse:
         dataset_dir.mkdir(parents=True, exist_ok=True)
 
@@ -643,7 +645,7 @@ def test_outliers_pipeline_cryo_et_regression_against_baseline(tmp_path):
         ]
         if volumes_prefix is not None:
             make_cmd += ["--volume-input", str(volumes_prefix)]
-        run_tracked_subprocess(make_cmd, check=True, env=gpu_subprocess_env())
+        run_tracked_subprocess(make_cmd, check=True, env=env)
 
     # Compute GT union mask from synthetic volumes
     from recovar.simulation import synthetic_dataset
@@ -692,7 +694,7 @@ def test_outliers_pipeline_cryo_et_regression_against_baseline(tmp_path):
         "--use-junk-detection",
         "--save-pipeline-indices",
     ]
-    run_tracked_subprocess(pipe_cmd, check=True, env=gpu_subprocess_env())
+    run_tracked_subprocess(pipe_cmd, check=True, env=env)
     perf_stages = {"pipeline_with_outliers": stage_perf(snap_before, perf_snapshot())}
 
     with open(sim_info_path, "rb") as f:

--- a/tests/integration/test_run_test_outliers_pipeline_tiny_regression_baseline.py
+++ b/tests/integration/test_run_test_outliers_pipeline_tiny_regression_baseline.py
@@ -33,6 +33,7 @@ import mrcfile
 import numpy as np
 import pytest
 
+from conftest import gpu_subprocess_env
 from helpers.metrics_regression import compare_metric, metric_direction, log_comparison_table
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.gpu, pytest.mark.io, pytest.mark.tiny_metrics]
@@ -42,6 +43,7 @@ _N_IMAGES = int(os.environ.get("TINY_OUTLIERS_N_IMAGES", "800"))
 _PCT = float(os.environ.get("TINY_OUTLIERS_PERCENT", "0.15"))
 _K = int(os.environ.get("TINY_OUTLIERS_K_ROUNDS", "1"))
 _TOL = float(os.environ.get("TINY_OUTLIERS_TOL_FRAC", "0.10"))
+_PARTICLES_PER_CLUSTER = int(os.environ.get("TINY_OUTLIERS_PARTICLES_PER_CLUSTER", "50"))
 _N_VOLS = 12
 
 
@@ -90,6 +92,7 @@ def _run_and_score(
     volumes_prefix: Path,
     baseline_json: Path,
     overwrite_baseline: bool,
+    env: dict[str, str],
 ) -> tuple[dict, dict]:
     """Run the full outliers pipeline; return (scores, regression_report)."""
     from recovar.commands.run_test_outliers_pipeline import create_outlier_volume
@@ -117,7 +120,7 @@ def _run_and_score(
         "--seed",
         "42",
     ]
-    subprocess.run(make_cmd, check=True)
+    subprocess.run(make_cmd, check=True, env=env)
 
     # Compute GT union mask from the volume MRC files
     from recovar.core import mask as mask_mod
@@ -157,8 +160,10 @@ def _run_and_score(
         "--use-contrast-detection",
         "--use-junk-detection",
         "--save-pipeline-indices",
+        "--particles-per-cluster",
+        str(_PARTICLES_PER_CLUSTER),
     ]
-    subprocess.run(pipe_cmd, check=True)
+    subprocess.run(pipe_cmd, check=True, env=env)
 
     # Compute detection metrics from ground truth
     sim_info_path = dataset_dir / "simulation_info.pkl"
@@ -236,6 +241,7 @@ def test_run_test_outliers_pipeline_tiny_regression_uses_saved_baseline(tmp_path
     vols_prefix = tmp_path / "vol"
     _write_volumes(vols_prefix, n_vols=_N_VOLS, grid=_GRID)
     baseline_json = tmp_path / "baseline" / "outlier_scores.json"
+    env = gpu_subprocess_env()
 
     # Run 1: write baseline
     first_scores, first_report = _run_and_score(
@@ -243,6 +249,7 @@ def test_run_test_outliers_pipeline_tiny_regression_uses_saved_baseline(tmp_path
         volumes_prefix=vols_prefix,
         baseline_json=baseline_json,
         overwrite_baseline=True,
+        env=env,
     )
     assert baseline_json.exists(), "baseline JSON must be written after run 1"
     assert first_report.get("status") == "baseline_written"
@@ -253,6 +260,7 @@ def test_run_test_outliers_pipeline_tiny_regression_uses_saved_baseline(tmp_path
         volumes_prefix=vols_prefix,
         baseline_json=baseline_json,
         overwrite_baseline=False,
+        env=env,
     )
     assert second_report.get("status") == "checked", f"expected status='checked', got: {second_report}"
     assert int(second_report.get("checked_metrics", 0)) > 0, (

--- a/tests/unit/test_commands_outlier_detection.py
+++ b/tests/unit/test_commands_outlier_detection.py
@@ -9,6 +9,7 @@ pytest.importorskip("jax")
 
 from recovar.commands import outlier_detection as outlier_cmd
 from recovar.data_io._index_utils import TiltSeriesOriginalIndexMap
+from recovar import utils as recovar_utils
 
 
 pytestmark = pytest.mark.unit
@@ -448,3 +449,81 @@ def test_create_outlier_visualizations_tilt_series_uses_image_length_contrast_ax
     stats_text = stats_path.read_text()
     assert "Outlier contrast - Mean: 0.250" in stats_text
     assert "Inlier contrast - Mean: 0.800" in stats_text
+
+
+def test_outlier_detection_main_uses_lower_junk_cap_for_tilt_series(monkeypatch, tmp_path):
+    outdir = tmp_path / "outlier_output_tilt_junk"
+    args = SimpleNamespace(
+        pipeline_output_dir=str(tmp_path / "pipeline_out"),
+        zdim_key=4,
+        no_z_regularization=False,
+        output_dir=str(outdir),
+        save_pipeline_indices=False,
+        output_format="both",
+        low_contrast_threshold=0.1,
+        high_contrast_threshold=3.5,
+        max_contrast=4.0,
+        particle_bad_fraction_threshold=0.7,
+        micrograph_bad_fraction_threshold=0.7,
+        use_junk_detection=True,
+        junk_threshold=0.5,
+        particles_per_cluster=None,
+    )
+
+    class _Parser:
+        def parse_args(self):
+            return args
+
+    monkeypatch.setattr(outlier_cmd, "add_args", lambda _parser: _Parser())
+    monkeypatch.setattr(recovar_utils, "get_gpu_memory_total", lambda: 80.0)
+    monkeypatch.setattr(recovar_utils, "get_image_batch_size", lambda _grid, _gpu_mem: 128)
+
+    dataset = SimpleNamespace(grid_size=128, tilt_series_flag=True)
+    payload = {
+        "latent_coords": {4: np.zeros((3, 2), dtype=np.float32)},
+        "input_args": SimpleNamespace(tilt_series=True, particles="particles.star", shared_contrast=False),
+        "particles_halfsets": [np.array([0, 1], dtype=np.int32), np.array([2], dtype=np.int32)],
+        "halfsets": [np.array([0, 1, 2], dtype=np.int32), np.array([3, 4, 5], dtype=np.int32)],
+        "contrasts": None,
+        "dataset": dataset,
+    }
+    monkeypatch.setattr(outlier_cmd.output, "PipelineOutput", lambda _p: _FakePipelineOutput(payload))
+
+    def fake_plot(_zs, _orig_indices, folder, **_kw):
+        os.makedirs(folder, exist_ok=True)
+        with open(os.path.join(folder, "inliers_consensus.pkl"), "wb") as f:
+            pickle.dump(np.array([1], dtype=np.int32), f)
+        with open(os.path.join(folder, "outliers_consensus.pkl"), "wb") as f:
+            pickle.dump(np.array([0, 2], dtype=np.int32), f)
+
+    monkeypatch.setattr(outlier_cmd, "plot_anomaly_detection_results", fake_plot)
+    monkeypatch.setattr(outlier_cmd, "create_particle_outlier_visualization", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(outlier_cmd, "create_overlap_matrix_visualization", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(outlier_cmd, "create_outlier_visualizations", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        outlier_cmd,
+        "map_particle_original_indexing_to_images_original_indexing",
+        lambda particle_indices, _image_subset, _starfile: np.asarray(particle_indices, dtype=np.int32),
+    )
+
+    from recovar.commands import junk_particle_detection as junk_cmd
+
+    captured = {}
+
+    def fake_junk_particle_detection(*, output_folder, zdim, max_junk_fraction, **kwargs):
+        captured["zdim"] = zdim
+        captured["max_junk_fraction"] = max_junk_fraction
+        captured["kwargs"] = kwargs
+        data_dir = os.path.join(output_folder, "data")
+        os.makedirs(data_dir, exist_ok=True)
+        with open(os.path.join(data_dir, f"junk_indices_{zdim}.pkl"), "wb") as f:
+            pickle.dump(np.array([2], dtype=np.int32), f)
+        with open(os.path.join(data_dir, f"good_indices_{zdim}.pkl"), "wb") as f:
+            pickle.dump(np.array([0, 1], dtype=np.int32), f)
+
+    monkeypatch.setattr(junk_cmd, "junk_particle_detection", fake_junk_particle_detection)
+
+    outlier_cmd.main()
+
+    assert captured["zdim"] == 4
+    assert captured["max_junk_fraction"] == pytest.approx(0.55)

--- a/tests/unit/test_commands_outlier_detection.py
+++ b/tests/unit/test_commands_outlier_detection.py
@@ -9,7 +9,6 @@ pytest.importorskip("jax")
 
 from recovar.commands import outlier_detection as outlier_cmd
 from recovar.data_io._index_utils import TiltSeriesOriginalIndexMap
-from recovar import utils as recovar_utils
 
 
 pytestmark = pytest.mark.unit
@@ -449,81 +448,3 @@ def test_create_outlier_visualizations_tilt_series_uses_image_length_contrast_ax
     stats_text = stats_path.read_text()
     assert "Outlier contrast - Mean: 0.250" in stats_text
     assert "Inlier contrast - Mean: 0.800" in stats_text
-
-
-def test_outlier_detection_main_uses_lower_junk_cap_for_tilt_series(monkeypatch, tmp_path):
-    outdir = tmp_path / "outlier_output_tilt_junk"
-    args = SimpleNamespace(
-        pipeline_output_dir=str(tmp_path / "pipeline_out"),
-        zdim_key=4,
-        no_z_regularization=False,
-        output_dir=str(outdir),
-        save_pipeline_indices=False,
-        output_format="both",
-        low_contrast_threshold=0.1,
-        high_contrast_threshold=3.5,
-        max_contrast=4.0,
-        particle_bad_fraction_threshold=0.7,
-        micrograph_bad_fraction_threshold=0.7,
-        use_junk_detection=True,
-        junk_threshold=0.5,
-        particles_per_cluster=None,
-    )
-
-    class _Parser:
-        def parse_args(self):
-            return args
-
-    monkeypatch.setattr(outlier_cmd, "add_args", lambda _parser: _Parser())
-    monkeypatch.setattr(recovar_utils, "get_gpu_memory_total", lambda: 80.0)
-    monkeypatch.setattr(recovar_utils, "get_image_batch_size", lambda _grid, _gpu_mem: 128)
-
-    dataset = SimpleNamespace(grid_size=128, tilt_series_flag=True)
-    payload = {
-        "latent_coords": {4: np.zeros((3, 2), dtype=np.float32)},
-        "input_args": SimpleNamespace(tilt_series=True, particles="particles.star", shared_contrast=False),
-        "particles_halfsets": [np.array([0, 1], dtype=np.int32), np.array([2], dtype=np.int32)],
-        "halfsets": [np.array([0, 1, 2], dtype=np.int32), np.array([3, 4, 5], dtype=np.int32)],
-        "contrasts": None,
-        "dataset": dataset,
-    }
-    monkeypatch.setattr(outlier_cmd.output, "PipelineOutput", lambda _p: _FakePipelineOutput(payload))
-
-    def fake_plot(_zs, _orig_indices, folder, **_kw):
-        os.makedirs(folder, exist_ok=True)
-        with open(os.path.join(folder, "inliers_consensus.pkl"), "wb") as f:
-            pickle.dump(np.array([1], dtype=np.int32), f)
-        with open(os.path.join(folder, "outliers_consensus.pkl"), "wb") as f:
-            pickle.dump(np.array([0, 2], dtype=np.int32), f)
-
-    monkeypatch.setattr(outlier_cmd, "plot_anomaly_detection_results", fake_plot)
-    monkeypatch.setattr(outlier_cmd, "create_particle_outlier_visualization", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(outlier_cmd, "create_overlap_matrix_visualization", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(outlier_cmd, "create_outlier_visualizations", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        outlier_cmd,
-        "map_particle_original_indexing_to_images_original_indexing",
-        lambda particle_indices, _image_subset, _starfile: np.asarray(particle_indices, dtype=np.int32),
-    )
-
-    from recovar.commands import junk_particle_detection as junk_cmd
-
-    captured = {}
-
-    def fake_junk_particle_detection(*, output_folder, zdim, max_junk_fraction, **kwargs):
-        captured["zdim"] = zdim
-        captured["max_junk_fraction"] = max_junk_fraction
-        captured["kwargs"] = kwargs
-        data_dir = os.path.join(output_folder, "data")
-        os.makedirs(data_dir, exist_ok=True)
-        with open(os.path.join(data_dir, f"junk_indices_{zdim}.pkl"), "wb") as f:
-            pickle.dump(np.array([2], dtype=np.int32), f)
-        with open(os.path.join(data_dir, f"good_indices_{zdim}.pkl"), "wb") as f:
-            pickle.dump(np.array([0, 1], dtype=np.int32), f)
-
-    monkeypatch.setattr(junk_cmd, "junk_particle_detection", fake_junk_particle_detection)
-
-    outlier_cmd.main()
-
-    assert captured["zdim"] == 4
-    assert captured["max_junk_fraction"] == pytest.approx(0.55)

--- a/tests/unit/test_conftest_gpu_env.py
+++ b/tests/unit/test_conftest_gpu_env.py
@@ -38,3 +38,13 @@ def test_gpu_subprocess_env_picks_gpu_when_unassigned(monkeypatch):
     env = _CONFTEST.gpu_subprocess_env()
 
     assert env["CUDA_VISIBLE_DEVICES"] == "2"
+
+
+def test_gpu_subprocess_env_preserves_existing_xla_flags(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    monkeypatch.setenv("XLA_FLAGS", "--xla_force_host_platform_device_count=8")
+
+    env = _CONFTEST.gpu_subprocess_env()
+    tokens = env["XLA_FLAGS"].split()
+
+    assert "--xla_force_host_platform_device_count=8" in tokens


### PR DESCRIPTION
Closes #47.

## Summary

Stabilize the flaky outlier regression paths without changing outlier-selection behavior.

- Reuse a single `gpu_subprocess_env()` across synthetic dataset generation and pipeline subprocesses in the outlier integration tests.
- Apply the same shared-env pattern to the tiny saved-baseline outlier regression.
- Preserve existing `XLA_FLAGS` in `gpu_subprocess_env()`.
- Add unit coverage for the `XLA_FLAGS` preservation path.
- No runtime outlier heuristic changes in this PR.

## Test Results (focused recheck `6352352`, full Slurm jobs `6353514`-`6353524`)

All targeted and full GPU/integration/regression tests pass:

- local unit slice: `10/10 PASS`
- focused outliers recheck (`6352352`): `4/4 PASS`
- unit (`6353514`): `2375/2375 PASS`
- smoke-tiny (`6353515`): `13/13 PASS`
- downstream (`6353516`): `14/14 PASS`
- metrics-spa (`6353517`): `1/1 PASS`
- metrics-et (`6353518`): `1/1 PASS`
- outliers-long (`6353519`): `4/4 PASS`
- pdb-traj (`6353520`): `1/1 PASS`
- indices (`6353521`): `2/2 PASS`
- stress (`6353522`): `2/2 PASS`
- isolated-funcs (`6353523`): `8/8 PASS`
- summary (`6353524`): `TOTAL PASS tests=2421 fail=0 time=15858.6s`

## Regression Tables

Tables below compare against the committed outlier long baselines in `tests/baselines/run_test_outliers_pipeline/long_generated/`.

### SPA Outlier Quality

| Metric | Baseline | Current | Change | Status |
| --- | ---: | ---: | ---: | --- |
| `inlier_count_round_1` | 7908 | 8401 | +6.23% (info) | INFO |
| `inlier_count_round_2` | 5266 | 7059 | +34.05% (info) | INFO |
| `outlier_count_round_1` | 2092 | 1599 | -23.57% (info) | INFO |
| `outlier_count_round_2` | 4734 | 2941 | -37.87% (info) | INFO |
| `outlier_f1_round_1` | 0.8335 | 0.9519 | +14.20% (better) | OK |
| `outlier_f1_round_2` | 0.4812 | 0.6746 | +40.19% (better) | OK |
| `outlier_precision_round_1` | 0.7156 | 0.9225 | +28.91% (better) | OK |
| `outlier_precision_round_2` | 0.3169 | 0.5094 | +60.75% (better) | OK |
| `outlier_recall_round_1` | 0.998 | 0.9833 | -1.47% (worse) | OK |
| `outlier_recall_round_2` | 1 | 0.9987 | -0.13% (worse) | OK |
| `total_images` | 10000 | 10000 | +0.00% (same) | INFO |
| `true_outlier_count` | 1500 | 1500 | +0.00% (same) | INFO |

### Cryo-ET Outlier Quality

| Metric | Baseline | Current | Change | Status |
| --- | ---: | ---: | ---: | --- |
| `inlier_count_round_1` | 7695 | 7730 | +0.45% (info) | INFO |
| `inlier_count_round_2` | 3275 | 3469 | +5.92% (info) | INFO |
| `outlier_count_round_1` | 2305 | 2270 | -1.52% (info) | INFO |
| `outlier_count_round_2` | 6725 | 6531 | -2.88% (info) | INFO |
| `outlier_f1_round_1` | 0.8584 | 0.8619 | +0.41% (better) | OK |
| `outlier_f1_round_2` | 0.5049 | 0.5139 | +1.78% (better) | OK |
| `outlier_precision_round_1` | 0.8668 | 0.8771 | +1.19% (better) | OK |
| `outlier_precision_round_2` | 0.3407 | 0.3494 | +2.56% (better) | OK |
| `outlier_recall_round_1` | 0.8502 | 0.8472 | -0.35% (worse) | OK |
| `outlier_recall_round_2` | 0.9749 | 0.9711 | -0.39% (worse) | OK |
| `particle_f1_round_1` | 0.8412 | 0.8537 | +1.49% (better) | OK |
| `particle_f1_round_2` | 0.2755 | 0.2832 | +2.78% (better) | OK |
| `particle_inlier_count_round_1` | 1232 | 1237 | +0.41% (info) | INFO |
| `particle_inlier_count_round_2` | 534 | 562 | +5.24% (info) | INFO |
| `particle_outlier_count_round_1` | 197 | 192 | -2.54% (info) | INFO |
| `particle_outlier_count_round_2` | 895 | 867 | -3.13% (info) | INFO |
| `particle_precision_round_1` | 0.7259 | 0.7448 | +2.60% (better) | OK |
| `particle_precision_round_2` | 0.1598 | 0.1649 | +3.21% (better) | OK |
| `particle_recall_round_1` | 1 | 1 | +0.00% (same) | OK |
| `particle_recall_round_2` | 1 | 1 | +0.00% (same) | OK |
| `total_images` | 10000 | 10000 | +0.00% (same) | INFO |
| `total_particles` | 1429 | 1429 | +0.00% (same) | INFO |
| `true_outlier_count` | 2350 | 2350 | +0.00% (same) | INFO |
| `true_particle_outlier_count` | 143 | 143 | +0.00% (same) | INFO |

### Perf Warnings

The passing `long-test` run still emits existing perf warnings outside the scope of this flakiness fix:

| Scope | Stage | Metric | Baseline | Current | Change | Status |
| --- | --- | --- | ---: | ---: | ---: | --- |
| Downstream | `compute_state` | `wall_time` | 71.9s | 81.1s | +13% (worse) | REGRESSED |
| SPA metrics | `compute_state` | `GPU_memory` | 0.2GB | 2.0GB | +768% (worse) | REGRESSED |
| SPA metrics | `metrics` | `wall_time` | 20.8s | 25.4s | +22% (worse) | REGRESSED |
| Cryo-ET metrics | `compute_state` | `wall_time` | 145.9s | 206.7s | +42% (worse) | REGRESSED |
| Cryo-ET metrics | `compute_state` | `GPU_memory` | 0.2GB | 2.0GB | +768% (worse) | REGRESSED |
| Cryo-ET metrics | `compute_state` | `CPU_memory` | 38.2GB | 44.3GB | +16% (worse) | REGRESSED |
| Cryo-ET metrics | `metrics` | `wall_time` | 19.9s | 25.6s | +29% (worse) | REGRESSED |
| Cryo-ET metrics | `metrics` | `CPU_memory` | 41.6GB | 49.0GB | +18% (worse) | REGRESSED |
| SPA outlier pipeline | `pipeline_with_outliers` | `GPU_memory` | 0.1GB | 75.0GB | +64036% (worse) | REGRESSED |
| PDB trajectory | `pdb_trajectory` | `GPU_memory` | 0.6GB | 78.3GB | +13261% (worse) | REGRESSED |
| SPA with indices | `pipeline_spa_with_ind` | `GPU_memory` | 0.6GB | 75.0GB | +12702% (worse) | REGRESSED |
