### PR TITLE
Make project mode the standard workflow

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,16 +12,31 @@ The wizard walks you through selecting your input files, mask, downsampling, and
 
 ## Manual quick start
 
-### From RELION
+### Recommended: project workflow
+
+```bash
+recovar init_project my_project
+cd my_project
+
+# RELION
+recovar pipeline particles.star --mask mask.mrc --project .
+
+# cryoSPARC
+recovar pipeline particles.cs --mask mask.mrc --datadir /path/to/cryosparc/project --project .
+
+# Analyze the latest completed Pipeline job
+recovar analyze --zdim=10 --project .
+```
+
+In project mode, RECOVAR keeps machine-stable numbered directories on disk (for example `Pipeline/job_0001/`) and stores readable job aliases in project metadata for the CLI and GUI.
+
+### Optional: standalone output directories
+
+If you prefer the older explicit-path style, it still works:
 
 ```bash
 recovar pipeline particles.star -o output --mask mask.mrc
-```
-
-### From cryoSPARC
-
-```bash
-recovar pipeline particles.cs -o output --mask mask.mrc --datadir /path/to/cryosparc/project
+recovar analyze output --zdim=10
 ```
 
 ### With downsampling
@@ -29,18 +44,11 @@ recovar pipeline particles.cs -o output --mask mask.mrc --datadir /path/to/cryos
 If your images are larger than ~256 pixels, downsample for faster processing:
 
 ```bash
-recovar pipeline particles.star -o output --mask mask.mrc --downsample 128
+recovar pipeline particles.star --mask mask.mrc --downsample 128 --project .
 ```
 
-This automatically pre-downsamples images to disk the first time and caches them for re-runs.
+This automatically pre-downsamples images into the shared project cache on the first run and reuses that cache across matching project runs.
 
-### Analyze the results
-
-```bash
-recovar analyze output --zdim=10
-```
-
-This runs k-means clustering, generates representative volumes, computes UMAP embeddings, and optionally creates trajectory movies.
 
 ### View volumes
 
@@ -54,7 +62,7 @@ output/analysis_10/kmeans/center001.mrc
 
 ## Project system
 
-For multi-step workflows, use the project system. It auto-numbers job directories (e.g. `Pipeline/job_0001/`, `Analyze/job_0001/`) and tracks job metadata (`job.json`, `command.txt`, `run.log`, `README.txt`).
+For multi-step workflows, use the project system. It is the standard RECOVAR workflow: numbered job directories stay stable on disk (e.g. `Pipeline/job_0001/`, `Analyze/job_0001/`), while the CLI and GUI show human-readable job names from project metadata.
 
 ```bash
 # Initialize a project directory
@@ -64,14 +72,14 @@ cd my_project
 # Run pipeline (auto-creates Pipeline/job_0001/)
 recovar pipeline particles.star --mask mask.mrc --project .
 
-# Analyze (auto-creates Analyze/job_0001/)
-recovar analyze Pipeline/job_0001 --zdim=10 --project .
+# Analyze the latest completed pipeline (auto-creates Analyze/job_0001/)
+recovar analyze --zdim=10 --project .
 
-# Check status of all jobs
+# Check status of all jobs and aliases
 recovar project_status
 ```
 
-All commands accept `--project <dir>` to enable project mode. If you run from within a project directory, it is auto-detected.
+All commands accept `--project <dir>` to enable project mode. If you run from within a project directory, it is auto-detected. Downstream commands can omit `result_dir`; RECOVAR then uses the latest completed Pipeline job in that project.
 
 ## Web GUI
 

--- a/docs/guide/downsampling.md
+++ b/docs/guide/downsampling.md
@@ -4,29 +4,34 @@ If your images are larger than 256x256 pixels, downsampling significantly speeds
 
 ## Automatic downsampling (recommended)
 
-Use `--downsample D` with the pipeline:
+Use `--downsample D` with the pipeline inside a project:
 
 ```bash
-recovar pipeline particles.star -o output --mask mask.mrc --downsample 128
+recovar init_project my_project
+cd my_project
+recovar pipeline particles.star --mask mask.mrc --downsample 128 --project .
 ```
 
 The pipeline automatically:
 
-1. Pre-downsamples all images to disk (stored in `output/downsampled/`)
-2. Runs the pipeline on the downsampled images
-3. On re-runs with the same output directory, reuses the cached downsampled images
+1. Pre-downsamples all images to disk in the shared project cache (`Cache/downsample/...`)
+2. Runs the pipeline on the downsampled images in the numbered Pipeline job directory
+3. Reuses the cached downsampled images across matching project runs, instead of tying the cache to one output directory
 
-This is the simplest approach — one command handles everything.
+This is the simplest and recommended approach — one command handles everything.
 
 ## Manual pre-downsampling
 
-For maximum control or to reuse across multiple pipeline runs:
+For maximum control or to materialize a reusable downsampled dataset explicitly:
 
 ```bash
-# Downsample to 128x128
+# Project-style downsample job
+recovar downsample particles.star -D 128 --project . --output-name particles_d128
+
+# Or an explicit standalone output directory
 recovar downsample particles.star -D 128 -o downsampled/
 
-# Run pipeline on downsampled data
+# Run pipeline on the materialized downsampled data
 recovar pipeline downsampled/particles.128.star -o output --mask mask.mrc
 ```
 
@@ -35,7 +40,7 @@ recovar pipeline downsampled/particles.128.star -o output --mask mask.mrc
 | Flag | Description |
 |------|-------------|
 | `-D`, `--target-D` | Target box size (must be even) |
-| `-o`, `--outdir` | Output directory |
+| `-o`, `--outdir` | Output directory (optional in project mode; shared project cache is still used when available) |
 | `--datadir` | Base directory for image paths |
 | `--strip-prefix` | Strip prefix from paths |
 | `--batch-size` | Images per batch (default: 1000) |

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -8,18 +8,22 @@ The RECOVAR pipeline takes particle images and a mask, then computes the mean re
 ## Basic usage
 
 ```bash
-# RELION star file
-recovar pipeline particles.star -o output --mask mask.mrc
+# Recommended: run inside a project
+recovar init_project my_project
+cd my_project
+recovar pipeline particles.star --mask mask.mrc --project .
 
 # cryoSPARC cs file
-recovar pipeline particles.cs -o output --mask mask.mrc --datadir /project/
+recovar pipeline particles.cs --mask mask.mrc --datadir /project/ --project .
 
 # With downsampling
-recovar pipeline particles.star -o output --mask mask.mrc --downsample 128
+recovar pipeline particles.star --mask mask.mrc --downsample 128 --project .
+
+# Standalone explicit output directory (still supported)
+recovar pipeline particles.star -o output --mask mask.mrc
 
 # Legacy pickle files
-recovar pipeline particles.128.mrcs -o output \
-    --poses poses.pkl --ctf ctf.pkl --mask mask.mrc
+recovar pipeline particles.128.mrcs -o output     --poses poses.pkl --ctf ctf.pkl --mask mask.mrc
 ```
 
 ## Required arguments
@@ -27,7 +31,7 @@ recovar pipeline particles.128.mrcs -o output \
 | Argument | Description |
 |----------|-------------|
 | `particles` | Input particles (`.star`, `.cs`, `.mrcs`, or `.txt`) |
-| `-o`, `--outdir` | Output directory |
+| `-o`, `--outdir` | Output directory (optional in project mode) |
 | `--mask` | Solvent mask (`.mrc`), or `from_halfmaps`, `sphere`, `none` |
 
 ## Common options
