### PR TITLE
Stabilize data multiplier state across dataset views

### DIFF
--- a/recovar/data_io/cryoem_dataset.py
+++ b/recovar/data_io/cryoem_dataset.py
@@ -389,12 +389,12 @@ class CryoEMDataset:
     @property
     def data_multiplier(self):
         """Sign multiplier for data inversion (±1)."""
-        return getattr(self.image_source, "mult", 1)
+        return getattr(self.image_source, "data_multiplier", 1)
 
     @data_multiplier.setter
     def data_multiplier(self, value):
         if self.image_source is not None:
-            self.image_source.mult = value
+            self.image_source.data_multiplier = value
 
     @property
     def dataset_tilt_indices(self):
@@ -478,7 +478,7 @@ class CryoEMDataset:
             ind=original_image_indices,
             lazy=lazy,
             padding=self.padding,
-            uninvert_data=info.invert_data,
+            uninvert_data=bool(self.data_multiplier < 0),
             tilt_series=self.tilt_series_flag,
             tilt_series_ctf=info.tilt_series_ctf,
             dose_per_tilt=info.dose_per_tilt,

--- a/recovar/data_io/image_backends.py
+++ b/recovar/data_io/image_backends.py
@@ -126,7 +126,7 @@ class ParticleImageDataset:
         self.image_shape = (self.image_size, self.image_size)
         self.total_pixels = self.image_size * self.image_size
         self.image_mask = np.array(mask.window_mask(self.image_size, 0.85, 0.99))
-        self.data_multiplier = -1 if invert_data else 1
+        self._data_multiplier = -1 if invert_data else 1
 
         # Compatibility aliases
         self.N = self.num_images
@@ -134,13 +134,29 @@ class ParticleImageDataset:
         self.D = self.image_size
         self.unpadded_D = self.image_size
         self.mask = self.image_mask
-        self.mult = self.data_multiplier
 
     def __len__(self) -> int:
         return self.num_images
 
     def __repr__(self) -> str:
         return f"ParticleImageDataset(N={self.num_images}, D={self.image_size})"
+
+    @property
+    def data_multiplier(self):
+        return self._data_multiplier
+
+    @data_multiplier.setter
+    def data_multiplier(self, value):
+        self._data_multiplier = value
+        self.invert_data = bool(value < 0)
+
+    @property
+    def mult(self):
+        return self.data_multiplier
+
+    @mult.setter
+    def mult(self, value):
+        self.data_multiplier = value
 
     @nvtx.annotate("ParticleImageDataset.__getitem__", color="yellow", domain=NVTX_DOMAIN_DATA_IO)
     def __getitem__(self, index):
@@ -154,7 +170,7 @@ class ParticleImageDataset:
             images = images * self.image_mask
         import recovar.core.padding as pad
 
-        images = pad.padded_dft(images * self.mult, self.D, self.padding)
+        images = pad.padded_dft(images * self.data_multiplier, self.D, self.padding)
         return images.astype(self.dtype, copy=False)
 
     def process_images_half(self, images: np.ndarray, apply_image_mask: bool = False) -> np.ndarray:

--- a/recovar/data_io/image_sources.py
+++ b/recovar/data_io/image_sources.py
@@ -10,7 +10,7 @@ top-level dataset/view object. It provides:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal, Optional
 
 import numpy as np
@@ -143,12 +143,20 @@ class ImageSource:
         raise NotImplementedError
 
     @property
-    def mult(self):
+    def data_multiplier(self):
         raise NotImplementedError
+
+    @data_multiplier.setter
+    def data_multiplier(self, value):
+        raise NotImplementedError
+
+    @property
+    def mult(self):
+        return self.data_multiplier
 
     @mult.setter
     def mult(self, value):
-        raise NotImplementedError
+        self.data_multiplier = value
 
     @property
     def dataset_tilt_indices(self):
@@ -254,12 +262,17 @@ class BackendImageSource(ImageSource):
         return self.backend.mask
 
     @property
-    def mult(self):
-        return self.backend.mult
+    def data_multiplier(self):
+        return self.backend.data_multiplier
 
