### PR TITLE
Fix CS parser: convert shifts from Angstroms to pixels

### DIFF
--- a/recovar/data_io/metadata_readers.py
+++ b/recovar/data_io/metadata_readers.py
@@ -232,7 +232,10 @@ def parse_poses_from_cs(
             break
 
     if shift_key is not None:
-        trans_pixels = data[shift_key].astype(np.float64)  # (N, 2)
+        shifts_angstrom = data[shift_key].astype(np.float64)  # (N, 2) in Angstroms
+        # Convert Angstroms → pixels using per-particle pixel size
+        apix = data["blob/psize_A"].astype(np.float64)  # (N,)
+        trans_pixels = shifts_angstrom / apix.reshape(-1, 1)
     else:
         logger.warning("No translation field found in CS file; assuming zero shifts.")
         trans_pixels = np.zeros((n, 2), dtype=np.float64)


### PR DESCRIPTION
## Summary

- CryoSPARC `.cs` files store `alignments3D/shift` in **Angstroms**, but the parser was treating them as pixel values
- This caused a systematic ~7% translation error (proportional to pixel size, e.g. 1.07 A/px)
- **Fix**: divide by per-particle `blob/psize_A` to convert Angstroms to pixels before normalization

## Changes

- `recovar/data_io/metadata_readers.py`: 1 line changed to 4 lines in `parse_poses_from_cs()`

## Test plan

- [ ] Verify with a known CS dataset that translations match expected pixel values
- [ ] Run pipeline on CS-imported data and compare reconstruction quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)