### PR TITLE
Fix missing psutil dependency in pip installs

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -46,6 +46,7 @@ typing_extensions = "*"
 
 # profiling
 nvtx = ">=0.2.13"
+psutil = "*"
 
 # Testing
 pytest = ">=8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "numpy>=2.0.0,<2.3.0",
     "optax==0.2.7",
     "pandas==2.2.3",
+    "psutil>=5.9",
     "scikit-image>=0.22.0",
     "scikit-learn==1.6.1",
     "scipy==1.15.2",

--- a/tests/unit/test_packaging_metadata.py
+++ b/tests/unit/test_packaging_metadata.py
@@ -1,0 +1,27 @@
+import tomllib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_toml(path: Path) -> dict:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def test_psutil_declared_for_runtime_installs():
+    pyproject = _load_toml(REPO_ROOT / "pyproject.toml")
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert any(dep.startswith("psutil") for dep in dependencies)
+
+
+def test_psutil_declared_for_pixi_dev_env():
+    pixi = _load_toml(REPO_ROOT / "pixi.toml")
+    dependencies = pixi["dependencies"]
+
+    assert "psutil" in dependencies


### PR DESCRIPTION
## Summary
- add `psutil` to the runtime package dependencies so `pip install -e ".[dev]"` installs it automatically
- make the pixi dev environment declare `psutil` explicitly as well
- add a unit regression test that checks both packaging manifests keep the dependency

Closes #101.

## Verification
- fresh pip install in an isolated venv now resolves and installs `psutil`
- `JAX_PLATFORMS=cpu recovar run_test_dataset --help`
- `JAX_PLATFORMS=cpu recovar init_project --help`

## Tests
- full regression suite not run, per requester instruction for this packaging-only fix
- regression tables not generated for this draft PR because the long-test workflow was intentionally skipped