@@ -143,7 +147,7 @@ output/
   analysis_*/              # Results per zdim (after running analyze)
 ```
 
-When using the **project system** (`--project`), pipeline output is placed into auto-numbered directories like `Pipeline/job_0001/`.
+When using the **project system** (`--project`), pipeline output is placed into auto-numbered directories like `Pipeline/job_0001/`. The numbered directories stay stable on disk, while RECOVAR records human-readable job names in project metadata for the CLI and GUI.
 
 ## Example output
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,6 +2,8 @@
 
 All RECOVAR commands follow the pattern `recovar <command> [arguments]`.
 
+Project mode is the standard workflow: pass `--project <dir>` (or run from inside a project), let RECOVAR place outputs in stable numbered directories such as `Pipeline/job_0001/`, and use project metadata for readable names in the CLI and GUI. Standalone explicit paths remain supported.
+
 ## Main workflow
 
 | Command | Description |
@@ -74,7 +76,8 @@ recovar <command> -h
 Run the full heterogeneity analysis pipeline.
 
 ```bash
-recovar pipeline particles.star -o output --mask mask.mrc [options]
+recovar pipeline particles.star --mask mask.mrc --project .
+# or: recovar pipeline particles.star -o output --mask mask.mrc [options]
 ```
 
 See [Running the Pipeline](../guide/pipeline.md) for full documentation.
@@ -86,7 +89,8 @@ See [Running the Pipeline](../guide/pipeline.md) for full documentation.
 Post-pipeline analysis: k-means clustering, volume generation, UMAP, trajectories.
 
 ```bash
-recovar analyze result_dir --zdim=10 [options]
+recovar analyze --zdim=10 --project .
+# or: recovar analyze result_dir --zdim=10 [options]
 ```
 
 | Flag | Default | Description |
@@ -117,13 +121,14 @@ recovar analyze result_dir --zdim=10 [options]
 Pre-downsample particle images to disk via Fourier cropping.
 
 ```bash
-recovar downsample particles.star -D 128 -o downsampled/ [options]
+recovar downsample particles.star -D 128 --project . --output-name particles_d128
+# or: recovar downsample particles.star -D 128 -o downsampled/ [options]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-D`, `--target-D` | Required | Target box size (even integer) |
-| `-o`, `--outdir` | Required | Output directory |
+| `-o`, `--outdir` | Auto in project mode | Output directory |
 | `--datadir` | None | Base directory for image paths |
 | `--strip-prefix` | None | Strip prefix from paths |
 | `--batch-size` | 1000 | Images per batch |
@@ -320,7 +325,7 @@ recovar project_status [directory] [--tree]
 
 ## Common flag: `--project`
 
-All commands that produce output accept `--project <dir>` to enable project mode. When active, output directories are auto-generated. If you run from within a project directory (containing `project.json`), it is auto-detected without needing the flag.
+All commands that produce output accept `--project <dir>` to enable project mode. This is the recommended way to run RECOVAR. When active, output directories are auto-generated, downstream commands may omit `result_dir` to use the latest completed Pipeline job, and RECOVAR stores human-readable job names alongside the numbered directories. If you run from within a project directory (containing `project.json`), it is auto-detected without needing the flag.
 
 Each job creates `job.json`, `command.txt`, `run.log`, and `README.txt` metadata files.
 
@@ -328,7 +333,7 @@ Each job creates `job.json`, `command.txt`, `run.log`, and `README.txt` metadata
 
 | CLI command | Directory name | Example |
 |-------------|----------------|---------|
-| `pipeline` | `Pipeline/` | `Pipeline/job_0001/` |
+| `pipeline` | `Pipeline/` | `Pipeline/job_0001/` (alias shown separately in CLI/GUI) |
 | `analyze` | `Analyze/` | `Analyze/job_0001/` |
 | `compute_state` | `ReconstructState/` | `ReconstructState/job_0001/` |
 | `compute_trajectory` | `ReconstructTrajectory/` | `ReconstructTrajectory/job_0001/` |

