### PR TITLE
Fix changed-files CI checks and add pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${RECOVAR_SKIP_PRE_PUSH_CHANGED_PYTHON:-0}" == "1" ]]; then
+  echo "Skipping changed-files Python checks because RECOVAR_SKIP_PRE_PUSH_CHANGED_PYTHON=1"
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+echo "Running changed-files Python checks before push..."
+exec pixi run check-changed-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,22 +24,13 @@ jobs:
       - name: Ruff format check (changed .py files only)
         run: |
           BASE=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
-          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.py' || true)
-          if [ -n "$FILES" ]; then
-            echo "Checking: $FILES"
-            echo "$FILES" | xargs ruff format --check --diff
-          else
-            echo "No Python files changed"
-          fi
+          bash scripts/check_changed_python.sh --base "$BASE" --format
 
       - name: Ruff lint (changed .py files only)
         if: always()
         run: |
           BASE=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
-          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.py' || true)
-          if [ -n "$FILES" ]; then
-            echo "$FILES" | xargs ruff check
-          fi
+          bash scripts/check_changed_python.sh --base "$BASE" --lint
 
   typecheck:
     name: Type Check (changed files only)
@@ -58,13 +49,7 @@ jobs:
       - name: Mypy (changed .py files only)
         run: |
           BASE=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
-          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.py' || true)
-          if [ -n "$FILES" ]; then
-            echo "Checking: $FILES"
-            echo "$FILES" | xargs python -m mypy --config-file pyproject.toml
-          else
-            echo "No Python files changed"
-          fi
+          bash scripts/check_changed_python.sh --base "$BASE" --typecheck
 
   fast-tests:
     name: Unit tests

--- a/pixi.lock
+++ b/pixi.lock
@@ -338,11 +338,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/71/73a18fc9e40433a47f535d34dfb9056a45e5577856daa1d7f0a7d54a93da/array_record-0.8.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/2b/a88e0bca1a46a902854122e008d2f5fa67e42e011f5ed36a040587cc1c9d/astropy_iers_data-0.2026.3.30.0.54.34-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/96/97e6e46c8198015b0dcd3709794b358aae42a18e5a1bed393dc34307165f/astropy_iers_data-0.2026.4.6.0.54.57-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/0b/bdf449df87be3f07b23091ceafee8c3ef569cf6d2fb7edec6e3b12b3faa4/bokeh-3.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/c6/9963d588cc3d75d766c819e0377a168ef83cf3316a92769971527a1ad1de/colorcet-3.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/53/f696e4480b1d1de3b1523991dea71cf417c8b19fe70c704da164f3f90972/colorlover-0.3.0-py3-none-any.whl
@@ -381,14 +381,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/45/d8/55e0901103c93d57bab3b932294c216f0cbd49054187ce29f8f13808d530/jaxopt-0.8.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/7e/da7b57a1f3af7303a0f3c8594d820fc0d3a9bbe3810a357eb21eb166e76b/jaxtyping-0.2.38-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/28/b5/ea85873abc99dc64a7a27ff1a8dbfdc7dbb57d4e5d1a423abc11217af4f1/keras-3.13.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c0/20/78d26f81115d570bdf0e57d19b81de9ad8aa55ddb68eb10c8f0699fccb63/keras-3.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/1b/7e726d8616e813007874468c61790099ba21493e0ea07561b7d9fc53151c/kneed-0.8.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/fc/716c1e62e512ef1c160e7984a73a5fc7df45166f2ff3f254e71c58076f7c/libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/a6/8006ae81227105476a45691f5831499e4d936b1c049b0c1feb17c11b02d1/librt-0.8.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/81/7e/3404d9c62795777c537de076f06828d80e24284efbcbeb6000f33220e401/lineax-0.0.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/12/b5/99cf8772fdd846c07da4fd70f07812a3c8fd17ea2409522c946bb0f2b277/llvmlite-0.46.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/89/ea8f91594bc5dbb879734d35a6f2b0ad50605d7fb419de2b63d4211765cc/lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
@@ -411,7 +411,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/bc/465daf1de06409cdd4532082806770ee0d8d7df434da79c76564d0f69741/namex-0.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/b7/ec1cbc6b297a808c513f59f501656389623fc09ad6a58c640851289c7854/nh3-0.3.4-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/19/16/aa6e3ba3cd45435c117d1101b278b646444ed05b7c712af631b91353f573/numba-0.64.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/a7/11e2b24251d57cf41fc9ad83f378d890d61a890e3f8eb6338b39833f67a4/numba-0.65.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/1b/54f7595727516ba21b59dd8607ade5e6dda973462264be9af74b5ee0dee3/nvidia_cublas_cu12-12.9.2.10.tar.gz
       - pypi: https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl
@@ -449,6 +449,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/fb/f8a86c4fe94a3fa3fb8a7ab5f877cbc8a5f31cec55bc01935833a51e9745/starfile-0.5.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/03/9a99555a762de8cd4a405efbd39a732d926d8e58791441889560b7675b3e/tensorflow_cpu-2.21.0-cp311-cp311-manylinux_2_27_x86_64.whl
@@ -691,10 +692,10 @@ packages:
   - astropy[dev] ; extra == 'dev-all'
   - astropy[test-all] ; extra == 'dev-all'
   requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/fb/2b/a88e0bca1a46a902854122e008d2f5fa67e42e011f5ed36a040587cc1c9d/astropy_iers_data-0.2026.3.30.0.54.34-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d2/96/97e6e46c8198015b0dcd3709794b358aae42a18e5a1bed393dc34307165f/astropy_iers_data-0.2026.4.6.0.54.57-py3-none-any.whl
   name: astropy-iers-data
