### PR TITLE
Fix n_pcs_to_compute to 200 for reproducibility across GPUs

### DIFF
--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -283,6 +283,14 @@ def add_args(parser: argparse.ArgumentParser):
         action="store_true",
         help="Use lowest memory options for covariance estimation",
     )
+    perf.add_argument(
+        "--adaptive-memory",
+        dest="adaptive_memory",
+        action="store_true",
+        help="Adapt number of PCs to available GPU memory. By default, "
+             "200 PCs are used regardless of GPU size for reproducibility. "
+             "This flag reduces n_pcs on smaller GPUs to avoid OOM.",
+    )
 
     # ── Advanced / debugging ─────────────────────────────────────────────
     adv = parser.add_argument_group("Advanced")
@@ -993,13 +1001,15 @@ def standard_recovar_pipeline(args):
         utils.report_memory_device(logger=logger)
 
         # --- Covariance options ---
-        covariance_options = covariance_estimation.get_default_covariance_computation_options(ds.grid_size)
+        adaptive = args.low_memory_option or getattr(args, "adaptive_memory", False)
+        covariance_options = covariance_estimation.get_default_covariance_computation_options(
+            ds.grid_size, adaptive_n_pcs=adaptive,
+        )
 
         if args.low_memory_option:
-            logger.info("Using low-memory covariance options (reduced sampling)")
+            logger.info("Using low-memory covariance options (reduced sampling, adaptive n_pcs)")
             covariance_options["sampling_n_cols"] = 50
             covariance_options["randomized_sketch_size"] = 100
-            covariance_options["n_pcs_to_compute"] = 100
             covariance_options["sampling_avoid_in_radius"] = 3
 
         if args.very_low_memory_option:

--- a/recovar/heterogeneity/covariance_estimation.py
+++ b/recovar/heterogeneity/covariance_estimation.py
@@ -88,16 +88,20 @@ NVTX_DOMAIN_H_B = "compute_H_B"
 
 
 @nvtx.annotate("get_default_covariance_computation_options", color="red")