--- a/recovar/commands/downsample.py
+++ b/recovar/commands/downsample.py
@@ -15,14 +15,20 @@ can then be passed directly to ``recovar pipeline``.
 """
 
 import argparse
+import fcntl
+import hashlib
+import json
 import logging
 import os
 import sys
 import time
+from contextlib import contextmanager
 from typing import Optional, Tuple
 
 import mrcfile
 import numpy as np
+
+from recovar.project.project import normalize_job_alias
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +36,80 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def _downsample_cache_fingerprint(
+    particles_file: str,
+    target_D: int,
+    datadir: str = "",
+    strip_prefix: Optional[str] = None,
+) -> str:
+    """Fingerprint the effective downsample input for project cache reuse."""
+    payload = {
+        "particles_file": os.path.abspath(particles_file),
+        "target_D": int(target_D),
+        "datadir": os.path.abspath(datadir) if datadir else "",
+        "strip_prefix": strip_prefix or "",
+    }
+    try:
+        stat = os.stat(particles_file)
+        payload["particles_mtime_ns"] = stat.st_mtime_ns
+        payload["particles_size"] = stat.st_size
+    except OSError:
+        payload["particles_mtime_ns"] = None
+        payload["particles_size"] = None
+    digest = hashlib.sha1(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[:10]
+    return digest
+
+
+def build_project_downsample_cache_dir(
+    project_root: str,
+    particles_file: str,
+    target_D: int,
+    datadir: str = "",
+    strip_prefix: Optional[str] = None,
+) -> str:
+    """Return the shared project cache directory for a downsampled dataset."""
+    stem = normalize_job_alias(os.path.splitext(os.path.basename(particles_file))[0])
+    digest = _downsample_cache_fingerprint(particles_file, target_D, datadir=datadir, strip_prefix=strip_prefix)
+    return os.path.join(os.path.abspath(project_root), "Cache", "downsample", f"{stem}_d{int(target_D)}_{digest}")
+
+
+@contextmanager
+def downsample_cache_lock(ds_dir: str):
+    """Serialize writes to a shared downsample cache directory."""
+    os.makedirs(ds_dir, exist_ok=True)
+    lock_path = os.path.join(ds_dir, ".lock")
+    with open(lock_path, "w") as fd:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def write_downsample_cache_metadata(
+    ds_dir: str,
+    particles_file: str,
+    target_D: int,
+    datadir: str = "",
+    strip_prefix: Optional[str] = None,
+) -> None:
+    """Write a small manifest alongside project-cached downsample outputs."""
+    payload = {
+        "particles_file": os.path.abspath(particles_file),
+        "target_D": int(target_D),
+        "datadir": os.path.abspath(datadir) if datadir else "",
+        "strip_prefix": strip_prefix or "",
+        "fingerprint": _downsample_cache_fingerprint(
+            particles_file,
+            target_D,
+            datadir=datadir,
+            strip_prefix=strip_prefix,
+        ),
+    }
+    with open(os.path.join(ds_dir, "cache.json"), "w") as f:
+        json.dump(payload, f, indent=2)
 
 
 def downsample_to_disk(
@@ -190,7 +270,12 @@ def main():
     parser = argparse.ArgumentParser(description="Downsample particle images via Fourier cropping and save to disk.")
     parser.add_argument("particles", help="Input particles (.mrcs, .star, .cs, or .txt)")
     parser.add_argument("-D", "--target-D", type=int, required=True, help="Target box size in pixels (must be even)")
-    parser.add_argument("-o", "--outdir", required=True, help="Output directory")
+    parser.add_argument(
+        "-o",
+        "--outdir",
+        required=False,
+        help="Output directory. Required unless --project is used.",
+    )
     parser.add_argument("--datadir", default=None, help="Path prefix for resolving relative image paths")
     parser.add_argument("--strip-prefix", default=None, help="Prefix to strip from paths in star file")
     parser.add_argument("--batch-size", type=int, default=1000, help="Number of images per batch (default: 1000)")
@@ -208,9 +293,10 @@ def main():
         default=None,
         help="Split output into chunks of this many images (default: single file)",
     )
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
 
     args = parser.parse_args()
 

--- a/recovar/commands/estimate_conformational_density.py
+++ b/recovar/commands/estimate_conformational_density.py
@@ -24,9 +24,10 @@ def parse_args():
         default=None,
         help="Directory to save the density estimation results. Default = recovar_result_dir/density/",
     )
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
     parser.add_argument(
         "--pca_dim",
         type=int,

--- a/recovar/commands/estimate_stable_states.py
+++ b/recovar/commands/estimate_stable_states.py
@@ -45,9 +45,10 @@ def parse_args():
         default=3,
         help="Number of local maxima to find. If <1, will use whatever HDBSCAN finds.",
     )
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
     return parser.parse_args()
 
 

--- a/recovar/commands/extract_image_subset.py
+++ b/recovar/commands/extract_image_subset.py
@@ -88,9 +88,10 @@ def main():
         type=list_of_ints,
         help="Coordinate in pixel of the feature for which you want images. E.g. 20,30,50",
     )
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
 
     args = parser.parse_args()
     if args.subvol_idx is None and args.mask is None and args.coordinate is None:

--- a/recovar/commands/extract_image_subset_from_kmeans.py
+++ b/recovar/commands/extract_image_subset_from_kmeans.py
@@ -57,9 +57,10 @@ def main():
         action="store_true",
         help="If provided, keep the images that correspond to kmeans centers that are not in list of kmeans indices",
     )
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
 
     args = parser.parse_args()
     # job_context checks for args.output; this parser uses output_path

--- a/recovar/commands/junk_particle_detection.py
+++ b/recovar/commands/junk_particle_detection.py
@@ -2730,9 +2730,10 @@ def add_args(parser):
         help="Save all detailed diagnostic plots and data files (default: only summary plot and essential indices)",
     )
 
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
 
     return parser
 

--- a/recovar/commands/outlier_detection.py
+++ b/recovar/commands/outlier_detection.py
@@ -1552,9 +1552,10 @@ def add_args(parser):
         help="Save all detailed diagnostic plots and per-method data files (default: only combined results and summary)",
     )
 
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
 
     return parser
 

--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -37,9 +37,10 @@ def add_args(parser: argparse.ArgumentParser):
         type=os.path.abspath,
         help="Output directory to save model. Required unless --project is used.",
     )
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
     parser.add_argument(
         "--mask",
         metavar="mrc",
@@ -763,29 +764,54 @@ def standard_recovar_pipeline(args):
 
     # --- Auto pre-downsample to disk if requested ---
     if getattr(args, "downsample", None) is not None:
-        from recovar.commands.downsample import downsample_to_disk
+        from recovar.commands.downsample import (
+            build_project_downsample_cache_dir,
+            downsample_cache_lock,
+            downsample_to_disk,
+            write_downsample_cache_metadata,
+        )
 
         # Save original values for metadata before swapping
         args._original_particles = args.particles
         args._downsample_applied = args.downsample
 
-        ds_dir = os.path.join(args.outdir, "downsampled")
-        ds_mrcs = os.path.join(ds_dir, f"particles.{args.downsample}.mrcs")
-
-        if os.path.exists(ds_mrcs):
-            logger.info("Using cached downsampled images: %s", ds_mrcs)
-        else:
-            logger.info("Pre-downsampling images to D=%d ...", args.downsample)
-            downsample_to_disk(
+        project_root = getattr(args, "_project_root", None)
+        if project_root:
+            ds_dir = build_project_downsample_cache_dir(
+                project_root=project_root,
                 particles_file=args.particles,
                 target_D=args.downsample,
-                outdir=ds_dir,
                 datadir=getattr(args, "datadir", None) or "",
                 strip_prefix=getattr(args, "strip_prefix", None),
-                gpu_memory_gb=args.gpu_memory,
             )
+            logger.info("Using project downsample cache directory: %s", ds_dir)
+        else:
+            ds_dir = os.path.join(args.outdir, "downsampled")
 
+        ds_mrcs = os.path.join(ds_dir, f"particles.{args.downsample}.mrcs")
         ds_star = os.path.join(ds_dir, f"particles.{args.downsample}.star")
+
+        with downsample_cache_lock(ds_dir):
+            if os.path.exists(ds_mrcs) and os.path.exists(ds_star):
+                logger.info("Using cached downsampled images: %s", ds_mrcs)
+            else:
+                logger.info("Pre-downsampling images to D=%d ...", args.downsample)
+                downsample_to_disk(
+                    particles_file=args.particles,
+                    target_D=args.downsample,
+                    outdir=ds_dir,
+                    datadir=getattr(args, "datadir", None) or "",
+                    strip_prefix=getattr(args, "strip_prefix", None),
+                    gpu_memory_gb=args.gpu_memory,
+                )
+                if project_root:
+                    write_downsample_cache_metadata(
+                        ds_dir=ds_dir,
+                        particles_file=args._original_particles,
+                        target_D=args._downsample_applied,
+                        datadir=getattr(args, "datadir", None) or "",
+                        strip_prefix=getattr(args, "strip_prefix", None),
+                    )
 
         # Swap to downsampled data (STAR has full metadata for both CS and STAR input)
         args.particles = ds_star

--- a/recovar/commands/postprocess.py
+++ b/recovar/commands/postprocess.py
@@ -110,9 +110,10 @@ def add_args(parser: argparse.ArgumentParser):
         help="Use v2 algorithm for local resolution calculation (faster but may be less accurate)",
     )
 
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
 
     return parser
 

--- a/recovar/commands/reconstruct_from_external_embedding.py
+++ b/recovar/commands/reconstruct_from_external_embedding.py
@@ -173,9 +173,10 @@ def add_args(parser: argparse.ArgumentParser):
         help="Whether CTF is premultiplied in the data",
     )
 
-    from recovar.utils.parser_args import add_project_arg
+    from recovar.utils.parser_args import add_output_name_arg, add_project_arg
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
 
     return parser
 

--- a/recovar/project/job_context.py
+++ b/recovar/project/job_context.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from recovar.output.job import JobDir
-from recovar.project.project import RecovarProject, find_project_root
+from recovar.project.project import RecovarProject, default_job_alias, find_project_root
 from recovar.project.registry import get_job_type
 
 logger = logging.getLogger(__name__)
@@ -124,10 +124,12 @@ def job_context(args, command_name: str):
         # Explicit output dir (standalone or project override)
         ctx.output_dir = os.path.abspath(outdir)
         if project is not None:
-            # Still register in project even with explicit -o
-            uid, _ = project.allocate_job(command_name)
-            ctx.uid = uid
-            # But use the user's explicit path
+            # Reuse a preallocated project job dir when one is provided (GUI path),
+            # otherwise allocate a bookkeeping uid for this run.
+            ctx.uid = project.infer_uid_from_job_dir(ctx.output_dir, expected_command=command_name)
+            if ctx.uid is None:
+                uid, _ = project.allocate_job(command_name)
+                ctx.uid = uid
     elif result_dir is not None:
         # No project, no explicit outdir — auto-generate inside result_dir
         ctx.output_dir = os.path.join(os.path.abspath(result_dir), jt.dir_name if jt else command_name)
@@ -139,11 +141,16 @@ def job_context(args, command_name: str):
         )
 
     # --- Resolve pipeline directory ---
-    if jt and jt.needs_pipeline and result_dir is not None:
+    if jt and jt.needs_pipeline:
         if project is not None:
             ctx.pipeline_dir = project.resolve_pipeline(result_dir)
-        else:
+        elif result_dir is not None:
             ctx.pipeline_dir = os.path.abspath(result_dir)
+        else:
+            raise ValueError(
+                "No pipeline result directory specified. Pass result_dir explicitly, "
+                "or use --project from within a project with a completed Pipeline job."
+            )
     elif result_dir is not None:
         ctx.pipeline_dir = os.path.abspath(result_dir)
 
@@ -154,6 +161,10 @@ def job_context(args, command_name: str):
             ctx.parent_jobs = [parent_uid]
 
     # --- Create JobDir and start ---
+    setattr(args, "_project_root", project.root if project is not None else None)
+    setattr(args, "_project_uid", ctx.uid)
+    setattr(args, "_resolved_pipeline_dir", ctx.pipeline_dir)
+
     job = JobDir(ctx.output_dir, command_name)
     ctx.job = job
     job._parent_result_dir = ctx.pipeline_dir
@@ -168,6 +179,7 @@ def job_context(args, command_name: str):
             command_name,
             command_line="python " + " ".join(sys.argv),
             parent_jobs=ctx.parent_jobs,
+            alias=default_job_alias(command_name, vars(args)),
         )
 
     try:

--- a/recovar/project/project.py
+++ b/recovar/project/project.py
@@ -13,8 +13,9 @@ import fcntl
 import json
 import logging
 import os
+import re
 from contextlib import contextmanager
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from recovar.project.registry import JOB_TYPES, get_job_type
 
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 PROJECT_FILE = "project.json"
 LOCK_FILE = ".project.lock"
 PROJECT_VERSION = "1.0"
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
 
 
 def _get_recovar_version():
@@ -48,6 +50,147 @@ def find_project_root(start_dir: Optional[str] = None) -> Optional[str]:
             break
         d = parent
     return None
+
+
+def normalize_job_alias(value: str) -> str:
+    """Normalize a user- or system-provided job label for CLI/UI use."""
+    text = _NON_ALNUM_RE.sub("_", str(value).strip().lower())
+    text = re.sub(r"_+", "_", text).strip("_")
+    return text or "job"
+
+
+def uniquify_job_alias(alias: str, existing: set[str]) -> str:
+    """Return *alias* or a numbered variant that is unique within *existing*."""
+    if alias not in existing:
+        return alias
+
+    suffix = 2
+    while True:
+        candidate = f"{alias}_{suffix}"
+        if candidate not in existing:
+            return candidate
+        suffix += 1
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value in (None, "", False):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _basename_stem(path: Any) -> str | None:
+    if not path:
+        return None
+    stem = os.path.splitext(os.path.basename(str(path)))[0]
+    alias = normalize_job_alias(stem)
+    return alias if alias != "job" else None
+
+
+def default_job_alias(command_name: str, params: Mapping[str, Any] | None = None) -> str:
+    """Generate a readable default alias for a recovar job."""
+    params = params or {}
+    explicit = params.get("output_name")
+    if explicit:
+        return normalize_job_alias(str(explicit))
+
+    command = str(command_name).strip().lower()
+
+    if command == "pipeline":
+        particle_stem = _basename_stem(params.get("particles"))
+        downsample = _coerce_int(params.get("downsample"))
+        if particle_stem and downsample:
+            return f"{particle_stem}_d{downsample}"
+        if particle_stem:
+            return particle_stem
+        return "pipeline"
+
+    if command == "analyze":
+        zdim = _coerce_int(params.get("zdim"))
+        return f"embedding_k{zdim}" if zdim else "embedding"
+
+    if command == "compute_state":
+        zdim = _coerce_int(params.get("zdim"))
+        return f"compute_state_k{zdim}" if zdim else "compute_state"
+
+    if command == "compute_trajectory":
+        zdim = _coerce_int(params.get("zdim"))
+        return f"trajectory_k{zdim}" if zdim else "trajectory"
+
+    if command == "estimate_conformational_density":
+        zdim = _coerce_int(params.get("z_dim_used")) or _coerce_int(params.get("pca_dim"))
+        return f"density_k{zdim}" if zdim else "density"
+
+    if command == "estimate_stable_states":
+        return "stable_states"
+
+    if command == "junk_particle_detection":
+        zdim = _coerce_int(params.get("zdim"))
+        return f"junk_detection_k{zdim}" if zdim else "junk_detection"
+
+    if command == "outlier_detection":
+        return "outlier_detection"
+
+    if command == "postprocess":
+        input_stem = _basename_stem(params.get("input"))
+        return f"postprocess_{input_stem}" if input_stem else "postprocess"
+
+    if command == "downsample":
+        target_d = _coerce_int(params.get("target_D"))
+        particle_stem = _basename_stem(params.get("particles"))
+        if particle_stem and target_d:
+            return f"{particle_stem}_d{target_d}"
+        if target_d:
+            return f"downsample_d{target_d}"
+        return "downsample"
+
+    if command == "pipeline_with_outliers":
+        return "pipeline_with_outliers"
+
+    if command == "reconstruct_from_external_embedding":
+        return "external_reconstruction"
+
+    return normalize_job_alias(command.replace("-", "_"))
+
+
+def infer_job_display_name(
+    type_name: str,
+    params: Mapping[str, Any] | None = None,
+    output_dir: str | None = None,
+    alias: str | None = None,
+) -> str:
+    """Return the best available human-readable label for a job."""
+    if alias:
+        return alias
+
+    type_to_command = {
+        "Pipeline": "pipeline",
+        "Analyze": "analyze",
+        "ComputeState": "compute_state",
+        "ReconstructState": "compute_state",
+        "ComputeTrajectory": "compute_trajectory",
+        "ReconstructTrajectory": "compute_trajectory",
+        "Density": "estimate_conformational_density",
+        "StableStates": "estimate_stable_states",
+        "JunkDetection": "junk_particle_detection",
+        "OutlierDetection": "outlier_detection",
+        "Postprocess": "postprocess",
+        "Downsample": "downsample",
+        "PipelineWithOutliers": "pipeline_with_outliers",
+        "ReconstructExternal": "reconstruct_from_external_embedding",
+    }
+    command_name = type_to_command.get(type_name, type_name)
+    display = default_job_alias(command_name, params)
+    if display and display != "job":
+        return display
+
+    if output_dir:
+        tail = os.path.basename(os.path.normpath(output_dir))
+        if tail:
+            return tail
+    return normalize_job_alias(type_name)
 
 
 class RecovarProject:
@@ -94,6 +237,7 @@ class RecovarProject:
             "recovar_version": _get_recovar_version(),
             "counters": {},
             "jobs": [],
+            "aliases": {},
         }
         with open(proj_file, "w") as f:
             json.dump(data, f, indent=2)
@@ -131,6 +275,7 @@ class RecovarProject:
                 "recovar_version": _get_recovar_version(),
                 "counters": {},
                 "jobs": [],
+                "aliases": {},
             }
         with open(self._project_file) as f:
             return json.load(f)
@@ -174,7 +319,13 @@ class RecovarProject:
     # ------------------------------------------------------------------
 
     def register_job_start(
-        self, uid: str, command_name: str, command_line: str = "", parent_jobs: Optional[list] = None
+        self,
+        uid: str,
+        command_name: str,
+        command_line: str = "",
+        parent_jobs: Optional[list] = None,
+        alias: Optional[str] = None,
+        description: str = "",
     ):
         """Add a job entry to project.json with status=running."""
         entry = {
@@ -185,15 +336,24 @@ class RecovarProject:
             "completed": None,
             "parent_jobs": parent_jobs or [],
             "alias": None,
-            "description": "",
+            "description": description,
         }
         with self._lock():
             data = self._read()
-            jobs = data.setdefault("jobs", [])
-            # Remove any existing entry for this uid (e.g. from a crashed restart)
-            jobs = [j for j in jobs if j.get("uid") != uid]
+            jobs = [j for j in data.setdefault("jobs", []) if j.get("uid") != uid]
+            aliases = {
+                name: target
+                for name, target in data.setdefault("aliases", {}).items()
+                if target != uid
+            }
+            existing_aliases = {j.get("alias") for j in jobs if j.get("alias")}
+            if alias:
+                alias = uniquify_job_alias(normalize_job_alias(alias), existing_aliases)
+                entry["alias"] = alias
+                aliases[alias] = uid
             jobs.append(entry)
             data["jobs"] = jobs
+            data["aliases"] = aliases
             self._write(data)
 
     def register_job_complete(self, uid: str, status: str = "completed"):
@@ -237,6 +397,30 @@ class RecovarProject:
         """Return the absolute path for a job uid."""
         return os.path.join(self.root, uid)
 
+    def get_job_alias_map(self) -> dict[str, str]:
+        """Return a mapping of job uid -> alias for jobs that define one."""
+        with self._lock():
+            data = self._read()
+        return {job["uid"]: job["alias"] for job in data.get("jobs", []) if job.get("alias")}
+
+    def infer_uid_from_job_dir(self, job_dir: str, expected_command: Optional[str] = None) -> Optional[str]:
+        """Infer a project job uid from an on-disk job directory path."""
+        abs_job_dir = os.path.abspath(job_dir)
+        try:
+            rel = os.path.relpath(abs_job_dir, self.root)
+        except ValueError:
+            return None
+        if rel.startswith(".."):
+            return None
+        parts = rel.split(os.sep)
+        if len(parts) < 2 or not parts[1].startswith("job_"):
+            return None
+        if expected_command is not None:
+            jt = get_job_type(expected_command)
+            if jt is not None and parts[0] != jt.dir_name:
+                return None
+        return f"{parts[0]}/{parts[1]}"
+
     def resolve_pipeline(self, result_dir_arg: Optional[str] = None) -> str:
         """Resolve a pipeline directory from a CLI argument.
 