-  version: 0.2026.3.30.0.54.34
-  sha256: b6784cbd4d1f28f5767af03702af4db33480ce4d159d64e0c65d33183b192973
+  version: 0.2026.4.6.0.54.57
+  sha256: e3d85850ccfd2e68f797c417cd1cc30fe1bdbd54c3a6ec6e48c307c879858ac4
   requires_dist:
   - pytest ; extra == 'docs'
   - hypothesis ; extra == 'test'
@@ -1080,10 +1081,10 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 51033
   timestamp: 1754767444665
-- pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl
   name: click
-  version: 8.3.1
-  sha256: 981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
+  version: 8.3.2
+  sha256: 1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
   requires_dist:
   - colorama ; sys_platform == 'win32'
   requires_python: '>=3.10'
@@ -2787,10 +2788,10 @@ packages:
   purls: []
   size: 239104
   timestamp: 1703333860145
-- pypi: https://files.pythonhosted.org/packages/28/b5/ea85873abc99dc64a7a27ff1a8dbfdc7dbb57d4e5d1a423abc11217af4f1/keras-3.13.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c0/20/78d26f81115d570bdf0e57d19b81de9ad8aa55ddb68eb10c8f0699fccb63/keras-3.14.0-py3-none-any.whl
   name: keras
-  version: 3.13.2
-  sha256: 14b2afc0f9c636cc295d28efc36aae42fc52e7b892c950eec33f3befe4d22fb5
+  version: 3.14.0
+  sha256: 19ce94b798caaba4d404ab6ef4753b44219170e5c2868156de8bb0494a260114
   requires_dist:
   - absl-py
   - numpy
@@ -3755,10 +3756,10 @@ packages:
   purls: []
   size: 3268766
   timestamp: 1673584331056
-- pypi: https://files.pythonhosted.org/packages/12/b5/99cf8772fdd846c07da4fd70f07812a3c8fd17ea2409522c946bb0f2b277/llvmlite-0.46.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: llvmlite
-  version: 0.46.0
-  sha256: a3df43900119803bbc52720e758c76f316a9a0f34612a886862dfe0a5591a17e
+  version: 0.47.0
+  sha256: ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
   name: locket
@@ -4344,12 +4345,13 @@ packages:
   - pkg:pypi/notebook-shim?source=hash-mapping
   size: 16817
   timestamp: 1733408419340
-- pypi: https://files.pythonhosted.org/packages/19/16/aa6e3ba3cd45435c117d1101b278b646444ed05b7c712af631b91353f573/numba-0.64.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/c1/a7/11e2b24251d57cf41fc9ad83f378d890d61a890e3f8eb6338b39833f67a4/numba-0.65.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: numba
-  version: 0.64.0
-  sha256: d17071b4ffc9d39b75d8e6c101a36f0c81b646123859898c9799cb31807c8f78
+  version: 0.65.0
+  sha256: 032b0b8e879512cd424d79eed6d772a1399c6387ded184c2cf3cc22c08d750a6
   requires_dist:
-  - llvmlite>=0.46.0.dev0,<0.47
+  - llvmlite>=0.47.0.dev0,<0.48
+  - numpy>=1.22
   - numpy>=1.22,<2.5
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py311h5d046bc_0.conda
@@ -5659,6 +5661,11 @@ packages:
   - pkg:pypi/rpds-py?source=hash-mapping
   size: 387057
   timestamp: 1756737832651
+- pypi: https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: ruff
+  version: 0.15.9
+  sha256: 2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.25.2-py311hed34c8f_2.conda
   sha256: 423fd5c1b5a7469c8e08e45f3e006d84518788104fefade7e78ea3e651bc7322
   md5: 515ec832e4a98828374fded73405e3f3

--- a/pixi.toml
+++ b/pixi.toml
@@ -56,6 +56,7 @@ pytest-cov = ">=5.0"
 # Documentation
 mkdocstrings = { extras = ["python"], version = "*" }
 mypy = "==1.20.0"
+ruff = ">=0.8.0"
 # JAX 0.9.x with CUDA 12 support. Pin plugin/PJRT to match jaxlib exactly
 # so fresh resolutions do not pull newer incompatible CUDA wheels.
 jax = { extras = ["cuda12"], version = "==0.9.0.1" }
@@ -100,6 +101,8 @@ test-recovar = "recovar run_test_dataset"
 
 # Quick smoke test: verifies the environment can import the package without running workloads.
 smoke-import-recovar = "python -c \"import recovar; print('recovar_import_ok')\""
+check-changed-python = "bash ./scripts/check_changed_python.sh"
+install-git-hooks = "git config core.hooksPath .githooks && chmod +x .githooks/pre-push"
 
 # Pytest tasks
 test-fast = "python -m pytest tests/ -q --ignore=tests/unit/test_gui_app.py"