-    @mult.setter
-    def mult(self, value):
-        self.backend.mult = value
+    @data_multiplier.setter
+    def data_multiplier(self, value):
+        self.backend.data_multiplier = value
+        self.info = replace(self.info, invert_data=bool(value < 0))
+
+    @property
+    def mult(self):
+        return self.data_multiplier
 
     def __getitem__(self, index):
         return self.backend[index]
@@ -304,7 +317,6 @@ class SubsetImageSource(ImageSource):
 
     def __init__(self, parent: ImageSource, image_indices):
         self.parent = parent
-        self.info = parent.info
         self._parent_local_image_indices = _normalize_indices(
             image_indices, parent.n_images, name="image_indices"
         ).astype(np.int32, copy=False)
@@ -324,6 +336,10 @@ class SubsetImageSource(ImageSource):
     @property
     def already_prefetches(self) -> bool:
         return self.parent.already_prefetches
+
+    @property
+    def info(self) -> ImageSourceInfo:
+        return self.parent.info
 
     @property
     def n_images(self) -> int:
@@ -358,12 +374,16 @@ class SubsetImageSource(ImageSource):
         return self.parent.mask
 
     @property
-    def mult(self):
-        return self.parent.mult
+    def data_multiplier(self):
+        return self.parent.data_multiplier
 
-    @mult.setter
-    def mult(self, value):
-        self.parent.mult = value
+    @data_multiplier.setter
+    def data_multiplier(self, value):
+        self.parent.data_multiplier = value
+
+    @property
+    def mult(self):
+        return self.data_multiplier
 
     def __getitem__(self, index):
         if self.tilt_series:

--- a/tests/unit/test_cryoem_dataset.py
+++ b/tests/unit/test_cryoem_dataset.py
@@ -156,6 +156,21 @@ def test_reorder_to_dataset_indexing_uses_local_dataset_order():
     np.testing.assert_array_equal(out, np.array([20.0, 40.0, 10.0, 30.0], dtype=np.float32))
 
 
+def test_dataset_data_multiplier_prefers_image_source_data_multiplier():
+    class _Source:
+        data_multiplier = -1
+        mult = 1
+
+    cryo = dataset.CryoEMDataset.__new__(dataset.CryoEMDataset)
+    cryo._image_source = _Source()
+
+    assert cryo.data_multiplier == -1
+
+    cryo.data_multiplier = 1
+    assert cryo.image_source.data_multiplier == 1
+    assert cryo.image_source.mult == 1
+
+
 def test_reorder_to_original_indexing_from_halfsets_rejects_too_small_num_images():
     arr = np.array([1.0], dtype=np.float32)
     halfsets = [np.array([2], dtype=np.int32), np.array([], dtype=np.int32)]
@@ -276,6 +291,7 @@ def test_cryoemdataset_halfset_original_group_indices_tilt():
 
 def test_reload_from_original_images_preserves_original_indices_and_noise_mapping(monkeypatch):
     fake_stack = _FakeImageStack(n_images=6, D=8, padding=0, Np=3)