@@ -257,6 +441,18 @@ class RecovarProject:
             candidate2 = os.path.join(self.root, "Pipeline", result_dir_arg)
             if os.path.isdir(candidate2):
                 return candidate2
+
+            # Project alias (e.g. "ribosome_d128")
+            with self._lock():
+                aliases = self._read().get("aliases", {})
+            alias_target = aliases.get(result_dir_arg)
+            if alias_target is None and os.sep not in result_dir_arg:
+                alias_target = aliases.get(normalize_job_alias(result_dir_arg))
+            if alias_target:
+                candidate3 = self.get_job_dir(alias_target)
+                if os.path.isdir(candidate3):
+                    return candidate3
+
             # Fall back to treating as absolute
             return os.path.abspath(result_dir_arg)
 

--- a/recovar/utils/parser_args.py
+++ b/recovar/utils/parser_args.py
@@ -10,7 +10,18 @@ def add_project_arg(parser: argparse.ArgumentParser):
         help="Path to a recovar project directory (containing project.json). "
         "If omitted, auto-detects by walking up from the current directory. "
         "When a project is active, output directories are auto-generated "
-        "(e.g. ComputeState/job_0001/).",
+        "(e.g. ComputeState/job_0001/), and downstream commands default to the latest completed Pipeline job when result_dir is omitted.",
+    )
+    return parser
+
+
+def add_output_name_arg(parser: argparse.ArgumentParser):
+    """Add a human-readable project job label without changing the job dir name."""
+    parser.add_argument(
+        "--output-name",
+        default=None,
+        help="Human-readable job label stored in project metadata and shown in the GUI. "
+        "Does not change the on-disk job directory name.",
     )
     return parser
 