--- a/recovar/commands/downsample.py
+++ b/recovar/commands/downsample.py
@@ -148,7 +148,7 @@ def downsample_to_disk(
     (mrcs_path, star_path) : tuple of str
         Paths to the output ``.mrcs`` stack and ``.star`` metadata file.
     """
-    from recovar.data_io.downsample import downsample_images, get_downsample_batch_size, _gpu_available
+    from recovar.data_io.downsample import _gpu_available, downsample_images, get_downsample_batch_size
     from recovar.data_io.image_loader import load_images
 
     if target_D % 2 != 0:
@@ -388,7 +388,6 @@ def _write_output_star(input_path, mrcs_path, star_path, target_D, new_apix, n_i
     If the input was a CS file, convert metadata to RELION STAR format.
     Otherwise, write a minimal file with just image references.
     """
-    import pandas as pd
 
     ext = input_path.rsplit(".", 1)[-1].lower()
 
@@ -402,7 +401,6 @@ def _write_output_star(input_path, mrcs_path, star_path, target_D, new_apix, n_i
         # Use our own cached read_star (fast) rather than the external starfile package.
         try:
             from recovar.data_io.starfile import read_star, write_star
-            import pandas as pd
 
             particles_df, optics_df = read_star(input_path)
 
@@ -435,9 +433,9 @@ def _write_output_star(input_path, mrcs_path, star_path, target_D, new_apix, n_i
 
 def _write_star_from_cs(cs_path, star_path, mrcs_rel, target_D, new_apix, n_images):
     """Convert cryoSPARC .cs metadata to a RELION 3.1 STAR file."""
-    from scipy.spatial.transform import Rotation as SciPyRot
-    import starfile
     import pandas as pd
+    import starfile
+    from scipy.spatial.transform import Rotation as SciPyRot
 
     data = np.load(cs_path, allow_pickle=True)
 
@@ -530,8 +528,8 @@ def _write_star_from_cs(cs_path, star_path, mrcs_rel, target_D, new_apix, n_imag
 
 def _write_minimal_star(star_path, mrcs_rel, target_D, new_apix, n_images):
     """Write a minimal RELION 3.1 STAR file."""
-    import starfile
     import pandas as pd
+    import starfile
 
     optics = pd.DataFrame(
         {

--- a/recovar/commands/estimate_conformational_density.py
+++ b/recovar/commands/estimate_conformational_density.py
@@ -1,4 +1,3 @@
-import recovar.jax_config
 import argparse
 import logging
 from pathlib import Path
@@ -7,8 +6,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from recovar import utils
-from recovar.output import output
 from recovar.heterogeneity import deconvolve_density
+from recovar.output import output
 
 logger = logging.getLogger(__name__)
 

--- a/recovar/commands/estimate_stable_states.py
+++ b/recovar/commands/estimate_stable_states.py
@@ -5,10 +5,10 @@ import os
 import numpy as np
 
 from recovar import utils
-
-logger = logging.getLogger(__name__)
 from recovar.heterogeneity import deconvolve_density
 from recovar.output import output
+
+logger = logging.getLogger(__name__)
 
 
 def estimate_stable_states(density, latent_space_bounds, percent_top=1, n_local_maxs=3, file_path=None):

--- a/recovar/commands/extract_image_subset.py
+++ b/recovar/commands/extract_image_subset.py
@@ -1,6 +1,6 @@
 import argparse
-import os
 import logging
+import os
 
 import numpy as np
 

--- a/recovar/commands/junk_particle_detection.py
+++ b/recovar/commands/junk_particle_detection.py
@@ -20,16 +20,29 @@ New in this version:
 - Reconstruction metadata is saved in reconstructions_info_{zdim_key}.pkl
 """
 
+import argparse
+import logging
 import os
 import pickle
-import numpy as np
+
+import jax.numpy as jnp
 import matplotlib
+import matplotlib.cm as cm
+import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
-import logging
+import mrcfile
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import umap
 from sklearn.cluster import KMeans
-from recovar import utils
-from recovar.reconstruction import relion_functions
+
+import recovar.core.fourier_transform_utils as fourier_transform_utils
 from recovar.output import output, plot_utils
+from recovar.reconstruction import relion_functions
+
+logger = logging.getLogger(__name__)
+matplotlib.rcParams["contour.negative_linestyle"] = "solid"
 
 
 def _safe_savefig(filepath, **kwargs):
@@ -45,21 +58,6 @@ def _safe_savefig(filepath, **kwargs):
     except (ValueError, TypeError):
         kwargs.pop("bbox_inches", None)
         plt.savefig(filepath, **kwargs)
-
-
-import recovar.core.fourier_transform_utils as fourier_transform_utils
-import jax.numpy as jnp
-import seaborn as sns
-import mrcfile
-import pandas as pd
-import matplotlib.cm as cm
-import matplotlib.colors as mcolors
-import umap
-import argparse
-
-matplotlib.rcParams["contour.negative_linestyle"] = "solid"
-
-logger = logging.getLogger(__name__)
 
 
 def compute_fsc_auc(fsc_curve, grid_size, voxel_size, threshold=1 / 7):
@@ -261,8 +259,6 @@ def compute_cluster_fsc_scores(
 
         # Apply low-pass filtering if requested
         if filter_resolution is not None:
-            from recovar.reconstruction import regularization
-
             # Convert resolution to frequency
             freq_threshold = 1.0 / filter_resolution  # 1/Angstrom
 
@@ -2638,7 +2634,7 @@ def junk_particle_detection(
             "n_particles_per_cluster": np.array([info.get("n_particles", 0) for info in junk_info.values()])
             if junk_info
             else np.array([]),
-            "junk_threshold": junk_threshold if "junk_threshold" in dir() else 0.5,
+            "junk_threshold": locals().get("junk_threshold", 0.5),
             "n_junk": len(junk_particles),
             "n_good": len(good_particles),
         }
@@ -3100,13 +3096,13 @@ Good Particles: {stats["good_particles"]:,} ({(1 - stats["junk_fraction"]) * 100
 Cluster Statistics:
   Junk Clusters: {stats["n_junk_clusters"]}
   Good Clusters: {stats["n_good_clusters"]}
-  
+
   Avg Junk Cluster Size: {stats["avg_junk_cluster_size"]:.1f}
   Avg Good Cluster Size: {stats["avg_good_cluster_size"]:.1f}
-  
+
   Max Junk Cluster Size: {stats["max_junk_cluster_size"]}
   Max Good Cluster Size: {stats["max_good_cluster_size"]}
-  
+
   Min Junk Cluster Size: {stats["min_junk_cluster_size"]}
   Min Good Cluster Size: {stats["min_good_cluster_size"]}
 
@@ -3197,9 +3193,9 @@ Classification Quality:
 
         # Overlay good and junk particles
         if len(good_particles) > 0:
-            ax.scatter(zs[good_particles, 0], zs[good_particles, 1], c="green", alpha=0.6, s=5, label=f"Good particles")
+            ax.scatter(zs[good_particles, 0], zs[good_particles, 1], c="green", alpha=0.6, s=5, label="Good particles")
         if len(junk_particles) > 0:
-            ax.scatter(zs[junk_particles, 0], zs[junk_particles, 1], c="red", alpha=0.6, s=5, label=f"Junk particles")
+            ax.scatter(zs[junk_particles, 0], zs[junk_particles, 1], c="red", alpha=0.6, s=5, label="Junk particles")
 
         ax.set_xlabel("Latent Dimension 1")
         ax.set_ylabel("Latent Dimension 2")

--- a/recovar/commands/outlier_detection.py
+++ b/recovar/commands/outlier_detection.py
@@ -1386,7 +1386,7 @@ def _run_outlier_detection(args):
     if save_all_plots:
         breakdown_file = os.path.join(combined_output_dir, "detection_breakdown.txt")
         with open(breakdown_file, "w") as f:
-            f.write(f"Combined Outlier Detection Results\n")
+            f.write("Combined Outlier Detection Results\n")
             f.write(f"Total particles: {total_particles}\n")
             f.write(
                 f"Combined image outliers: {len(combined_image_outliers)} ({len(combined_image_outliers) / original_image_indices.size * 100:.1f}%)\n"

--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -1,23 +1,25 @@
 """Main recovar pipeline command: mean reconstruction, covariance, PCA, embedding."""
 
+import argparse
 import logging
+import os
+import sys
+import time
 
-logger = logging.getLogger(__name__)
-import recovar.jax_config
 import numpy as np
-import os, argparse, time, sys
-from recovar import utils
-from recovar.reconstruction import homogeneous, noise
-from recovar.output import output
-from recovar.data_io import cryoem_dataset, halfsets
-from recovar.core import mask
-from recovar.heterogeneity import embedding, principal_components, covariance_estimation
-from recovar.output.output_paths import ResultPaths
+
 import recovar.core.fourier_transform_utils as fourier_transform_utils
-
-
+from recovar import utils
+from recovar.core import mask
+from recovar.data_io import halfsets
+from recovar.heterogeneity import covariance_estimation, embedding, principal_components
+from recovar.output import output
+from recovar.output.output_paths import ResultPaths
+from recovar.reconstruction import homogeneous, noise
 from recovar.utils.helpers import RobustFileHandler as _RobustFileHandler
 from recovar.utils.helpers import RobustStreamHandler as _RobustStreamHandler
+
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser: argparse.ArgumentParser):
@@ -289,8 +291,8 @@ def add_args(parser: argparse.ArgumentParser):
         dest="adaptive_memory",
         action="store_true",
         help="Adapt number of PCs to available GPU memory. By default, "
-             "200 PCs are used regardless of GPU size for reproducibility. "
-             "This flag reduces n_pcs on smaller GPUs to avoid OOM.",
+        "200 PCs are used regardless of GPU size for reproducibility. "
+        "This flag reduces n_pcs on smaller GPUs to avoid OOM.",
     )
 
     # ── Advanced / debugging ─────────────────────────────────────────────
@@ -895,10 +897,13 @@ def standard_recovar_pipeline(args):
         raise ValueError(f"noise model {noise_model} not recognized")
 
     contrasts_for_second = None
+    est_contrasts = None
     for repeat in range(n_repeats):
         if repeat == 1:
             ndim = 10 if 10 in options.zs_dim_to_test else int(np.median(options.zs_dim_to_test))
             logger.warning("repeating with contrast of zdim=%s", ndim)
+            if est_contrasts is None or ndim not in est_contrasts:
+                raise RuntimeError(f"missing contrast estimate for zdim={ndim} before repeat")
             contrasts_for_second = est_contrasts[ndim]
             contrasts_for_second /= np.mean(contrasts_for_second)
             # Embedding returns contrasts in original dataset order (no halfset reordering needed).
@@ -1017,7 +1022,8 @@ def standard_recovar_pipeline(args):
         # --- Covariance options ---
         adaptive = args.low_memory_option or getattr(args, "adaptive_memory", False)
         covariance_options = covariance_estimation.get_default_covariance_computation_options(
-            ds.grid_size, adaptive_n_pcs=adaptive,
+            ds.grid_size,
+            adaptive_n_pcs=adaptive,
         )
 
         if args.low_memory_option:

--- a/recovar/commands/postprocess.py
+++ b/recovar/commands/postprocess.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
 import argparse
+import glob
 import logging
 import os
-import glob
+
 import numpy as np
+
+import recovar.core.fourier_transform_utils as fourier_transform_utils
 from recovar import utils
 from recovar.heterogeneity import locres
-import recovar.core.fourier_transform_utils as fourier_transform_utils
 
 logger = logging.getLogger(__name__)
 
@@ -206,9 +208,9 @@ def estimate_bfactor_from_halfmaps(halfmap1, voxel_size, plot_path=None):
     -------
     RuntimeError : If estimation fails due to insufficient data
     """
-    import numpy as np
-    import matplotlib.pyplot as plt
     import logging
+
+    import numpy as np
 
     logger = logging.getLogger(__name__)
 
@@ -420,7 +422,6 @@ def _create_bfactor_plot_robust(
 ):
     """Create diagnostic plot for B-factor estimation (RELION-inspired)."""
     import matplotlib.pyplot as plt
-    import numpy as np
 
     fig, axes = plt.subplots(1, 3, figsize=(15, 5))
 
@@ -554,9 +555,10 @@ def estimate_bfactor_from_fsc_weighted_halfmaps(
       - The B-factor fit line (on the FSC-weighted plot)
     If multiple FSCs are available (e.g., unmasked, masked), plot them all for comparison.
     """
-    import numpy as np
-    import matplotlib.pyplot as plt
     import logging
+
+    import matplotlib.pyplot as plt
+    import numpy as np
 
     logger = logging.getLogger(__name__)
     # Use seaborn for style if available
@@ -857,7 +859,7 @@ def local_filter_halfmaps(
     else:
         info_path = output_path + "_info.txt"
     with open(info_path, "w") as f:
-        f.write(f"Local Resolution Statistics:\n")
+        f.write("Local Resolution Statistics:\n")
         if not np.isnan(median_resol):
             f.write(f"  Median: {median_resol:.2f} Angstroms\n")
             f.write(f"  Mean: {mean_resol:.2f} Angstroms\n")
@@ -866,7 +868,7 @@ def local_filter_halfmaps(
         f.write(f"Voxel Size: {voxel_size} Angstroms\n")
         f.write(f"Input Halfmap1: {halfmap1_path}\n")
         f.write(f"Input Halfmap2: {halfmap2_path}\n")
-        f.write(f"Local Resolution Parameters:\n")
+        f.write("Local Resolution Parameters:\n")
         f.write(f"  Sampling: {locres_sampling} Angstroms\n")
         f.write(f"  Mask radius: {locres_maskrad} Angstroms\n")
         f.write(f"  Edge width: {locres_edgwidth} Angstroms\n")
@@ -881,7 +883,7 @@ def local_filter_halfmaps(
             f.write(f"B-factor fit plot: {bfactor_plot_prefix}_bfactor_fsc_panels.png\n")
         if apply_mask_path is not None:
             f.write(f"Apply mask: {apply_mask_path}\n")
-        f.write(f"Output files:\n")
+        f.write("Output files:\n")
         f.write(f"  Filtered map: {output_path}\n")
         f.write(f"  Local resolution map: {local_resol_path}\n")
         f.write(f"  Local AUC map: {local_auc_path}\n")
@@ -1184,28 +1186,28 @@ def main():
 Examples:
   # Single halfmap filtering (global)
   python -m recovar.commands.postprocess half1_unfil.mrc --voxel-size 1.0 --output filtered.mrc
-  
+
   # Single halfmap filtering (local)
   python -m recovar.commands.postprocess half1_unfil.mrc --voxel-size 1.0 --output filtered.mrc --local
-  
+
   # With B-factor sharpening and masking (global)
   python -m recovar.commands.postprocess half1_unfil.mrc --voxel-size 1.0 --output filtered.mrc --B-factor -100 --mask-radius 50
-  
+
   # With B-factor sharpening and masking (local)
   python -m recovar.commands.postprocess half1_unfil.mrc --voxel-size 1.0 --output filtered.mrc --local --B-factor -100 --mask-radius 50
-  
+
   # With custom mask applied to final result
   python -m recovar.commands.postprocess half1_unfil.mrc --voxel-size 1.0 --output filtered.mrc --apply-mask mask.mrc
-  
+
   # Local filtering with custom parameters
   python -m recovar.commands.postprocess half1_unfil.mrc --voxel-size 1.0 --output filtered.mrc --local --locres-sampling 20 --locres-minres 30
-  
+
   # Batch process analyze output volumes directory (global)
   python -m recovar.commands.postprocess /path/to/analysis_output/kmeans_center_volumes --batch --voxel-size 1.0 --output /path/to/filtered_volumes
-  
+
   # Batch process analyze output volumes directory (local)
   python -m recovar.commands.postprocess /path/to/analysis_output/kmeans_center_volumes --batch --local --voxel-size 1.0 --output /path/to/filtered_volumes
-  
+
   # Specify both halfmaps explicitly
   python -m recovar.commands.postprocess half1_unfil.mrc --halfmap2 half2_unfil.mrc --voxel-size 1.0 --output filtered.mrc
         """,

--- a/recovar/commands/reconstruct_from_external_embedding.py
+++ b/recovar/commands/reconstruct_from_external_embedding.py
@@ -1,4 +1,3 @@
-import recovar.jax_config
 import argparse
 import logging
 import os
@@ -7,7 +6,7 @@ import time
 import numpy as np
 
 from recovar import utils
-from recovar.data_io import cryoem_dataset, halfsets
+from recovar.data_io import halfsets
 from recovar.output import output as o
 from recovar.reconstruction import noise
 

--- a/recovar/project/job_context.py
+++ b/recovar/project/job_context.py
@@ -167,7 +167,7 @@ def job_context(args, command_name: str):
 
     job = JobDir(ctx.output_dir, command_name)
     ctx.job = job
-    job._parent_result_dir = ctx.pipeline_dir
+    setattr(job, "_parent_result_dir", ctx.pipeline_dir)
     job.start(args)
 
     # --- Register in project ---

--- a/recovar/project/project.py
+++ b/recovar/project/project.py
@@ -17,7 +17,7 @@ import re
 from contextlib import contextmanager
 from typing import Any, Mapping, Optional
 
-from recovar.project.registry import JOB_TYPES, get_job_type
+from recovar.project.registry import get_job_type
 
 logger = logging.getLogger(__name__)
 
@@ -328,9 +328,10 @@ class RecovarProject:
         description: str = "",
     ):
         """Add a job entry to project.json with status=running."""
+        job_type = get_job_type(command_name)
         entry = {
             "uid": uid,
-            "type": get_job_type(command_name).name if get_job_type(command_name) else command_name,
+            "type": job_type.name if job_type is not None else command_name,
             "status": "running",
             "created": datetime.datetime.now().isoformat(),
             "completed": None,
@@ -341,11 +342,7 @@ class RecovarProject:
         with self._lock():
             data = self._read()
             jobs = [j for j in data.setdefault("jobs", []) if j.get("uid") != uid]
-            aliases = {
-                name: target
-                for name, target in data.setdefault("aliases", {}).items()
-                if target != uid
-            }
+            aliases = {name: target for name, target in data.setdefault("aliases", {}).items() if target != uid}
             existing_aliases = {j.get("alias") for j in jobs if j.get("alias")}
             if alias:
                 alias = uniquify_job_alias(normalize_job_alias(alias), existing_aliases)

--- a/recovar/utils/parser_args.py
+++ b/recovar/utils/parser_args.py
@@ -1,4 +1,5 @@
-import os, argparse
+import argparse
+import os
 
 
 def add_project_arg(parser: argparse.ArgumentParser):

--- a/scripts/check_changed_python.sh
+++ b/scripts/check_changed_python.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check_changed_python.sh [--base REV] [--head REV] [--format] [--lint] [--typecheck]
+
+Runs Ruff format check, Ruff lint, and/or mypy on Python files changed between two revisions.
+
+Defaults:
+  base: merge-base(HEAD, origin/dev) when origin/dev exists, else HEAD~1
+  head: HEAD
+  checks: format + lint + typecheck
+
+Examples:
+  bash scripts/check_changed_python.sh
+  bash scripts/check_changed_python.sh --base origin/dev --lint --typecheck
+  bash scripts/check_changed_python.sh --base "$BASE" --format
+EOF
+}
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+base=""
+head="HEAD"
+declare -a checks=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      base="${2:?missing value for --base}"
+      shift 2
+      ;;
+    --head)
+      head="${2:?missing value for --head}"
+      shift 2
+      ;;
+    --format)
+      checks+=("format")
+      shift
+      ;;
+    --lint)
+      checks+=("lint")
+      shift
+      ;;
+    --typecheck)
+      checks+=("typecheck")
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ${#checks[@]} -eq 0 ]]; then
+  checks=("format" "lint" "typecheck")
+fi
+
+if [[ -z "$base" ]]; then
+  if git show-ref --verify --quiet refs/remotes/origin/dev; then
+    base="$(git merge-base "$head" origin/dev)"
+  elif git rev-parse --verify -q "${head}~1" >/dev/null; then
+    base="${head}~1"
+  else
+    echo "Unable to determine a base revision automatically" >&2
+    exit 2
+  fi
+fi
+
+mapfile -d '' files < <(git diff -z --name-only --diff-filter=ACMR "$base" "$head" -- '*.py')
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No changed Python files between $base and $head"
+  exit 0
+fi
+
+echo "Changed Python files between $base and $head:"
+printf '  %s\n' "${files[@]}"
+
+for check in "${checks[@]}"; do
+  case "$check" in
+    format)
+      echo
+      echo "==> Ruff format check"
+      python -m ruff format --check --diff "${files[@]}"
+      ;;
+    lint)
+      echo
+      echo "==> Ruff lint"
+      python -m ruff check "${files[@]}"
+      ;;
+    typecheck)
+      echo
+      echo "==> Mypy"
+      python -m mypy --config-file pyproject.toml "${files[@]}"
+      ;;
+    *)
+      echo "Unknown check: $check" >&2
+      exit 2
+      ;;
+  esac
+done

