### PR TITLE
Remove 12.5% downsample threshold (honor explicit --downsample)

### DIFF
--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -464,18 +464,6 @@ def _resolve_downsample(args):
         args.downsample = None
         return
 
-    # Skip if within 12.5% — not worth the overhead
-    threshold = int(target_D * 1.125)
-    if orig_D <= threshold:
-        logger.info(
-            "Image size %d is close to target %d (threshold %d), skipping downsampling",
-            orig_D,
-            target_D,
-            threshold,
-        )
-        args.downsample = None
-        return
-
     logger.info("Will downsample images from %d to %d", orig_D, target_D)
 
 


### PR DESCRIPTION
## Summary

Previously, `_resolve_downsample` silently skipped downsampling if `orig_D <= target_D * 1.125`. So `--downsample 256` on 288px images did nothing. This was confusing — users thought they were running at 256 when they were actually at 288.

## Change

Removed the 12.5% threshold. Now `--downsample N` is honored whenever `N < orig_D`.

## Why

Discovered while investigating Challenge 2 runs. We tried to run `--downsample 256` on 288px particles to get comparable results across 256/288 resolutions, but the threshold made the flag a no-op. The logs said "skipping downsampling" but users expected the flag to work as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)