@@ -19,8 +30,11 @@ def standard_downstream_args(parser: argparse.ArgumentParser, analyze=False):
 
     parser.add_argument(
         "result_dir",
+        nargs="?",
+        default=None,
         type=os.path.abspath,
-        help="Pipeline job directory (e.g. Pipeline/job_0001 or an absolute path).",
+        help="Pipeline job directory (e.g. Pipeline/job_0001 or an absolute path). "
+        "When omitted in project mode, the latest completed Pipeline job is used.",
     )
 
     parser.add_argument(
@@ -32,6 +46,7 @@ def standard_downstream_args(parser: argparse.ArgumentParser, analyze=False):
     )
 
     add_project_arg(parser)
+    add_output_name_arg(parser)
 
     parser.add_argument(
         "--Bfactor",

--- a/tests/unit/test_commands_downsample.py
+++ b/tests/unit/test_commands_downsample.py
@@ -60,6 +60,42 @@ def test_get_pixel_size_returns_none_for_mrc_with_zero_voxel_size(tmp_path):
     assert ds_cmd._get_pixel_size(str(mrc_path)) is None
 
 
+def test_build_project_downsample_cache_dir_is_stable(tmp_path):
+    cache_dir = ds_cmd.build_project_downsample_cache_dir(
+        project_root=str(tmp_path / "project"),
+        particles_file=str(tmp_path / "Particles" / "ribosome.star"),
+        target_D=128,
+        datadir=str(tmp_path / "data"),
+        strip_prefix="Extract/job001",
+    )
+    assert cache_dir.endswith("Cache/downsample/ribosome_d128_" + cache_dir.split("_")[-1])
+    cache_dir_2 = ds_cmd.build_project_downsample_cache_dir(
+        project_root=str(tmp_path / "project"),
+        particles_file=str(tmp_path / "Particles" / "ribosome.star"),
+        target_D=128,
+        datadir=str(tmp_path / "data"),
+        strip_prefix="Extract/job001",
+    )
+    assert cache_dir == cache_dir_2
+
+
+def test_write_downsample_cache_metadata_creates_manifest(tmp_path):
+    ds_dir = tmp_path / "Cache" / "downsample" / "ribosome_d128"
+    ds_dir.mkdir(parents=True)
+    ds_cmd.write_downsample_cache_metadata(
+        ds_dir=str(ds_dir),
+        particles_file=str(tmp_path / "particles.star"),
+        target_D=128,
+        datadir=str(tmp_path / "data"),
+        strip_prefix="Extract/job001",
+    )
+    manifest = ds_dir / "cache.json"
+    assert manifest.exists()
+    payload = __import__("json").loads(manifest.read_text())
+    assert payload["target_D"] == 128
+    assert payload["strip_prefix"] == "Extract/job001"
+
+
 # ---------------------------------------------------------------------------
 # downsample_to_disk – input validation
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_commands_pipeline.py
+++ b/tests/unit/test_commands_pipeline.py
@@ -48,6 +48,11 @@ def test_pipeline_registers_zdim():
     assert "--zdim" in actions
 
 
+def test_pipeline_registers_output_name():
+    actions = _parser_with_pipeline_args()._option_string_actions
+    assert "--output-name" in actions
+
+
 def test_pipeline_zdim_default_is_list():
     """Default zdim must be a list (multiple resolutions are trained)."""
     parser = _parser_with_pipeline_args()
@@ -197,16 +202,29 @@ def test_standard_pipeline_passes_gpu_limit_to_predownsample(monkeypatch, tmp_pa
     captured = {}
 
     monkeypatch.setattr(pipeline_cmd, "_resolve_downsample", lambda _args: None)
+    monkeypatch.setattr(pipeline_cmd.utils, "jax_has_gpu", lambda: True)
     monkeypatch.setattr(
         pipeline_cmd.utils,
         "set_gpu_memory_limit",
         lambda value: captured.setdefault("limits", []).append(value),
     )
     monkeypatch.setattr(pipeline_cmd.os.path, "exists", lambda _path: False)
+    class _NoopLock:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
     monkeypatch.setitem(
         sys.modules,
         "recovar.commands.downsample",
-        SimpleNamespace(downsample_to_disk=lambda **kwargs: captured.setdefault("downsample_kwargs", kwargs)),
+        SimpleNamespace(
+            build_project_downsample_cache_dir=lambda **kwargs: str(tmp_path / "Cache" / "downsample" / "particles_d128"),
+            downsample_cache_lock=lambda _path: _NoopLock(),
+            downsample_to_disk=lambda **kwargs: captured.setdefault("downsample_kwargs", kwargs),
+            write_downsample_cache_metadata=lambda **kwargs: captured.setdefault("cache_metadata", kwargs),
+        ),
     )
     monkeypatch.setattr(
         pipeline_cmd.halfsets,
@@ -240,3 +258,70 @@ def test_standard_pipeline_passes_gpu_limit_to_predownsample(monkeypatch, tmp_pa
 
     assert captured["limits"] == [12.0]
     assert captured["downsample_kwargs"]["gpu_memory_gb"] == 12.0
+
+
+
+def test_standard_pipeline_uses_project_downsample_cache(monkeypatch, tmp_path):
+    captured = {}
+
+    monkeypatch.setattr(pipeline_cmd, "_resolve_downsample", lambda _args: None)
+    monkeypatch.setattr(pipeline_cmd.utils, "jax_has_gpu", lambda: True)
+    monkeypatch.setattr(pipeline_cmd.utils, "set_gpu_memory_limit", lambda value: None)
+
+    cache_dir = tmp_path / "project" / "Cache" / "downsample" / "particles_d128"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "particles.128.mrcs").touch()
+    (cache_dir / "particles.128.star").touch()
+
+    class _NoopLock:
+        def __enter__(self):
+            captured["locked"] = True
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setitem(
+        sys.modules,
+        "recovar.commands.downsample",
+        SimpleNamespace(
+            build_project_downsample_cache_dir=lambda **kwargs: captured.setdefault("cache_dir", str(cache_dir)),
+            downsample_cache_lock=lambda _path: _NoopLock(),
+            downsample_to_disk=lambda **kwargs: (_ for _ in ()).throw(AssertionError("should reuse cached downsample outputs")),
+            write_downsample_cache_metadata=lambda **kwargs: captured.setdefault("cache_metadata", kwargs),
+        ),
+    )
+    monkeypatch.setattr(
+        pipeline_cmd.halfsets,
+        "resolve_halfset_indices",
+        lambda _args: (_ for _ in ()).throw(RuntimeError("stop-after-cache-hit")),
+    )
+
+    args = SimpleNamespace(
+        outdir=str(tmp_path / "project" / "Pipeline" / "job_0001"),
+        particles="particles.star",
+        poses="poses.pkl",
+        ctf="ctf.pkl",
+        mask="mask.mrc",
+        datadir=None,
+        strip_prefix=None,
+        downsample=128,
+        accept_cpu=False,
+        tilt_series=False,
+        tilt_series_ctf=None,
+        dose_per_tilt=None,
+        angle_per_tilt=None,
+        do_over_with_contrast=False,
+        correct_contrast=False,
+        lazy=True,
+        gpu_memory=12.0,
+        noise_model="radial",
+        _project_root=str(tmp_path / "project"),
+    )
+
+    with pytest.raises(RuntimeError, match="stop-after-cache-hit"):
+        pipeline_cmd.standard_recovar_pipeline(args)
+
+    assert captured["locked"] is True
+    assert args.particles.endswith("particles.128.star")
+    assert args.downsample is None

--- a/tests/unit/test_parser_args.py
+++ b/tests/unit/test_parser_args.py
@@ -43,3 +43,12 @@ def test_standard_downstream_args_defaults_and_flags():
     assert parsed.no_z_regularization is True
     assert parsed.lazy is True
     assert parsed.apply_global_filtering is True
+
+
+
+def test_standard_downstream_args_project_mode_defaults():
+    parser = parser_args.standard_downstream_args(argparse.ArgumentParser(), analyze=True)
+    parsed = parser.parse_args(["--project", "/tmp/project", "--output-name", "embedding_k10"])
+    assert parsed.result_dir is None
+    assert parsed.project == "/tmp/project"
+    assert parsed.output_name == "embedding_k10"

--- a/tests/unit/test_parser_args.py
+++ b/tests/unit/test_parser_args.py
@@ -2,6 +2,7 @@ import argparse
 
 import pytest
 
+from recovar.commands import estimate_conformational_density, estimate_stable_states, postprocess
 from recovar.utils import parser_args
 
 pytestmark = pytest.mark.unit
@@ -52,3 +53,60 @@ def test_standard_downstream_args_project_mode_defaults():
     assert parsed.result_dir is None
     assert parsed.project == "/tmp/project"
     assert parsed.output_name == "embedding_k10"
+
+@pytest.mark.parametrize(
+    ("module", "argv", "expected"),
+    [
+        (
+            estimate_conformational_density,
+            [
+                "estimate_conformational_density",
+                "/tmp/pipeline",
+                "--project",
+                "/tmp/project",
+                "--output-name",
+                "density_custom",
+            ],
+            "density_custom",
+        ),
+        (
+            estimate_stable_states,
+            [
+                "estimate_stable_states",
+                "/tmp/density.pkl",
+                "-o",
+                "/tmp/stable",
+                "--project",
+                "/tmp/project",
+                "--output-name",
+                "stable_states_custom",
+            ],
+            "stable_states_custom",
+        ),
+    ],
+)
+def test_custom_project_parsers_accept_output_name(monkeypatch, module, argv, expected):
+    monkeypatch.setattr("sys.argv", argv)
+    parsed = module.parse_args()
+    assert parsed.project == "/tmp/project"
+    assert parsed.output_name == expected
+
+
+def test_postprocess_parser_accepts_output_name():
+    parser = postprocess.add_args(argparse.ArgumentParser())
+    parsed = parser.parse_args(
+        [
+            "/tmp/half1.mrc",
+            "--halfmap2",
+            "/tmp/half2.mrc",
+            "--output",
+            "/tmp/postprocess",
+            "--project",
+            "/tmp/project",
+            "--output-name",
+            "postprocess_custom",
+        ]
+    )
+    assert parsed.project == "/tmp/project"
+    assert parsed.output_name == "postprocess_custom"
+

--- a/tests/unit/test_pipeline_with_outliers.py
+++ b/tests/unit/test_pipeline_with_outliers.py
@@ -205,3 +205,84 @@ def test_pipeline_with_outliers_uses_original_particle_ids_between_rounds(tmp_pa
         np.testing.assert_array_equal(pickle.load(f), combined_particles_round_1)
     with open(tmp_path / "pipeline" / "round_2" / "particle_inliers_round_1.pkl", "rb") as f:
         np.testing.assert_array_equal(pickle.load(f), combined_particles_round_1)
+
+
+def test_pipeline_with_outliers_preserves_initial_subset_index_space_between_rounds(tmp_path, monkeypatch):
+    args = _make_args(tmp_path, tilt_series=True)
+    initial_images = np.array([100, 110, 120, 130], dtype=np.int32)
+    initial_particles = np.array([7, 11, 13], dtype=np.int32)
+    initial_ind = tmp_path / "initial_ind.pkl"
+    initial_tilt_ind = tmp_path / "initial_particle_ind.pkl"
+    with open(initial_ind, "wb") as f:
+        pickle.dump(initial_images, f)
+    with open(initial_tilt_ind, "wb") as f:
+        pickle.dump(initial_particles, f)
+    args.ind = str(initial_ind)
+    args.tilt_ind = str(initial_tilt_ind)
+
+    combined_images_round_1 = np.array([110, 120], dtype=np.int32)
+    combined_particles_round_1 = np.array([11], dtype=np.int32)
+    combined_images_round_2 = np.array([120], dtype=np.int32)
+    combined_particles_round_2 = np.array([11], dtype=np.int32)
+
+    monkeypatch.setattr(pipeline_with_outliers, "add_args", lambda parser: None)
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(pipeline_with_outliers.output, "mkdir_safe", os.makedirs)
+    monkeypatch.setattr(pipeline_with_outliers.output, "PipelineOutput", lambda outdir: _FakePO())
+    monkeypatch.setattr(
+        pipeline_with_outliers.output,
+        "standard_pipeline_plots",
+        lambda *unused, **unused_kwargs: None,
+    )
+
+    def fake_standard_recovar_pipeline(pipeline_args):
+        _write_round_artifacts(tmp_path / "pipeline" / f"round_{len(created_rounds) + 1}")
+        if len(created_rounds) == 0:
+            with open(pipeline_args.ind, "rb") as f:
+                np.testing.assert_array_equal(pickle.load(f), initial_images)
+            with open(pipeline_args.tilt_ind, "rb") as f:
+                np.testing.assert_array_equal(pickle.load(f), initial_particles)
+        else:
+            with open(pipeline_args.ind, "rb") as f:
+                np.testing.assert_array_equal(pickle.load(f), combined_images_round_1)
+            with open(pipeline_args.tilt_ind, "rb") as f:
+                np.testing.assert_array_equal(pickle.load(f), combined_particles_round_1)
+        created_rounds.append(pipeline_args.outdir)
+
+    def fake_outlier_main():
+        round_outdir = tmp_path / "pipeline" / f"round_{len(outlier_rounds) + 1}"
+        combined_dir = round_outdir / "outlier_detection" / "data" / "combined_results"
+        combined_dir.mkdir(parents=True, exist_ok=True)
+        image_ids = combined_images_round_1 if not outlier_rounds else combined_images_round_2
+        particle_ids = combined_particles_round_1 if not outlier_rounds else combined_particles_round_2
+        with open(combined_dir / "combined_image_inliers_4.pkl", "wb") as f:
+            pickle.dump(image_ids, f)
+        with open(combined_dir / "combined_image_outliers_4.pkl", "wb") as f:
+            pickle.dump(np.array([], dtype=np.int32), f)
+        with open(combined_dir / "combined_particle_inliers_4.pkl", "wb") as f:
+            pickle.dump(particle_ids, f)
+        with open(combined_dir / "combined_particle_outliers_4.pkl", "wb") as f:
+            pickle.dump(np.array([], dtype=np.int32), f)
+        outlier_rounds.append(str(round_outdir))
+
+    created_rounds = []
+    outlier_rounds = []
+    monkeypatch.setattr(
+        pipeline_with_outliers,
+        "standard_recovar_pipeline",
+        fake_standard_recovar_pipeline,
+    )
+    import recovar.commands.outlier_detection as outlier_detection
+
+    monkeypatch.setattr(outlier_detection, "main", fake_outlier_main)
+
+    pipeline_with_outliers._run_pipeline_with_outlier_removal_impl(args)
+
+    with open(tmp_path / "pipeline" / "inliers_round_1.pkl", "rb") as f:
+        np.testing.assert_array_equal(pickle.load(f), combined_images_round_1)
+    with open(tmp_path / "pipeline" / "particle_inliers_round_1.pkl", "rb") as f:
+        np.testing.assert_array_equal(pickle.load(f), combined_particles_round_1)
+    with open(tmp_path / "pipeline" / "round_2" / "inliers_round_1.pkl", "rb") as f:
+        np.testing.assert_array_equal(pickle.load(f), combined_images_round_1)
+    with open(tmp_path / "pipeline" / "round_2" / "particle_inliers_round_1.pkl", "rb") as f:
+        np.testing.assert_array_equal(pickle.load(f), combined_particles_round_1)

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 from recovar.project.registry import JOB_TYPES, get_job_type
-from recovar.project.project import RecovarProject, find_project_root
+from recovar.project.project import RecovarProject, default_job_alias, find_project_root
 
 pytestmark = pytest.mark.unit
 
@@ -162,6 +162,28 @@ class TestRecovarProject:
         resolved = proj.resolve_pipeline(None)
         assert resolved == job_dir
 
+
+    def test_register_job_start_records_unique_alias(self, tmp_path):
+        proj = RecovarProject.init(str(tmp_path / "p"))
+        uid1, _ = proj.allocate_job("pipeline")
+        proj.register_job_start(uid1, "pipeline", alias="ribosome")
+        uid2, _ = proj.allocate_job("pipeline")
+        proj.register_job_start(uid2, "pipeline", alias="ribosome")
+        jobs = {job["uid"]: job for job in proj.list_jobs()}
+        assert jobs[uid1]["alias"] == "ribosome"
+        assert jobs[uid2]["alias"] == "ribosome_2"
+        assert proj.get_job_alias_map() == {uid1: "ribosome", uid2: "ribosome_2"}
+
+    def test_resolve_pipeline_alias(self, tmp_path):
+        proj = RecovarProject.init(str(tmp_path / "p"))
+        uid, job_dir = proj.allocate_job("pipeline")
+        proj.register_job_start(uid, "pipeline", alias="ribosome_d128")
+        proj.register_job_complete(uid, "completed")
+        assert proj.resolve_pipeline("ribosome_d128") == job_dir
+
+    def test_default_job_alias_prefers_explicit_output_name(self):
+        assert default_job_alias("analyze", {"output_name": "My Embedding"}) == "my_embedding"
+
     def test_parent_jobs_tracking(self, tmp_path):
         proj = RecovarProject.init(str(tmp_path / "p"))
         uid_p, _ = proj.allocate_job("pipeline")
@@ -212,14 +234,14 @@ class TestJobContext:
             outdir=None,
             result_dir=None,
         )
-        with job_context(args, "compute_state") as ctx:
-            assert ctx.uid == "ReconstructState/job_0001"
+        with job_context(args, "pipeline") as ctx:
+            assert ctx.uid == "Pipeline/job_0001"
             assert os.path.isdir(ctx.output_dir)
             assert ctx.project is not None
 
         # After context exits, job should be completed
         jobs = proj.list_jobs()
-        assert any(j["uid"] == "ReconstructState/job_0001" and j["status"] == "completed" for j in jobs)
+        assert any(j["uid"] == "Pipeline/job_0001" and j["status"] == "completed" for j in jobs)
 
     def test_standalone_mode_with_explicit_outdir(self, tmp_path):
         from recovar.project.job_context import job_context
@@ -229,7 +251,7 @@ class TestJobContext:
             outdir=str(tmp_path / "my_output"),
             result_dir=None,
         )
-        with job_context(args, "compute_state") as ctx:
+        with job_context(args, "pipeline") as ctx:
             assert ctx.output_dir == str(tmp_path / "my_output")
             assert ctx.project is None
             assert ctx.uid is None
@@ -244,8 +266,34 @@ class TestJobContext:
             result_dir=None,
         )
         with pytest.raises(RuntimeError):
-            with job_context(args, "compute_state") as ctx:
+            with job_context(args, "pipeline") as ctx:
                 raise RuntimeError("test failure")
 
         jobs = proj.list_jobs()
-        assert any(j["uid"] == "ReconstructState/job_0001" and j["status"] == "failed" for j in jobs)
+        assert any(j["uid"] == "Pipeline/job_0001" and j["status"] == "failed" for j in jobs)
+
+
+    def test_project_mode_resolves_latest_pipeline_when_result_dir_omitted(self, tmp_path):
+        from recovar.project.job_context import job_context
+
+        proj = RecovarProject.init(str(tmp_path / "p"))
+        pipeline_uid, pipeline_dir = proj.allocate_job("pipeline")
+        proj.register_job_start(pipeline_uid, "pipeline", alias="sample_pipeline")
+        proj.register_job_complete(pipeline_uid, "completed")
+
+        args = argparse.Namespace(
+            project=str(tmp_path / "p"),
+            outdir=None,
+            output_dir=None,
+            output=None,
+            result_dir=None,
+            recovar_result_dir=None,
+            output_name="Embedding K10",
+        )
+        with job_context(args, "analyze") as ctx:
+            assert ctx.pipeline_dir == pipeline_dir
+            assert ctx.parent_jobs == [pipeline_uid]
+            assert ctx.uid == "Analyze/job_0001"
+
+        jobs = proj.list_jobs("Analyze")
+        assert jobs[0]["alias"] == "embedding_k10"


### PR DESCRIPTION
## Summary
- make project mode the standard RECOVAR workflow in docs and CLI ergonomics
- keep stable numbered job directories on disk while recording readable job aliases in project metadata
- add a shared project downsample cache under `Cache/downsample/...` so matching project runs reuse pre-downsampled particles
- extend explicit `--output-name` support across the remaining project-aware commands so GUI naming can work consistently
- add a deterministic outlier index-chaining test for the `--ind` / `--particle-ind` round-to-round path

## What changed
- `RecovarProject` now normalizes, uniquifies, and stores job aliases, and downstream project resolution can use aliases or the latest completed Pipeline job
- project-aware commands can omit `result_dir` in project mode and can infer an existing project uid from an explicit output directory
- `pipeline`, `downsample`, and the remaining custom project-mode commands accept `--output-name`, while auto-generated aliases still work when the field is omitted
- project-mode downsampling uses a fingerprinted shared cache instead of per-output `downsampled/` directories
- docs now present `--project` as the recommended path while keeping explicit output directories as a supported fallback
- `pipeline_with_outliers` unit coverage now directly checks that chained rounds preserve original global image and particle index spaces

## Validation
### Focused unit tests
- `CUDA_VISIBLE_DEVICES='' JAX_PLATFORMS=cpu pixi run pytest tests/unit/test_project.py tests/unit/test_commands_downsample.py tests/unit/test_commands_pipeline.py tests/unit/test_parser_args.py -v`
  - Result: `72 passed`
- `CUDA_VISIBLE_DEVICES='' JAX_PLATFORMS=cpu pixi run pytest tests/unit/test_parser_args.py -v`
  - Result: `7 passed`
- `CUDA_VISIBLE_DEVICES='' JAX_PLATFORMS=cpu pixi run pytest tests/unit/test_pipeline_with_outliers.py -v`
  - Result: `3 passed`

### Focused cryo-ET rerun
- `pixi run python -m pytest tests/integration/test_run_test_outliers_pipeline_regression.py::test_outliers_pipeline_cryo_et_regression_against_baseline --long-test -v`
  - Slurm job: `6659783`
  - Result: `1 passed in 1562.38s`
  - Log: `/scratch/gpfs/GILLES/mg6942/recovar_codex_project_first_20260406_215616_9281/logs/recovar-outliers-et-rerun-6659783.out`

### Full long-test regression
Submitted via `./scripts/run_tests_parallel.sh long-test`

| Group | Job | Result |
|-------|-----|--------|
| unit | 6661324 | PASS |
| smoke-tiny | 6661325 | PASS |
| downstream | 6661326 | PASS |
| metrics-spa | 6661327 | PASS |
| metrics-et | 6661328 | PASS |
| outliers-long | 6661329 | PASS |
| pdb-traj | 6661330 | PASS |
| indices | 6661331 | PASS |
| stress | 6661332 | PASS |
| isolated-funcs | 6661333 | PASS |
| summary | 6661334 | TOTAL PASS (`2451 tests`, `0 failed`) |

Summary log: `/scratch/gpfs/GILLES/mg6942/recovar_codex_project_first_20260406_215616_9281/logs/recovar-summary-6661334.out`

## Regression Tables

### SPA Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.026187 | 0.026233 | +0.18% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025933 | -1.20% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026086 | +0.34% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.026070 | -0.12% (better) | OK |
| embedding_squared_error_10 | 1.978306 | 1.953429 | -1.26% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.383312 | +0.96% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980249 | +0.04% (better) | OK |
| noise_max_relative_error | 2.112245 | 2.114650 | +0.11% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049131 | -3.69% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005746 | -3.62% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.478741 | +3.97% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.475398 | +5.23% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.024244 | 0.024065 | -0.74% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024057 | -0.83% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023827 | -0.82% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023820 | -0.84% (better) | OK |
| embedding_squared_error_10 | 1.460294 | 1.411573 | -3.34% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.203243 | -5.07% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.06% (better) | OK |
| noise_max_relative_error | 2.152798 | 2.140589 | -0.57% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049609 | -4.26% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005677 | -0.37% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.640399 | +0.93% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.638426 | +0.92% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### SPA Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 136.2s | 147.6s | +8.4% (worse) | OK |
| dataset_generation | GPU_memory | 4.9GB | 4.9GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.3GB | 5.6GB | +6.0% (worse) | OK |
| pipeline | wall_time | 578.5s | 589.9s | +2.0% (worse) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 42.7GB | 41.0GB | -3.9% (better) | OK |
| compute_state | wall_time | 317.3s | 219.6s | -30.8% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 46.7GB | 45.6GB | -2.5% (better) | OK |
| metrics | wall_time | 20.8s | 26.3s | +26.5% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2682.9% (worse) | **REGRESSED** |
| metrics | CPU_memory | 50.7GB | 50.3GB | -0.8% (better) | OK |

### Cryo-ET Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 128.5s | 140.1s | +9.0% (worse) | OK |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.1GB | 5.4GB | +6.2% (worse) | OK |
| pipeline | wall_time | 1886.7s | 1912.0s | +1.3% (worse) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 38.1GB | 37.8GB | -0.7% (better) | OK |
| compute_state | wall_time | 145.9s | 208.8s | +43.1% (worse) | **REGRESSED** |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 38.2GB | 44.0GB | +15.4% (worse) | **REGRESSED** |
| metrics | wall_time | 19.9s | 25.8s | +29.7% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2682.9% (worse) | **REGRESSED** |
| metrics | CPU_memory | 41.6GB | 48.9GB | +17.4% (worse) | **REGRESSED** |

Refs #83
Refs #99