--- a/tests/unit/test_commands_downsample.py
+++ b/tests/unit/test_commands_downsample.py
@@ -9,7 +9,6 @@ Covers:
 
 import argparse
 import sys
-from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -130,7 +129,9 @@ def test_downsample_to_disk_uses_explicit_gpu_memory_cap(monkeypatch, tmp_path):
         return 4
 
     monkeypatch.setattr(ds_io, "get_downsample_batch_size", _record_batch_size)
-    monkeypatch.setattr(ds_io, "downsample_images", lambda images, target_D, use_gpu=None: images[:, :target_D, :target_D])
+    monkeypatch.setattr(
+        ds_io, "downsample_images", lambda images, target_D, use_gpu=None: images[:, :target_D, :target_D]
+    )
     monkeypatch.setattr("recovar.data_io.image_loader.load_images", lambda *args, **kwargs: _FakeLoader())
 
     import recovar.utils.helpers as helpers
@@ -264,7 +265,6 @@ def test_write_minimal_star_creates_file(tmp_path):
         n_images=10,
     )
     assert (tmp_path / "particles.128.star").exists()
-
 
 
 def _make_relion31_star_input(tmp_path, orig_D=288, orig_apix=1.5, n_images=4):

--- a/tests/unit/test_commands_pipeline.py
+++ b/tests/unit/test_commands_pipeline.py
@@ -209,6 +209,7 @@ def test_standard_pipeline_passes_gpu_limit_to_predownsample(monkeypatch, tmp_pa
         lambda value: captured.setdefault("limits", []).append(value),
     )
     monkeypatch.setattr(pipeline_cmd.os.path, "exists", lambda _path: False)
