### PR TITLE
Fix cryoSPARC .cs translation scaling

### DIFF
--- a/recovar/data_io/metadata_readers.py
+++ b/recovar/data_io/metadata_readers.py
@@ -239,8 +239,13 @@ def parse_poses_from_cs(
         logger.warning("No translation field found in CS file; assuming zero shifts.")
         trans_pixels = np.zeros((n, 2), dtype=np.float64)
 
-    # Pixel → fractional
-    trans_fractional = trans_pixels / float(D)
+    # Pixel → fractional. Use the original image size from the .cs file when
+    # available so downsampled runs preserve the same fractional translations.
+    if "blob/shape" in data.dtype.names:
+        orig_D = data["blob/shape"][:, 0].astype(np.float64).reshape(-1, 1)
+        trans_fractional = trans_pixels / orig_D
+    else:
+        trans_fractional = trans_pixels / float(D)
 
     return rot_matrices, trans_fractional
 

--- a/recovar/data_io/metadata_readers.py
+++ b/recovar/data_io/metadata_readers.py
@@ -232,10 +232,9 @@ def parse_poses_from_cs(
             break
 
     if shift_key is not None:
-        shifts_angstrom = data[shift_key].astype(np.float64)  # (N, 2) in Angstroms
-        # Convert Angstroms → pixels using per-particle pixel size
-        apix = data["blob/psize_A"].astype(np.float64)  # (N,)
-        trans_pixels = shifts_angstrom / apix.reshape(-1, 1)
+        # cryoSPARC stores alignments*/shift in pixel units. Keep the values
+        # as-is and only convert to the fractional convention expected by recovar.
+        trans_pixels = data[shift_key].astype(np.float64)
     else:
         logger.warning("No translation field found in CS file; assuming zero shifts.")
         trans_pixels = np.zeros((n, 2), dtype=np.float64)

--- a/tests/unit/test_commands_downsample.py
+++ b/tests/unit/test_commands_downsample.py
@@ -12,10 +12,13 @@ import sys
 from types import SimpleNamespace
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from recovar.commands import downsample as ds_cmd
 from recovar.data_io import downsample as ds_io
+from recovar.data_io import metadata_readers as metadata_parsing
+from recovar.data_io.starfile import StarFile, write_star
 
 pytestmark = pytest.mark.unit
 
@@ -225,3 +228,170 @@ def test_write_minimal_star_creates_file(tmp_path):
         n_images=10,
     )
     assert (tmp_path / "particles.128.star").exists()
+
+
+
+def _make_relion31_star_input(tmp_path, orig_D=288, orig_apix=1.5, n_images=4):
+    star_path = tmp_path / "input.star"
+    optics = pd.DataFrame(
+        {
+            "_rlnOpticsGroup": [1],
+            "_rlnOpticsGroupName": ["opticsGroup1"],
+            "_rlnImagePixelSize": [orig_apix],
+            "_rlnImageSize": [orig_D],
+            "_rlnImageDimensionality": [2],
+            "_rlnVoltage": [300.0],
+            "_rlnSphericalAberration": [2.7],
+            "_rlnAmplitudeContrast": [0.1],
+        }
+    )
+    trans_px = np.array(
+        [
+            [3.25, -1.5],
+            [-4.0, 2.75],
+            [0.5, 0.25],
+            [-1.125, -2.5],
+        ],
+        dtype=np.float64,
+    )[:n_images]
+    particles = pd.DataFrame(
+        {
+            "_rlnImageName": [f"{i + 1}@input.mrcs" for i in range(n_images)],
+            "_rlnOpticsGroup": np.ones(n_images, dtype=int),
+            "_rlnAngleRot": [10.0, 20.0, 30.0, 40.0][:n_images],
+            "_rlnAngleTilt": [15.0, 25.0, 35.0, 45.0][:n_images],
+            "_rlnAnglePsi": [5.0, 12.0, 18.0, 24.0][:n_images],
+            "_rlnOriginXAngst": trans_px[:, 0] * orig_apix,
+            "_rlnOriginYAngst": trans_px[:, 1] * orig_apix,
+            "_rlnDefocusU": np.linspace(10000.0, 13000.0, n_images),
+            "_rlnDefocusV": np.linspace(11000.0, 14000.0, n_images),
+            "_rlnDefocusAngle": np.linspace(0.0, 90.0, n_images),
+            "_rlnPhaseShift": np.linspace(0.0, 12.0, n_images),
+        }
+    )
+    write_star(str(star_path), particles, optics)
+    return str(star_path), trans_px, float(orig_apix), int(orig_D), n_images
+
+
+def _make_cs_input(tmp_path, orig_D=288, orig_apix=1.5, n_images=4):
+    cs_path = tmp_path / "input.cs"
+    rotvecs = np.array(
+        [
+            [0.05, -0.02, 0.01],
+            [-0.03, 0.04, 0.02],
+            [0.01, 0.02, -0.05],
+            [0.06, 0.01, 0.03],
+        ],
+        dtype=np.float32,
+    )[:n_images]
+    trans_px = np.array(
+        [
+            [3.25, -1.5],
+            [-4.0, 2.75],
+            [0.5, 0.25],
+            [-1.125, -2.5],
+        ],
+        dtype=np.float32,
+    )[:n_images]
+    dtype = np.dtype(
+        [
+            ("blob/idx", np.int32),
+            ("blob/path", "U200"),
+            ("blob/shape", np.int32, (2,)),
+            ("blob/psize_A", np.float32),
+            ("alignments3D/pose", np.float32, (3,)),
+            ("alignments3D/shift", np.float32, (2,)),
+            ("ctf/df1_A", np.float32),
+            ("ctf/df2_A", np.float32),
+            ("ctf/df_angle_rad", np.float32),
+            ("ctf/accel_kv", np.float32),
+            ("ctf/cs_mm", np.float32),
+            ("ctf/amp_contrast", np.float32),
+            ("ctf/phase_shift_rad", np.float32),
+        ]
+    )
+    data = np.zeros(n_images, dtype=dtype)
+    data["blob/idx"] = np.arange(n_images, dtype=np.int32)
+    data["blob/path"] = "input.mrcs"
+    data["blob/shape"] = [orig_D, orig_D]
+    data["blob/psize_A"] = np.float32(orig_apix)
+    data["alignments3D/pose"] = rotvecs
+    data["alignments3D/shift"] = trans_px
+    data["ctf/df1_A"] = np.linspace(10000.0, 13000.0, n_images, dtype=np.float32)
+    data["ctf/df2_A"] = np.linspace(11000.0, 14000.0, n_images, dtype=np.float32)
+    data["ctf/df_angle_rad"] = np.deg2rad(np.linspace(0.0, 90.0, n_images)).astype(np.float32)
+    data["ctf/accel_kv"] = 300.0
+    data["ctf/cs_mm"] = 2.7
+    data["ctf/amp_contrast"] = 0.1
+    data["ctf/phase_shift_rad"] = np.deg2rad(np.linspace(0.0, 12.0, n_images)).astype(np.float32)
+    with open(cs_path, "wb") as f:
+        np.save(f, data)
+    return str(cs_path), trans_px.astype(np.float64), float(orig_apix), int(orig_D), n_images
+
+
+@pytest.mark.parametrize("target_D", [288, 192, 128, 96])
+def test_write_output_star_preserves_star_metadata_across_downsampling(tmp_path, target_D):
+    input_star, trans_px, orig_apix, orig_D, n_images = _make_relion31_star_input(tmp_path)
+    expected_rot, expected_trans = metadata_parsing.parse_poses_from_star(input_star, target_D)
+    expected_ctf = metadata_parsing.parse_ctf_from_star(input_star, target_D)
+
+    out_star = tmp_path / f"particles.{target_D}.star"
+    out_mrcs = tmp_path / f"particles.{target_D}.mrcs"
+    new_apix = orig_apix * orig_D / float(target_D)
+
+    ds_cmd._write_output_star(
+        input_path=input_star,
+        mrcs_path=str(out_mrcs),
+        star_path=str(out_star),
+        target_D=target_D,
+        new_apix=new_apix,
+        n_images=n_images,
+    )
+
+    sf = StarFile.load(str(out_star))
+    assert np.all(sf.resolution == target_D)
+    assert np.allclose(sf.apix, new_apix)
+    assert np.allclose(sf.apix * sf.resolution, orig_apix * orig_D)
+
+    got_rot, got_trans = metadata_parsing.parse_poses_from_star(str(out_star), target_D)
+    got_ctf = metadata_parsing.parse_ctf_from_star(str(out_star), target_D)
+
+    np.testing.assert_allclose(got_rot, expected_rot, atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(got_trans, expected_trans, atol=1e-10, rtol=1e-12)
+    np.testing.assert_allclose(got_trans, trans_px / float(orig_D), atol=1e-10, rtol=1e-12)
+    np.testing.assert_allclose(got_ctf, expected_ctf, atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(got_ctf[:, 0] * target_D, orig_apix * orig_D, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.parametrize("target_D", [288, 192, 128, 96])
+def test_write_output_star_preserves_cs_metadata_across_downsampling(tmp_path, target_D):
+    input_cs, trans_px, orig_apix, orig_D, n_images = _make_cs_input(tmp_path)
+    expected_rot, expected_trans = metadata_parsing.parse_poses_from_cs(input_cs, target_D)
+    expected_ctf = metadata_parsing.parse_ctf_from_cs(input_cs, target_D)
+
+    out_star = tmp_path / f"particles.{target_D}.star"
+    out_mrcs = tmp_path / f"particles.{target_D}.mrcs"
+    new_apix = orig_apix * orig_D / float(target_D)
+
+    ds_cmd._write_output_star(
+        input_path=input_cs,
+        mrcs_path=str(out_mrcs),
+        star_path=str(out_star),
+        target_D=target_D,
+        new_apix=new_apix,
+        n_images=n_images,
+    )
+
+    sf = StarFile.load(str(out_star))
+    assert np.all(sf.resolution == target_D)
+    assert np.allclose(sf.apix, new_apix)
+    assert np.allclose(sf.apix * sf.resolution, orig_apix * orig_D)
+
+    got_rot, got_trans = metadata_parsing.parse_poses_from_star(str(out_star), target_D)
+    got_ctf = metadata_parsing.parse_ctf_from_star(str(out_star), target_D)
+
+    np.testing.assert_allclose(got_rot, expected_rot, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(got_trans, expected_trans, atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(got_trans, trans_px / float(orig_D), atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(got_ctf, expected_ctf, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(got_ctf[:, 0] * target_D, orig_apix * orig_D, atol=1e-6, rtol=1e-6)

--- a/tests/unit/test_cs_parsing_realdata.py
+++ b/tests/unit/test_cs_parsing_realdata.py
@@ -89,6 +89,18 @@ def test_parse_poses_translation_regression(ref):
     )
 
 
+def test_parse_poses_translation_downsample_invariant(ref):
+    """Fractional translations should not change when target D is downsampled."""
+    _, trans = parse_poses_from_cs(CS_PATH, 128)
+    np.testing.assert_allclose(
+        trans,
+        ref["translations"],
+        atol=1e-10,
+        rtol=1e-12,
+        err_msg="Translations should use the original CS image size, not target D",
+    )
+
+
 def test_parse_poses_rotations_are_orthogonal(ref):
     """All rotation matrices should be proper rotations (det=1, R^T R = I)."""
     D = int(ref["D"])

--- a/tests/unit/test_metadata_readers.py
+++ b/tests/unit/test_metadata_readers.py
@@ -272,6 +272,15 @@ class TestParseFromCS:
         expected_frac = trans_pix / float(grid_size)
         assert_allclose(trans_frac, expected_frac, atol=1e-5)
 
+    def test_translation_uses_original_image_size_when_target_D_differs(self):
+        """Downsampled target D must not rescale CS fractional translations."""
+        cs_path, _, trans_pix, *_, voxel_size, grid_size = _make_test_cs(grid_size=288)
+
+        _, trans_frac = metadata_parsing.parse_poses_from_cs(cs_path, 128)
+
+        expected_frac = trans_pix / float(grid_size)
+        assert_allclose(trans_frac, expected_frac, atol=1e-5)
+
     def test_ctf_extraction(self):
         """CS CTF extraction produces correct values."""
         cs_path, _, _, dfu, dfv, dfang_rad, volt, cs_mm, amp_c, phase_rad, voxel_size, grid_size = _make_test_cs()


### PR DESCRIPTION
## Summary
- treat cryoSPARC `alignments3D/shift` as pixel units when parsing `.cs` poses
- normalize `.cs` fractional translations by the original image size from `blob/shape`, not the requested target `D`
- add round-trip/downsample regression tests to ensure `.cs -> .star` metadata stays physically consistent after downsampling

## What Changed
- [`recovar/data_io/metadata_readers.py`](recovar/data_io/metadata_readers.py)
  - `parse_poses_from_cs()` now keeps `alignments3D/shift` in pixels
  - `parse_poses_from_cs()` now uses `blob/shape[:, 0]` when available so downsampled runs preserve the same fractional translations
- [`tests/unit/test_metadata_readers.py`](tests/unit/test_metadata_readers.py)
  - add synthetic regression for preserving fractional translations when target `D` differs from original image size
- [`tests/unit/test_cs_parsing_realdata.py`](tests/unit/test_cs_parsing_realdata.py)
  - add real-data regression confirming translations are invariant when parsing the same `.cs` file at a smaller target `D`
- [`tests/unit/test_commands_downsample.py`](tests/unit/test_commands_downsample.py)
  - add `.star` and `.cs` round-trip tests across `D = 288, 192, 128, 96`
  - verify on reload that `voxel_size * image_size` stays constant and translations/CTF remain consistent

## Validation
Per request, validation here is scoped to the `.cs` / `.star` metadata path and does **not** include unrelated full-suite regression jobs.

### Environment / provenance
| Check | Result |
| --- | --- |
| `pixi install` | passed |
| `pixi run install-recovar` | passed |
| editable reinstall + CUDA rebuild | passed |
| `pixi run smoke-import-recovar` | passed |
| provenance gate (`recovar` from checkout, `jax` from pixi env) | passed |

### Scoped tests
| Command | Result |
| --- | --- |
| `pixi run pytest tests/unit/test_commands_downsample.py tests/unit/test_metadata_readers.py tests/unit/test_cs_parsing_realdata.py -v` | `50 passed` |

## Notes
- I inspected cryoDRGN's `parse_pose_csparc` implementation as a comparison point. It also divides by the requested `-D`, so I did **not** treat it as the oracle for this behavior. The tests in this PR instead enforce the physical invariant directly on recovar's metadata round-trip path.