-def get_default_covariance_computation_options(grid_size=None):
+def get_default_covariance_computation_options(grid_size=None, adaptive_n_pcs=False):
     """Return default options dict for covariance computation.
 
-    Automatically sizes the number of principal components and column
-    sampling parameters based on available GPU memory and the
-    reconstruction grid size.
+    Uses a fixed number of principal components (200) by default for
+    reproducibility across different GPU configurations. If
+    ``adaptive_n_pcs=True``, the number of PCs is reduced to fit in
+    available GPU memory (useful for smaller GPUs, but results will
+    depend on hardware).
 
     Args:
-        grid_size: Side length of the 3-D reconstruction grid.  When
-            provided, the number of PCs is scaled to fit in GPU memory.
+        grid_size: Side length of the 3-D reconstruction grid. Used for
+            memory estimation and adaptive PC count.
+        adaptive_n_pcs: If True, reduce the number of PCs to fit in GPU
+            memory. Default False (always use 200 PCs).
 
     Returns:
         Dictionary with keys ``reg_fn``, ``left_kernel``,
@@ -107,60 +111,50 @@ def get_default_covariance_computation_options(grid_size=None):
 
     gpu_memory = utils.get_gpu_memory_total()
 
-    if grid_size is not None:
-        # Account for basis memory: basis has shape (volume_size, n_pcs)
-        # where volume_size = grid_size^3
-        # Memory usage scales as volume_size * n_pcs * dtype_size
+    if adaptive_n_pcs and grid_size is not None:
         volume_size = grid_size**3
         dtype_size = 8  # bytes for complex64
-
-        # Reserve some memory for other operations (keep ~30% free)
         available_memory_gb = gpu_memory * 0.7
+        base_memory_coefficient = 75 / (200**4)
+        basis_memory_coefficient = volume_size * dtype_size / 1e9
 
-        # The original formula: n_pcs = ceil((gpu_memory / (75 / 200^4))^(1/4))
-        # This implies memory scales as: base_memory = (75 / 200^4) * n_pcs^4
-        # Total memory = base_memory + basis_memory
-        # Total memory = (75 / 200^4) * n_pcs^4 + volume_size * n_pcs * dtype_size / 1e9
-
-        base_memory_coefficient = 75 / (200**4)  # From original formula
-        basis_memory_coefficient = volume_size * dtype_size / 1e9  # GB per PC
-
-        # Solve: base_memory_coefficient * n_pcs^4 + basis_memory_coefficient * n_pcs <= available_memory_gb
-        # This is a quartic equation, but we can approximate by trying values
-
-        if gpu_memory < 70:
-            # Start with original estimate and adjust down if needed
-            n_pcs_original = np.ceil((gpu_memory / (75 / 200**4)) ** (1 / 4)).astype(int)
-        else:
-            n_pcs_original = 200
-
-        # Check if original estimate fits with basis memory
-        for n_pcs in range(n_pcs_original, 0, -1):
+        n_pcs = 200
+        for n_pcs in range(200, 0, -1):
             base_memory = base_memory_coefficient * (n_pcs**4)
             basis_memory = basis_memory_coefficient * n_pcs
-            total_memory = base_memory + basis_memory
-
-            if total_memory <= available_memory_gb:
+            if base_memory + basis_memory <= available_memory_gb:
                 break
         else:
-            n_pcs = 50  # Fallback to minimum
+            n_pcs = 50
 
         logger.info(
-            "Using %s PCs for covariance computation (GPU memory: %s GB, grid_size: %s, original estimate: %s, base+basis memory: %.2f GB)",
-            n_pcs,
-            gpu_memory,
-            grid_size,
-            n_pcs_original,
-            base_memory + basis_memory,
+            "Adaptive n_pcs: using %s PCs for covariance computation "
+            "(GPU memory: %.1f GB, grid_size: %s, estimated memory: %.1f GB)",
+            n_pcs, gpu_memory, grid_size, base_memory + basis_memory,
         )
     else:
-        # Fallback to original calculation if grid_size not provided
-        if gpu_memory < 70:
-            n_pcs = np.ceil((gpu_memory / (75 / 200**4)) ** (1 / 4)).astype(int)
-            logger.info("Using %s PCs for covariance computation (GPU memory: %s GB)", n_pcs, gpu_memory)
+        n_pcs = 200
+
+        # Estimate memory usage so we can warn if it might OOM
+        if grid_size is not None:
+            volume_size = grid_size**3
+            dtype_size = 8
+            base_memory_gb = (75 / (200**4)) * (n_pcs**4)
+            basis_memory_gb = volume_size * dtype_size * n_pcs / 1e9
+            total_memory_gb = base_memory_gb + basis_memory_gb
+            logger.info(
+                "Using %s PCs for covariance computation "
+                "(GPU memory: %.1f GB, grid_size: %s, estimated memory: %.1f GB)",
+                n_pcs, gpu_memory, grid_size, total_memory_gb,
+            )
+            if total_memory_gb > gpu_memory * 0.8:
+                logger.warning(
+                    "Estimated memory (%.1f GB) may exceed available GPU memory (%.1f GB). "
+                    "If you get OOM errors, use --low-memory-option to adaptively reduce n_pcs.",
+                    total_memory_gb, gpu_memory,
+                )
         else:
-            n_pcs = 200
-            logger.info("Using %s PCs for covariance computation (GPU memory: %s GB)", n_pcs, gpu_memory)
+            logger.info("Using %s PCs for covariance computation (GPU memory: %.1f GB)", n_pcs, gpu_memory)
 
     options = {
         "reg_fn": "new",


### PR DESCRIPTION
## Summary

- Fixed `n_pcs_to_compute` to 200 by default instead of adapting to GPU memory
- Previously: 107 PCs on 38GB GPU, 180 PCs on 76GB GPU for the same 288px dataset
- Now: always 200, with `--low-memory-option` for adaptive reduction on smaller GPUs
- Warns if estimated memory exceeds 80% of available GPU memory

## Why

Results were non-reproducible across different GPU hardware. The number of PCs directly affects covariance estimation, eigenvalues, embeddings, density, and volumes. See #97.

## Test plan

- [ ] Running Challenge 2 at 256px and 288px with 200 PCs to verify no OOM on 80GB GPUs
- [ ] Will compare density/embeddings quantitatively against previous runs
- [ ] Long-test and regression tables pending — this changes mathematical output so baselines need updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)