+
     class _NoopLock:
         def __enter__(self):
             return None
@@ -220,7 +221,9 @@ def test_standard_pipeline_passes_gpu_limit_to_predownsample(monkeypatch, tmp_pa
         sys.modules,
         "recovar.commands.downsample",
         SimpleNamespace(
-            build_project_downsample_cache_dir=lambda **kwargs: str(tmp_path / "Cache" / "downsample" / "particles_d128"),
+            build_project_downsample_cache_dir=lambda **kwargs: str(
+                tmp_path / "Cache" / "downsample" / "particles_d128"
+            ),
             downsample_cache_lock=lambda _path: _NoopLock(),
             downsample_to_disk=lambda **kwargs: captured.setdefault("downsample_kwargs", kwargs),
             write_downsample_cache_metadata=lambda **kwargs: captured.setdefault("cache_metadata", kwargs),
@@ -260,7 +263,6 @@ def test_standard_pipeline_passes_gpu_limit_to_predownsample(monkeypatch, tmp_pa
     assert captured["downsample_kwargs"]["gpu_memory_gb"] == 12.0
 
 
-
 def test_standard_pipeline_uses_project_downsample_cache(monkeypatch, tmp_path):
     captured = {}
 
@@ -287,7 +289,9 @@ def test_standard_pipeline_uses_project_downsample_cache(monkeypatch, tmp_path):
         SimpleNamespace(
             build_project_downsample_cache_dir=lambda **kwargs: captured.setdefault("cache_dir", str(cache_dir)),
             downsample_cache_lock=lambda _path: _NoopLock(),
-            downsample_to_disk=lambda **kwargs: (_ for _ in ()).throw(AssertionError("should reuse cached downsample outputs")),
+            downsample_to_disk=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("should reuse cached downsample outputs")
+            ),
             write_downsample_cache_metadata=lambda **kwargs: captured.setdefault("cache_metadata", kwargs),
         ),
     )

--- a/tests/unit/test_parser_args.py
+++ b/tests/unit/test_parser_args.py
@@ -46,13 +46,13 @@ def test_standard_downstream_args_defaults_and_flags():
     assert parsed.apply_global_filtering is True
 
 
-
 def test_standard_downstream_args_project_mode_defaults():
     parser = parser_args.standard_downstream_args(argparse.ArgumentParser(), analyze=True)
     parsed = parser.parse_args(["--project", "/tmp/project", "--output-name", "embedding_k10"])
     assert parsed.result_dir is None
     assert parsed.project == "/tmp/project"
     assert parsed.output_name == "embedding_k10"
+
 
 @pytest.mark.parametrize(
     ("module", "argv", "expected"),
@@ -109,4 +109,3 @@ def test_postprocess_parser_accepts_output_name():
     )
     assert parsed.project == "/tmp/project"
     assert parsed.output_name == "postprocess_custom"
-

--- a/tests/unit/test_pipeline_with_outliers.py
+++ b/tests/unit/test_pipeline_with_outliers.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import pickle
+
 import numpy as np
 import pytest
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -6,8 +6,8 @@ import os
 
 import pytest
 
-from recovar.project.registry import JOB_TYPES, get_job_type
 from recovar.project.project import RecovarProject, default_job_alias, find_project_root
+from recovar.project.registry import JOB_TYPES, get_job_type
 
 pytestmark = pytest.mark.unit
 
@@ -162,7 +162,6 @@ class TestRecovarProject:
         resolved = proj.resolve_pipeline(None)
         assert resolved == job_dir
 
-
     def test_register_job_start_records_unique_alias(self, tmp_path):
         proj = RecovarProject.init(str(tmp_path / "p"))
         uid1, _ = proj.allocate_job("pipeline")
@@ -271,7 +270,6 @@ class TestJobContext:
 
         jobs = proj.list_jobs()
         assert any(j["uid"] == "Pipeline/job_0001" and j["status"] == "failed" for j in jobs)
-
 
     def test_project_mode_resolves_latest_pipeline_when_result_dir_omitted(self, tmp_path):
         from recovar.project.job_context import job_context


### PR DESCRIPTION
## Summary
- fix the recurring changed-files CI failures by cleaning the current Ruff and mypy issues on the touched Python files
- add a shared changed-files checker script used by both local hooks and GitHub CI
- add a repo-managed pre-push hook so pushes fail locally before the GitHub checks fail remotely

## What Changed
- added [scripts/check_changed_python.sh](/scratch/gpfs/GILLES/mg6942/recovar_codex_ci_cleanup_20260407_101722/scripts/check_changed_python.sh) to run Ruff format, Ruff lint, and mypy on changed Python files only
- added [.githooks/pre-push](/scratch/gpfs/GILLES/mg6942/recovar_codex_ci_cleanup_20260407_101722/.githooks/pre-push) and wired it through the new `pixi run install-git-hooks` task in [pixi.toml](/scratch/gpfs/GILLES/mg6942/recovar_codex_ci_cleanup_20260407_101722/pixi.toml)
- updated [ci.yml](/scratch/gpfs/GILLES/mg6942/recovar_codex_ci_cleanup_20260407_101722/.github/workflows/ci.yml) so the GitHub `Lint (changed files only)` and `Type Check (changed files only)` jobs call the same shared script
- fixed the current changed-files code issues in the touched project/pipeline command files so the checks pass now

## Validation
Local changed-files checks passed:
```bash
pixi run bash ./scripts/check_changed_python.sh
./.githooks/pre-push
```

Focused unit slice passed:
```bash
CUDA_VISIBLE_DEVICES='' JAX_PLATFORMS=cpu pixi run pytest tests/unit/test_project.py tests/unit/test_commands_pipeline.py tests/unit/test_parser_args.py -v
```
Result: `52 passed, 1 warning in 14.32s`

Full long-test submitted:
- jobs: `6667358 6667359 6667360 6667361 6667362 6667363 6667364 6667365 6667366 6667367`
- summary: `6667368`
- summary log: `/scratch/gpfs/GILLES/mg6942/recovar_codex_ci_cleanup_20260407_101722/logs/recovar-summary-6667368.out`

Current full-suite result on this branch:
- `TOTAL FAIL tests=2451 fail=1 time=16941.9s`
- only failing group: `outliers-long`
- exact failing test: `tests/integration/test_run_test_outliers_pipeline_regression.py::test_outliers_pipeline_cryo_et_regression_against_baseline`
- failing log: `/scratch/gpfs/GILLES/mg6942/recovar_codex_ci_cleanup_20260407_101722/logs/recovar-outliers-long-6667363.out`

## Regression Tables

### SPA Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.026187 | 0.026231 | +0.17% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025938 | -1.18% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026097 | +0.38% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.026075 | -0.10% (better) | OK |
| embedding_squared_error_10 | 1.978306 | 1.952680 | -1.30% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.383102 | +0.90% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980249 | +0.04% (better) | OK |
| noise_max_relative_error | 2.112245 | 2.114650 | +0.11% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049131 | -3.69% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005747 | -3.61% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.478698 | +3.96% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.475376 | +5.23% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.024244 | 0.024062 | -0.75% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024055 | -0.83% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023824 | -0.84% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023801 | -0.92% (better) | OK |
| embedding_squared_error_10 | 1.460294 | 1.411161 | -3.36% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.201468 | -5.90% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.06% (better) | OK |
| noise_max_relative_error | 2.152798 | 2.140589 | -0.57% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049609 | -4.26% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005677 | -0.36% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.640397 | +0.93% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.638417 | +0.92% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### SPA Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 136.2s | 147.9s | +8.6% (worse) | OK |
| dataset_generation | GPU_memory | 4.9GB | 4.9GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.3GB | 5.6GB | +6.2% (worse) | OK |
| pipeline | wall_time | 578.5s | 681.5s | +17.8% (worse) | **REGRESSED** |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 42.7GB | 41.0GB | -3.9% (better) | OK |
| compute_state | wall_time | 317.3s | 220.7s | -30.5% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 46.7GB | 45.5GB | -2.6% (better) | OK |
| metrics | wall_time | 20.8s | 25.7s | +23.6% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2694.7% (worse) | **REGRESSED** |
| metrics | CPU_memory | 50.7GB | 50.2GB | -0.9% (better) | OK |

### Cryo-ET Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 128.5s | 141.2s | +9.9% (worse) | OK |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.1GB | 5.4GB | +6.5% (worse) | OK |
| pipeline | wall_time | 1886.7s | 1918.8s | +1.7% (worse) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 38.1GB | 41.2GB | +8.0% (worse) | OK |
| compute_state | wall_time | 145.9s | 206.7s | +41.6% (worse) | **REGRESSED** |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 38.2GB | 46.8GB | +22.7% (worse) | **REGRESSED** |
| metrics | wall_time | 19.9s | 25.8s | +29.3% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2682.9% (worse) | **REGRESSED** |
| metrics | CPU_memory | 41.6GB | 51.7GB | +24.1% (worse) | **REGRESSED** |