+    fake_stack.data_multiplier = -1
     image_source = dataset.BackendImageSource(
         fake_stack,
         info=dataset.ImageSourceInfo(
@@ -395,6 +411,81 @@ def test_reload_from_original_images_preserves_original_indices_and_noise_mappin
         half0.CTF_params,
         ctf[[0, 2, 4]],
     )
+
+
+def test_reload_from_original_images_uses_live_data_multiplier(monkeypatch):
+    fake_stack = _FakeImageStack(n_images=4, D=8, padding=0, Np=2)
+    fake_stack.data_multiplier = -1
+    image_source = dataset.BackendImageSource(
+        fake_stack,
+        info=dataset.ImageSourceInfo(tilt_series=True, invert_data=True),
+    )
+    rots = np.tile(np.eye(3, dtype=np.float32), (4, 1, 1))
+    trans = np.zeros((4, 2), dtype=np.float32)
+    ctf = np.zeros((4, 9), dtype=np.float32)
+    cryo = dataset.CryoEMDataset(
+        image_source=image_source,
+        voxel_size=1.0,
+        metadata=dataset.ImageMetadata(rots, trans, ctf),
+        dataset_indices=np.array([10, 11, 12, 13], dtype=np.int32),
+        tilt_series_flag=True,
+    )
+    cryo.particles_file = "particles.star"
+    cryo.poses_file = "poses.pkl"
+    cryo.ctf_file = "ctf.pkl"
+    cryo.halfset_indices = [
+        np.array([0, 2], dtype=np.int32),
+        np.array([1, 3], dtype=np.int32),
+    ]
+
+    captured = {}
+
+    class _Reloaded:
+        def update_poses(self, rots, trans):
+            self.rotation_matrices = np.asarray(rots)
+            self.translations = np.asarray(trans)
+
+        def update_ctf(self, ctf_params):
+            self.CTF_params = np.asarray(ctf_params)
+
+    def fake_load_dataset(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return _Reloaded()
+
+    monkeypatch.setattr(dataset, "load_dataset", fake_load_dataset)
+
+    cryo.data_multiplier = 1
+
+    cryo.get_halfset_dataset(0, independent=True, lazy=True)
+
+    assert cryo.image_source.info.invert_data is False
+    assert captured["kwargs"]["uninvert_data"] is False
+
+
+def test_subset_image_source_info_tracks_parent_data_multiplier():
+    fake_stack = _FakeImageStack(n_images=4, D=8, padding=0, Np=2)
+    fake_stack.data_multiplier = -1
+    image_source = dataset.BackendImageSource(
+        fake_stack,
+        info=dataset.ImageSourceInfo(tilt_series=True, invert_data=True),
+    )
+    rots = np.tile(np.eye(3, dtype=np.float32), (4, 1, 1))
+    trans = np.zeros((4, 2), dtype=np.float32)
+    ctf = np.zeros((4, 9), dtype=np.float32)
+    cryo = dataset.CryoEMDataset(
+        image_source=image_source,
+        voxel_size=1.0,
+        metadata=dataset.ImageMetadata(rots, trans, ctf),
+        dataset_indices=np.array([10, 11, 12, 13], dtype=np.int32),
+        tilt_series_flag=True,
+    )
+
+    sub = cryo.subset(np.array([1, 3], dtype=np.int32))
+    assert sub.image_source.info.invert_data is True
+
+    cryo.data_multiplier = 1
+
+    assert sub.image_source.info.invert_data is False
 
 
 def test_materialize_halfset_datasets_prefers_independent_reloads_for_lazy_sources(monkeypatch):

--- a/tests/unit/test_image_backends.py
+++ b/tests/unit/test_image_backends.py
@@ -52,6 +52,23 @@ def test_particle_image_dataset_process_images_half_matches_legacy_full_fft_path
     np.testing.assert_array_equal(processed_half, legacy_half)
 
 
+def test_particle_image_dataset_data_multiplier_and_mult_share_state(monkeypatch):
+    monkeypatch.setattr(image_backends.ImageLoader, "from_file", lambda *args, **kwargs: _DummySource(n=4, D=8))
+    ds = image_backends.ParticleImageDataset("dummy.mrcs", lazy=True, invert_data=False)
+
+    assert ds.data_multiplier == 1
+    assert ds.mult == 1
+    assert ds.invert_data is False
+
+    ds.mult = -1
+    assert ds.data_multiplier == -1
+    assert ds.invert_data is True
+
+    ds.data_multiplier = 1
+    assert ds.mult == 1
+    assert ds.invert_data is False
+
+
 def test_particle_image_dataset_subset_generators_preserve_order_and_duplicates(monkeypatch):
     monkeypatch.setattr(image_backends.ImageLoader, "from_file", lambda *args, **kwargs: _DummySource(n=5, D=8))
     ds = image_backends.ParticleImageDataset("dummy.mrcs", lazy=True, invert_data=False)


### PR DESCRIPTION
## Summary

- make `data_multiplier` the canonical sign state across particle backends, image sources, and `CryoEMDataset`
- keep `invert_data` metadata in sync when the live sign flips so subset views and reload paths see the current state
- add regression coverage for backend aliasing, subset metadata propagation, and halfset reloads after a sign change

## Scope

This PR addresses the brittle sign / uninvert state from issue #74 only.
It does **not** yet address:
- amplitude normalization / scaling
- resolution-switching rescaling for noise and related metadata

## Test Results (Slurm jobs 6617162-6617172)

Long-test summary: `TOTAL PASS tests=2425 fail=0 time=17657.4s`

All GPU/integration/regression groups pass:
- `unit`: `2379/2379 PASS`
- `smoke-tiny`: `13/13 PASS`
- `downstream`: `14/14 PASS`
- `metrics-spa`: `1/1 PASS`
- `metrics-et`: `1/1 PASS`
- `outliers-long`: `4/4 PASS`
- `pdb-traj`: `1/1 PASS`
- `indices`: `2/2 PASS`
- `stress`: `2/2 PASS`
- `isolated-funcs`: `8/8 PASS`

Additional focused validation:
- touched unit files: `131 passed`
- uninvert integration rerun: `1 passed` (`6360749`)

## Regression Tables

### SPA Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.026187 | 0.026292 | +0.40% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025993 | -0.97% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026182 | +0.71% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.026219 | +0.45% (worse) | OK |
| embedding_squared_error_10 | 1.978306 | 1.927887 | -2.55% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.382814 | +0.83% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980248 | +0.04% (better) | OK |
| noise_max_relative_error | 2.112245 | 2.114649 | +0.11% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049136 | -3.68% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005747 | -3.60% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.475227 | +3.21% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.472116 | +4.51% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.024244 | 0.024078 | -0.69% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024074 | -0.76% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023854 | -0.71% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023822 | -0.83% (better) | OK |
| embedding_squared_error_10 | 1.460294 | 1.432311 | -1.92% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.204556 | -4.45% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.06% (better) | OK |
| noise_max_relative_error | 2.152798 | 2.140589 | -0.57% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049609 | -4.26% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005677 | -0.36% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.637344 | +0.44% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.635390 | +0.44% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### SPA Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 136.2s | 138.3s | +1.5% (worse) | OK |
| dataset_generation | GPU_memory | 4.9GB | 4.9GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.3GB | 5.3GB | +0.5% (worse) | OK |
| pipeline | wall_time | 578.5s | 736.0s | +27.2% (worse) | **REGRESSED** |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 42.7GB | 42.2GB | -1.2% (better) | OK |
| compute_state | wall_time | 317.3s | 212.7s | -33.0% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 0.2GB | 0.0% (same) | OK |
| compute_state | CPU_memory | 46.7GB | 45.7GB | -2.2% (better) | OK |
| metrics | wall_time | 20.8s | 35.0s | +68.2% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 0.1GB | +65.8% (worse) | **REGRESSED** |
| metrics | CPU_memory | 50.7GB | 50.4GB | -0.6% (better) | OK |

### Cryo-ET Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 128.5s | 143.8s | +11.9% (worse) | **REGRESSED** |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.1GB | 5.1GB | +1.3% (worse) | OK |
| pipeline | wall_time | 1886.7s | 2680.8s | +42.1% (worse) | **REGRESSED** |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 38.1GB | 38.4GB | +0.7% (worse) | OK |
| compute_state | wall_time | 145.9s | 216.8s | +48.6% (worse) | **REGRESSED** |
| compute_state | GPU_memory | 0.2GB | 0.3GB | +7.2% (worse) | OK |
| compute_state | CPU_memory | 38.2GB | 42.4GB | +11.0% (worse) | **REGRESSED** |
| metrics | wall_time | 19.9s | 34.3s | +72.0% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 0.1GB | +65.8% (worse) | **REGRESSED** |
| metrics | CPU_memory | 41.6GB | 47.1GB | +13.1% (worse) | **REGRESSED** |

Refs #74.
