### PR TITLE
Finish packed batching activation for tilt-series workflows

### DIFF
--- a/recovar/heterogeneity/covariance_estimation.py
+++ b/recovar/heterogeneity/covariance_estimation.py
@@ -8,17 +8,16 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
-from recovar.utils.nvtx_shim import nvtx
 
 import recovar.core.forward as core_forward
 import recovar.core.fourier_transform_utils as fourier_transform_utils
-from recovar import core, utils, jax_config
-from recovar.core import linalg
-from recovar.jax_config import _to_cpu
-from recovar.core import cubic_interpolation
-from recovar.core.configs import ForwardModelConfig, ModelState, CovarianceOpts, CovColumnOpts
+from recovar import core, jax_config, utils
+from recovar.core import cubic_interpolation, linalg
+from recovar.core.configs import CovarianceOpts, CovColumnOpts, ForwardModelConfig, ModelState
 from recovar.heterogeneity import covariance_core
-from recovar.reconstruction import regularization, relion_functions, noise
+from recovar.jax_config import _to_cpu
+from recovar.reconstruction import noise, regularization, relion_functions
+from recovar.utils.nvtx_shim import nvtx
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +129,10 @@ def get_default_covariance_computation_options(grid_size=None, adaptive_n_pcs=Fa
         logger.info(
             "Adaptive n_pcs: using %s PCs for covariance computation "
             "(GPU memory: %.1f GB, grid_size: %s, estimated memory: %.1f GB)",
-            n_pcs, gpu_memory, grid_size, base_memory + basis_memory,
+            n_pcs,
+            gpu_memory,
+            grid_size,
+            base_memory + basis_memory,
         )
     else:
         n_pcs = 200
@@ -145,13 +147,17 @@ def get_default_covariance_computation_options(grid_size=None, adaptive_n_pcs=Fa
             logger.info(
                 "Using %s PCs for covariance computation "
                 "(GPU memory: %.1f GB, grid_size: %s, estimated memory: %.1f GB)",
-                n_pcs, gpu_memory, grid_size, total_memory_gb,
+                n_pcs,
+                gpu_memory,
+                grid_size,
+                total_memory_gb,
             )
             if total_memory_gb > gpu_memory * 0.8:
                 logger.warning(
                     "Estimated memory (%.1f GB) may exceed available GPU memory (%.1f GB). "
                     "If you get OOM errors, use --low-memory-option to adaptively reduce n_pcs.",
-                    total_memory_gb, gpu_memory,
+                    total_memory_gb,
+                    gpu_memory,
                 )
         else:
             logger.info("Using %s PCs for covariance computation (GPU memory: %.1f GB)", n_pcs, gpu_memory)
@@ -466,10 +472,10 @@ def variance_relion_kernel_trilinear(
     ctf_params,
     noise_variance,
     soften: int = 5,
-    Ft_y: jax.Array = None,
-    Ft_ctf: jax.Array = None,
-    Ft_im: jax.Array = None,
-    Ft_one: jax.Array = None,
+    Ft_y: jax.Array | None = None,
+    Ft_ctf: jax.Array | None = None,
+    Ft_im: jax.Array | None = None,
+    Ft_one: jax.Array | None = None,
 ):
     """Variance estimation via RELION-style trilinear kernel — Equinox API.
 
@@ -506,10 +512,10 @@ def _variance_relion_kernel_trilinear_explicit(
     volume_mask: jax.Array,
     image_mask: jax.Array,
     soften: int = 5,
-    Ft_y: jax.Array = None,
-    Ft_ctf: jax.Array = None,
-    Ft_im: jax.Array = None,
-    Ft_one: jax.Array = None,
+    Ft_y: jax.Array | None = None,
+    Ft_ctf: jax.Array | None = None,
+    Ft_im: jax.Array | None = None,
+    Ft_one: jax.Array | None = None,
 ):
     noise_variances = noise_variance
 
@@ -975,6 +981,7 @@ def compute_H_B_for_halfset(
             noise_half=False,
             noise_by_particle=True,
             by_image=not cryo.tilt_series_flag,
+            pack_groups=cryo.tilt_series_flag,
         )
         if halfset_id is not None:
             _iter_kw["halfset_id"] = halfset_id
@@ -1183,6 +1190,7 @@ def _compute_projected_covariance_single(
         noise_model=experiment_dataset.noise,
         noise_half=False,
         by_image=not experiment_dataset.tilt_series_flag,
+        pack_groups=experiment_dataset.tilt_series_flag,
     ):
         tilt_labels = None
         if experiment_dataset.tilt_series_flag:
@@ -1287,6 +1295,7 @@ def compute_projected_covariance(
             noise_half=False,
             halfset_id=halfset_id,
             by_image=not dataset.tilt_series_flag,
+            pack_groups=dataset.tilt_series_flag,
         ):
             tilt_labels = None
             if dataset.tilt_series_flag:
@@ -1444,10 +1453,12 @@ def _reduce_covariance_inner_explicit(
         )
 
     # Forward model basis vectors — use disc_type_u for eigenvectors
+    basis = model.basis
+    assert basis is not None
     config_u = config.replace(disc_type=opts.disc_type_u)
     AUs = covariance_core.batch_vol_forward_from_map(
         config_u,
-        model.basis,
+        basis,
         ctf_params,
         rotation_matrices,
         skip_ctf=config.premultiplied_ctf,
@@ -1648,8 +1659,8 @@ def compute_freq_batch(
     premultiplied_ctf: bool,
     shared_label: bool,
     no_mask: bool,
-    H_accum: jax.Array = None,
-    B_accum: jax.Array = None,
+    H_accum: jax.Array | None = None,
+    B_accum: jax.Array | None = None,
 ):
     """Compute H and B for a batch of frequencies in a single XLA program.
 

--- a/recovar/heterogeneity/embedding.py
+++ b/recovar/heterogeneity/embedding.py
@@ -1,21 +1,21 @@
 """Per-image latent coordinate estimation via linear projection."""
 
+import functools
 import logging
 import time
-import functools
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
-from recovar.utils.nvtx_shim import nvtx
 
 import recovar.core.forward as core_forward
 import recovar.core.fourier_transform_utils as ftu
 from recovar import core, jax_config, utils
 from recovar.core import linalg
-from recovar.core.configs import ForwardModelConfig, ModelState, EmbeddingOpts
+from recovar.core.configs import EmbeddingOpts, ForwardModelConfig, ModelState
 from recovar.heterogeneity import covariance_core
+from recovar.utils.nvtx_shim import nvtx
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +234,8 @@ def get_per_image_embedding(
         bias = bias.real
 
     return zs, cov_zs, est_contrasts, bias
+
+
 @nvtx.annotate("get_coords_in_basis_and_contrast", color="blue", domain=NVTX_DOMAIN_EMBED)
 def get_coords_in_basis_and_contrast_3(
     experiment_dataset,
@@ -316,8 +318,10 @@ def get_coords_in_basis_and_contrast_3(
         by_image=False,
         noise_model=noise_model,
         noise_half=prefer_half_noise,
-        # TODO(#45): enable pack_groups once compute_grouped_shared_batch_coords
-        # produces identical results to per-particle compute_batch_coords.
+        # For tilt series, pack multiple particles into each batch while
+        # preserving per-image particle ids so the grouped/shared-label solve
+        # remains numerically identical to the legacy per-particle loop.
+        pack_groups=shared_label,
     ):
         batch = jnp.asarray(batch)
         batch_image_ind = np.asarray(image_indices).reshape(-1)
@@ -331,12 +335,18 @@ def get_coords_in_basis_and_contrast_3(
             if contrast_shared_across_tilt_series:
                 # Batched solve for all particles at once.
                 xs_group, contrast_group, cov_group, bias_group = compute_grouped_shared_batch_coords(
-                    config, batch, model,
-                    experiment_dataset.image_mask, contrast_grid,
-                    contrast_mean, contrast_variance,
+                    config,
+                    batch,
+                    model,
+                    experiment_dataset.image_mask,
+                    contrast_grid,
+                    contrast_mean,
+                    contrast_variance,
                     jnp.asarray(particle_group_ids, dtype=jnp.int32),
                     int(unique_particles.size),
-                    compute_covariances, compute_bias, hermitian_weights,
+                    compute_covariances,
+                    compute_bias,
+                    hermitian_weights,
                     rotation_matrices=rotation_matrices,
                     translations=translations,
                     ctf_params=ctf_params,
@@ -352,11 +362,19 @@ def get_coords_in_basis_and_contrast_3(
                 # Per-image contrast: solve each particle separately.
                 for pid in unique_particles:
                     mask = particle_ids == pid
-                    local_nv = _noise_get_half_or_full(noise_model, batch_image_ind[mask], prefer_half=prefer_half_noise)
+                    local_nv = _noise_get_half_or_full(
+                        noise_model, batch_image_ind[mask], prefer_half=prefer_half_noise
+                    )
                     xs_single, contrast_single, cov_batch, bias_val = compute_batch_coords(
-                        config, batch[mask], model, opts,
-                        experiment_dataset.image_mask, contrast_grid,
-                        contrast_mean, contrast_variance, hermitian_weights,
+                        config,
+                        batch[mask],
+                        model,
+                        opts,
+                        experiment_dataset.image_mask,
+                        contrast_grid,
+                        contrast_mean,
+                        contrast_variance,
+                        hermitian_weights,
                         rotation_matrices=rotation_matrices[mask],
                         translations=translations[mask],
                         ctf_params=ctf_params[mask],
@@ -372,9 +390,15 @@ def get_coords_in_basis_and_contrast_3(
         else:
             # SPA: one solve per batch, results indexed by image or particle.
             xs_single, contrast_single, cov_batch, bias = compute_batch_coords(
-                config, batch, model, opts,
-                experiment_dataset.image_mask, contrast_grid,
-                contrast_mean, contrast_variance, hermitian_weights,
+                config,
+                batch,
+                model,
+                opts,
+                experiment_dataset.image_mask,
+                contrast_grid,
+                contrast_mean,
+                contrast_variance,
+                hermitian_weights,
                 rotation_matrices=rotation_matrices,
                 translations=translations,
                 ctf_params=ctf_params,
@@ -464,8 +488,11 @@ def _compute_batch_coords_p1(
             )
         batch = core.translate_images(batch, translations, config.image_shape)
 
+    basis = model.basis
+    assert basis is not None
+
     mean_half_volume = half and _mean_is_half_volume(model.mean_estimate, config.volume_shape)
-    basis_half_volume = half and _basis_is_half_volume(model.basis, config.volume_shape)
+    basis_half_volume = half and _basis_is_half_volume(basis, config.volume_shape)
     projected_mean = core_forward.forward_model(
         config,
         model.mean_estimate,
@@ -478,7 +505,7 @@ def _compute_batch_coords_p1(
     # AUs: (n_basis, n_images, n_pix[_half])
     AUs = covariance_core.batch_vol_forward_from_map(
         config,
-        model.basis,
+        basis,
         ctf_params,
         rotation_matrices,
         skip_ctf=config.premultiplied_ctf,
@@ -604,6 +631,7 @@ def _compute_batch_coords_explicit(
 ):
     contrast_grid = jnp.array(contrast_grid)
     eigenvalues = model.eigenvalues
+    assert eigenvalues is not None
 
     AU_t_images, AU_t_Amean, AU_t_AU, image_norms_sq, image_T_A_mean, A_mean_norm_sq = _compute_batch_coords_p1(
         config,
@@ -782,6 +810,7 @@ def _compute_grouped_shared_batch_coords_explicit(
     contrast_grid = jnp.asarray(contrast_grid)
     group_ids = jnp.asarray(group_ids, dtype=jnp.int32)
     eigenvalues = model.eigenvalues
+    assert eigenvalues is not None
 
     AU_t_images, AU_t_Amean, AU_t_AU, image_norms_sq, image_T_A_mean, A_mean_norm_sq = _compute_batch_coords_p1(
         config,

--- a/tests/unit/test_covariance_estimation.py
+++ b/tests/unit/test_covariance_estimation.py
@@ -1,19 +1,19 @@
 from types import SimpleNamespace
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
-
-pytest.importorskip("jax")
-
-import jax.numpy as jnp
-
-import recovar.heterogeneity.covariance_estimation as cov_est
-import recovar.core.fourier_transform_utils as fourier_transform_utils
-from recovar import core
-from recovar.core.configs import ForwardModelConfig
-from recovar.core.ctf import as_ctf_evaluator
-
 from helpers.tiny_synthetic import make_tiny_cryo_dataset, make_tiny_cryo_dataset_with_images
+
+import recovar.core.forward as core_forward
+import recovar.core.fourier_transform_utils as fourier_transform_utils
+import recovar.heterogeneity.covariance_estimation as cov_est
+from recovar import core
+from recovar.core import linalg
+from recovar.core.configs import CovarianceOpts, CovColumnOpts, ForwardModelConfig, ModelState
+from recovar.core.ctf import as_ctf_evaluator
+from recovar.heterogeneity import covariance_core
 
 pytestmark = pytest.mark.unit
 
@@ -493,6 +493,9 @@ def test_compute_h_b_for_halfset_preprocesses_tilt_labels_before_freq_kernel(mon
             return images
 
         def iter_batches(self, batch_size, **kwargs):
+            assert batch_size == 8
+            assert kwargs["by_image"] is False
+            assert kwargs["pack_groups"] is True
             yield (
                 np.zeros((3, 4), dtype=np.complex64),
                 np.zeros((3, 3, 3), dtype=np.float32),
@@ -648,8 +651,6 @@ def test_compute_h_b_runs_on_tiny_image_dataset():
 
 def test_compute_freq_batch_two_calls_accumulate():
     """Verify compute_freq_batch accumulates correctly across two calls."""
-    from recovar.core.configs import ForwardModelConfig, CovColumnOpts
-
     rng = np.random.RandomState(123)
     grid_size = 4
     n_images = 6
@@ -758,11 +759,184 @@ def test_compute_projected_covariance_runs_on_tiny_image_dataset():
     np.testing.assert_allclose(covar_np, covar_np.T, atol=1e-5, rtol=1e-5)
 
 
+def test_compute_projected_covariance_single_requests_packed_tilt_batches(monkeypatch):
+    seen_kwargs = []
+
+    class _FakeTiltDataset:
+        dtype = np.complex64
+        dtype_real = np.float32
+        tilt_series_flag = True
+        volume_shape = (2, 2, 1)
+        volume_size = 4
+        image_shape = (2, 2)
+        noise = object()
+        image_mask = np.ones((2, 2), dtype=np.float32)
+        halfset_indices = None
+
+        def process_images(self, images):
+            return images
+
+        def iter_batches(self, batch_size, **kwargs):
+            seen_kwargs.append(kwargs.copy())
+            assert batch_size == 6
+            assert kwargs["by_image"] is False
+            assert kwargs["pack_groups"] is True
+            yield (
+                np.zeros((3, 4), dtype=np.complex64),
+                np.zeros((3, 3, 3), dtype=np.float32),
+                np.zeros((3, 2), dtype=np.float32),
+                np.zeros((3, 9), dtype=np.float32),
+                np.zeros((3, 4), dtype=np.float32),
+                np.array([0, 0, 1], dtype=np.int32),
+                np.arange(3, dtype=np.int32),
+            )
+
+    config = SimpleNamespace(image_shape=(2, 2), volume_shape=(2, 2, 1))
+    monkeypatch.setattr(cov_est.ForwardModelConfig, "from_dataset", lambda *args, **kwargs: config)
+    monkeypatch.setattr(cov_est.linalg, "rfft2_hermitian_weights", lambda *args, **kwargs: jnp.ones((4,)))
+    monkeypatch.setattr(cov_est.utils, "report_memory_device", lambda *args, **kwargs: None)
+
+    def fake_reduce_covariance_inner(
+        config,
+        images,
+        model,
+        opts,
+        image_mask,
+        *,
+        rotation_matrices,
+        translations,
+        ctf_params,
+        noise_variance,
+        hermitian_weights,
+        lhs,
+        rhs,
+        tilt_labels,
+    ):
+        _ = (
+            config,
+            images,
+            model,
+            opts,
+            image_mask,
+            rotation_matrices,
+            translations,
+            ctf_params,
+            noise_variance,
+            hermitian_weights,
+            tilt_labels,
+        )
+        return lhs + jnp.eye(lhs.shape[0], dtype=lhs.dtype), rhs + jnp.eye(rhs.shape[0], dtype=rhs.dtype)
+
+    monkeypatch.setattr(cov_est, "reduce_covariance_inner", fake_reduce_covariance_inner)
+
+    covar = cov_est._compute_projected_covariance_single(
+        _FakeTiltDataset(),
+        mean_estimate=np.zeros(4, dtype=np.complex64),
+        basis=np.eye(4, 1, dtype=np.complex64),
+        volume_mask=np.ones((2, 2, 1), dtype=np.float32),
+        batch_size=6,
+        disc_type="linear_interp",
+        disc_type_u="linear_interp",
+        do_mask_images=False,
+    )
+
+    assert covar.shape == (1, 1)
+    assert len(seen_kwargs) == 1
+    assert seen_kwargs[0]["noise_half"] is False
+    assert seen_kwargs[0]["by_image"] is False
+    assert seen_kwargs[0]["pack_groups"] is True
+
+
+def test_compute_projected_covariance_halfsets_requests_packed_tilt_batches(monkeypatch):
+    seen_kwargs = []
+
+    class _FakeTiltHalfsetDataset:
+        dtype = np.complex64
+        dtype_real = np.float32
+        tilt_series_flag = True
+        volume_shape = (2, 2, 1)
+        volume_size = 4
+        image_shape = (2, 2)
+        noise = object()
+        image_mask = np.ones((2, 2), dtype=np.float32)
+        halfset_indices = [np.array([0], dtype=np.int32), np.array([1], dtype=np.int32)]
+
+        def process_images(self, images):
+            return images
+
+        def iter_batches(self, batch_size, **kwargs):
+            seen_kwargs.append(kwargs.copy())
+            assert batch_size == 6
+            assert kwargs["by_image"] is False
+            assert kwargs["pack_groups"] is True
+            yield (
+                np.zeros((3, 4), dtype=np.complex64),
+                np.zeros((3, 3, 3), dtype=np.float32),
+                np.zeros((3, 2), dtype=np.float32),
+                np.zeros((3, 9), dtype=np.float32),
+                np.zeros((3, 4), dtype=np.float32),
+                np.array([0, 0, 1], dtype=np.int32),
+                np.arange(3, dtype=np.int32),
+            )
+
+    config = SimpleNamespace(image_shape=(2, 2), volume_shape=(2, 2, 1))
+    monkeypatch.setattr(cov_est.ForwardModelConfig, "from_dataset", lambda *args, **kwargs: config)
+    monkeypatch.setattr(cov_est.linalg, "rfft2_hermitian_weights", lambda *args, **kwargs: jnp.ones((4,)))
+    monkeypatch.setattr(cov_est.utils, "report_memory_device", lambda *args, **kwargs: None)
+
+    def fake_reduce_covariance_inner(
+        config,
+        images,
+        model,
+        opts,
+        image_mask,
+        *,
+        rotation_matrices,
+        translations,
+        ctf_params,
+        noise_variance,
+        hermitian_weights,
+        lhs,
+        rhs,
+        tilt_labels,
+    ):
+        _ = (
+            config,
+            images,
+            model,
+            opts,
+            image_mask,
+            rotation_matrices,
+            translations,
+            ctf_params,
+            noise_variance,
+            hermitian_weights,
+            tilt_labels,
+        )
+        return lhs + jnp.eye(lhs.shape[0], dtype=lhs.dtype), rhs + jnp.eye(rhs.shape[0], dtype=rhs.dtype)
+
+    monkeypatch.setattr(cov_est, "reduce_covariance_inner", fake_reduce_covariance_inner)
+
+    covar = cov_est.compute_projected_covariance(
+        dataset=_FakeTiltHalfsetDataset(),
+        mean_estimate=np.zeros(4, dtype=np.complex64),
+        basis=np.eye(4, 1, dtype=np.complex64),
+        volume_mask=np.ones((2, 2, 1), dtype=np.float32),
+        batch_size=6,
+        disc_type="linear_interp",
+        disc_type_u="linear_interp",
+        do_mask_images=False,
+    )
+
+    assert covar.shape == (1, 1)
+    assert len(seen_kwargs) == 2
+    assert {kwargs["halfset_id"] for kwargs in seen_kwargs} == {0, 1}
+    assert all(kwargs["pack_groups"] is True for kwargs in seen_kwargs)
+
+
 # ---------------------------------------------------------------------------
 # GPU tests – verify CPU/GPU numerical equivalence
 # ---------------------------------------------------------------------------
-
-import jax
 
 
 @pytest.mark.gpu
@@ -1140,11 +1314,6 @@ def test_variance_kernel_accumulator_f64(enable_x64):
 # ---------------------------------------------------------------------------
 # Tests for half-image masking in reduce_covariance_inner
 # ---------------------------------------------------------------------------
-
-from recovar.heterogeneity import covariance_core
-from recovar.core import linalg
-from recovar.core.configs import ModelState, CovarianceOpts
-import recovar.core.forward as core_forward
 
 
 def _make_reduce_cov_fixtures(grid_size=4, n_images=6, seed=0):

--- a/tests/unit/test_dataset_tiny_io.py
+++ b/tests/unit/test_dataset_tiny_io.py
@@ -1,13 +1,17 @@
-import numpy as np
-import pytest
 from pathlib import Path
 from types import SimpleNamespace
+
+import numpy as np
+import pytest
 
 pytest.importorskip("jax")
 
 from helpers import tiny_synthetic
+
 from recovar import core, utils
-from recovar.data_io import cryoem_dataset as dataset, halfsets, starfile, image_backends as cryo_dataset
+from recovar.data_io import cryoem_dataset as dataset
+from recovar.data_io import halfsets, starfile
+from recovar.data_io import image_backends as cryo_dataset
 
 pytestmark = pytest.mark.unit
 
@@ -54,6 +58,16 @@ def _batch_images(batch):
 
 def _batch_particle_indices(batch):
     return np.asarray(batch[5]).reshape(-1)
+
+
+def _batch_particle_ids_per_image(batch):
+    particle_indices = _batch_particle_indices(batch)
+    n_images = int(_batch_images(batch).shape[0])
+    if particle_indices.size == n_images:
+        return particle_indices
+    if particle_indices.size == 1:
+        return np.full(n_images, particle_indices[0], dtype=particle_indices.dtype)
+    raise ValueError(f"Unexpected particle index layout {particle_indices.shape} for {n_images} images")
 
 
 def _batch_image_indices(batch):
@@ -1140,6 +1154,52 @@ def test_tiny_tilt_particle_subset_generator_preserves_duplicates(tmp_path):
     batches = _dataset_group_batches(cryo, batch_size=8, subset_indices=subset_particles)
     got_particles = [int(_batch_particle_indices(batch)[0]) for batch in batches]
     assert got_particles == [2, 0, 2]
+
+
+def test_simulator_tiny_tilt_packed_group_batches_preserve_flattened_order(sim_tiny_tilt_files):
+    files = sim_tiny_tilt_files
+    datadir = str(Path(files["particles_star"]).parent)
+    cryo = dataset.load_dataset(
+        particles_file=files["particles_star"],
+        poses_file=files["poses_pkl"],
+        ctf_file=files["ctf_pkl"],
+        datadir=datadir,
+        lazy=True,
+        tilt_series=True,
+        tilt_series_ctf="relion5",
+    )
+
+    subset_particles = np.array([2, 0, 2], dtype=np.int32)
+    unpacked_batches = list(
+        cryo.iter_batches(
+            batch_size=6,
+            indices=subset_particles,
+            by_image=False,
+            prefetch=False,
+            pack_groups=False,
+        )
+    )
+    packed_batches = list(
+        cryo.iter_batches(
+            batch_size=6,
+            indices=subset_particles,
+            by_image=False,
+            prefetch=False,
+            pack_groups=True,
+        )
+    )
+
+    unpacked_images = np.concatenate([_batch_images(batch) for batch in unpacked_batches], axis=0)
+    packed_images = np.concatenate([_batch_images(batch) for batch in packed_batches], axis=0)
+    unpacked_particles = np.concatenate([_batch_particle_ids_per_image(batch) for batch in unpacked_batches], axis=0)
+    packed_particles = np.concatenate([_batch_particle_ids_per_image(batch) for batch in packed_batches], axis=0)
+    unpacked_indices = np.concatenate([_batch_image_indices(batch) for batch in unpacked_batches], axis=0)
+    packed_indices = np.concatenate([_batch_image_indices(batch) for batch in packed_batches], axis=0)
+
+    np.testing.assert_allclose(packed_images, unpacked_images, atol=1e-6)
+    np.testing.assert_array_equal(packed_particles, unpacked_particles)
+    np.testing.assert_array_equal(packed_indices, unpacked_indices)
+    assert [int(np.asarray(batch[0]).shape[0]) for batch in packed_batches] == [6, 3]
 
 
 def test_tiny_tilt_split_indices_accepts_in_memory_halfsets_and_arrays(tmp_path):

--- a/tests/unit/test_embedding.py
+++ b/tests/unit/test_embedding.py
@@ -1,13 +1,13 @@
 from types import SimpleNamespace
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
+from helpers import tiny_synthetic
 
-jax = pytest.importorskip("jax")
-import jax.numpy as jnp
-
+from recovar.core.configs import EmbeddingOpts, ForwardModelConfig, ModelState
 from recovar.heterogeneity import embedding
-from recovar.core.configs import ForwardModelConfig, ModelState, EmbeddingOpts
 
 pytestmark = pytest.mark.unit
 
@@ -103,9 +103,6 @@ def test_generate_conformation_from_reprojection_linear_combination():
 # ---------------------------------------------------------------------------
 # GPU tests – verify CPU/GPU numerical equivalence
 # ---------------------------------------------------------------------------
-
-import jax
-import jax.numpy as jnp
 
 
 @pytest.mark.gpu
@@ -414,7 +411,8 @@ def test_get_coords_shared_label_splits_mixed_particle_batches(monkeypatch):
             return self.image_source.process_images(batch, apply_image_mask=apply_image_mask)
 
         def iter_batches(self, batch_size, **kwargs):
-            _ = (batch_size, kwargs)
+            assert batch_size == 8
+            assert kwargs["pack_groups"] is True
             batch = np.zeros((4, 16), dtype=np.complex64)
             particles_ind = np.array([0, 0, 1, 1], dtype=np.int32)
             batch_image_ind = np.array([0, 1, 2, 3], dtype=np.int32)
@@ -529,7 +527,8 @@ def test_get_coords_shared_label_grouped_shared_contrast(monkeypatch):
             return self.image_source.process_images(batch, apply_image_mask=apply_image_mask)
 
         def iter_batches(self, batch_size, **kwargs):
-            _ = (batch_size, kwargs)
+            assert batch_size == 8
+            assert kwargs["pack_groups"] is True
             batch = np.zeros((4, 16), dtype=np.complex64)
             particles_ind = np.array([0, 0, 1, 1], dtype=np.int32)
             batch_image_ind = np.array([0, 1, 2, 3], dtype=np.int32)
@@ -581,6 +580,110 @@ def test_get_coords_shared_label_grouped_shared_contrast(monkeypatch):
     np.testing.assert_allclose(contrasts, np.array([11.0, 12.0], dtype=np.float32))
     np.testing.assert_allclose(cov, np.stack([np.eye(2), 2 * np.eye(2)], axis=0))
     assert bias is None
+
+
+def test_compute_grouped_shared_batch_coords_matches_per_particle_loop():
+    cryo = tiny_synthetic.make_tiny_cryo_dataset_with_images(grid_size=4, n_images=4, seed=0)
+    config = ForwardModelConfig.from_dataset(
+        cryo,
+        disc_type="linear_interp",
+        process_fn=cryo.image_source.process_images,
+    )
+
+    mean_estimate = jnp.zeros((cryo.volume_size,), dtype=cryo.dtype)
+    basis = jnp.asarray(
+        np.stack(
+            [
+                np.linspace(0.1, 1.0, cryo.volume_size, dtype=np.float32),
+                np.linspace(1.0, 0.2, cryo.volume_size, dtype=np.float32),
+            ],
+            axis=0,
+        ).astype(np.complex64)
+    )
+    mean_estimate, basis = embedding._prepare_model_half_volumes(config, mean_estimate, basis)
+    model = ModelState(
+        mean_estimate=mean_estimate,
+        volume_mask=jnp.ones(cryo.volume_shape, dtype=cryo.dtype_real),
+        basis=basis,
+        eigenvalues=jnp.array([1.0, 2.0], dtype=cryo.dtype_real),
+    )
+
+    batch, rotation_matrices, translations, ctf_params, noise_variance, _particles_ind, _image_indices = next(
+        cryo.iter_batches(
+            batch_size=4,
+            by_image=True,
+            noise_model=cryo.noise,
+            noise_half=True,
+            prefetch=False,
+        )
+    )
+    group_ids = np.array([0, 0, 1, 1], dtype=np.int32)
+    contrast_grid = jnp.array([0.5, 1.0, 1.5], dtype=cryo.dtype_real)
+    image_mask = jnp.asarray(cryo.image_mask, dtype=cryo.dtype_real)
+    hermitian_weights = embedding._embedding_hermitian_weights(config)
+    opts = EmbeddingOpts(
+        compute_covariances=True,
+        compute_bias=True,
+        shared_label=True,
+        contrast_shared_across_tilt_series=True,
+    )
+
+    with jax.disable_jit():
+        grouped_xs, grouped_contrast, grouped_cov, grouped_bias = embedding.compute_grouped_shared_batch_coords(
+            config,
+            jnp.asarray(batch),
+            model,
+            image_mask,
+            contrast_grid,
+            1.0,
+            np.inf,
+            jnp.asarray(group_ids, dtype=jnp.int32),
+            2,
+            True,
+            True,
+            hermitian_weights,
+            rotation_matrices=jnp.asarray(rotation_matrices),
+            translations=jnp.asarray(translations),
+            ctf_params=jnp.asarray(ctf_params),
+            noise_variance=jnp.asarray(noise_variance),
+        )
+
+        ref_xs = []
+        ref_contrast = []
+        ref_cov = []
+        ref_bias = []
+        for gid in range(2):
+            mask = group_ids == gid
+            batch_data = _make_batch_fields(
+                images=jnp.asarray(batch)[mask],
+                rotation_matrices=jnp.asarray(rotation_matrices)[mask],
+                translations=jnp.asarray(translations)[mask],
+                ctf_params=jnp.asarray(ctf_params)[mask],
+                noise_variance=jnp.asarray(noise_variance)[mask],
+            )
+            xs, contrast, cov, bias = _call_compute_batch_coords(
+                config,
+                batch_data,
+                model,
+                opts,
+                image_mask,
+                contrast_grid,
+                hermitian_weights=hermitian_weights,
+            )
+            ref_xs.append(np.asarray(xs))
+            ref_contrast.append(np.asarray(contrast))
+            ref_cov.append(np.asarray(cov))
+            ref_bias.append(np.asarray(bias))
+
+    np.testing.assert_allclose(np.asarray(grouped_xs), np.concatenate(ref_xs, axis=0), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(
+        np.asarray(grouped_contrast),
+        np.concatenate(ref_contrast, axis=0),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    np.testing.assert_allclose(np.asarray(grouped_cov), np.concatenate(ref_cov, axis=0), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(np.asarray(grouped_bias), np.concatenate(ref_bias, axis=0), rtol=1e-5, atol=1e-5)
 
 
 def test_get_coords_spa_indexes_outputs_by_image_id_not_particle_id(monkeypatch):


### PR DESCRIPTION
## Summary

Finish the grouped tilt-series batching work from #41 by enabling packed grouped batches in the tilt-series embedding and projected-covariance paths.


- **Enable `pack_groups` for tilt-series embedding** so grouped loaders are actually used at the consumer call site
- **Enable `pack_groups` for projected covariance** so the grouped path is active there as well
- **Add equivalence tests** showing packed grouped batches preserve flattened image order and match the legacy per-particle numerical path
- **Keep behavior intended to be identical**; this is a batching activation / performance cleanup, not a science retune


## Test Results (Slurm jobs 6675055-6675065)

Full GPU/integration/regression bundle finished with one known failing group:

- outliers-long: 4 tests total, 1 failing regression
- indices: 2/2 PASS
- smoke-tiny: 13/13 PASS
- metrics-et/spa: PASS
- stress: 2/2 PASS
- downstream: 14/14 PASS
- unit: 2409/2409 PASS

Summary job: `6675065`

## Regression Tables

### SPA Quality
| Metric | Baseline | Current | Change | Status |
| -------- | -------- | -------- | -------- | -------- |
| contrast_abs_error_10 | 0.026187 | 0.026233 | +0.2% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025941 | -1.2% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026108 | +0.4% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.026086 | -0.1% (better) | OK |
| embedding_squared_error_10 | 1.9783 | 1.9533 | -1.3% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.383406 | +1.0% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980249 | 0.0% (same) | OK |
| noise_max_relative_error | 2.1122 | 2.1146 | +0.1% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049130 | -3.7% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005747 | -3.6% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.478753 | +4.0% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.475380 | +5.2% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality
| Metric | Baseline | Current | Change | Status |
| -------- | -------- | -------- | -------- | -------- |
| contrast_abs_error_10 | 0.024244 | 0.024061 | -0.8% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024054 | -0.8% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023828 | -0.8% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023806 | -0.9% (better) | OK |
| embedding_squared_error_10 | 1.4603 | 1.4106 | -3.4% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.201454 | -5.9% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.1% (better) | OK |
| noise_max_relative_error | 2.1528 | 2.1406 | -0.6% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049609 | -4.3% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005677 | -0.4% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.640359 | +0.9% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.638378 | +0.9% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### PDB Trajectory Quality
| Metric | Baseline | Current | Change | Status |
| -------- | -------- | -------- | -------- | -------- |
| embedding_squared_error_10 | 9.9890 | 1.9532 | -80.4% (better) | OK |
| embedding_squared_error_4 | 3.9957 | 0.383001 | -90.4% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.972851 | 0.980249 | +0.8% (better) | OK |
| noise_max_relative_error | 2.4805 | 2.1146 | -14.7% (better) | OK |
| noise_mean_relative_error | 0.057155 | 0.049131 | -14.0% (better) | OK |
| noise_median_relative_error | 0.006100 | 0.005747 | -5.8% (better) | OK |
| variance_fsc | 0.003700 | 0.233456 | +6208.9% (better) | OK |

### SPA Outlier Quality
| Metric | Baseline | Current | Change | Status |
| -------- | -------- | -------- | -------- | -------- |
| inlier_count_round_1 | 7908 | 8355 | +5.7% (higher) | OK |
| inlier_count_round_2 | 5266 | 7147 | +35.7% (higher) | OK |
| outlier_count_round_1 | 2092 | 1645 | -21.4% (lower) | OK |
| outlier_count_round_2 | 4734 | 2853 | -39.7% (lower) | OK |
| outlier_f1_round_1 | 0.833519 | 0.948808 | +13.8% (better) | OK |
| outlier_f1_round_2 | 0.481232 | 0.688720 | +43.1% (better) | OK |
| outlier_precision_round_1 | 0.715583 | 0.906991 | +26.7% (better) | OK |
| outlier_precision_round_2 | 0.316857 | 0.525412 | +65.8% (better) | OK |
| outlier_recall_round_1 | 0.998000 | 0.994667 | -0.3% (worse) | OK |
| outlier_recall_round_2 | 1.0 | 0.999333 | -0.1% (worse) | OK |
| total_images | 10000 | 10000 | 0.0% (same) | OK |
| true_outlier_count | 1500 | 1500 | 0.0% (same) | OK |

### Cryo-ET Outlier Quality
| Metric | Baseline | Current | Change | Status |
| -------- | -------- | -------- | -------- | -------- |
| inlier_count_round_1 | 7695 | 7794 | +1.3% (higher) | OK |
| inlier_count_round_2 | 3275 | 2991 | -8.7% (lower) | OK |
| outlier_count_round_1 | 2305 | 2206 | -4.3% (lower) | OK |
| outlier_count_round_2 | 6725 | 7009 | +4.2% (higher) | OK |
| outlier_f1_round_1 | 0.858400 | 0.874890 | +1.9% (better) | OK |
| outlier_f1_round_2 | 0.504900 | 0.491506 | -2.7% (worse) | OK |
| outlier_precision_round_1 | 0.866800 | 0.903445 | +4.2% (better) | OK |
| outlier_precision_round_2 | 0.340700 | 0.328150 | -3.7% (worse) | OK |
| outlier_recall_round_1 | 0.850200 | 0.848085 | -0.2% (worse) | OK |
| outlier_recall_round_2 | 0.974900 | 0.978723 | +0.4% (better) | OK |
| particle_f1_round_1 | 0.841200 | 0.882700 | +4.9% (better) | OK |
| particle_f1_round_2 | 0.275500 | 0.263600 | -4.3% (worse) | OK |
| particle_inlier_count_round_1 | 1232 | 1248 | +1.3% (higher) | OK |
| particle_inlier_count_round_2 | 534.0 | 487.0 | -8.8% (lower) | OK |
| particle_outlier_count_round_1 | 197.0 | 181.0 | -8.1% (lower) | OK |
| particle_outlier_count_round_2 | 895.0 | 942.0 | +5.3% (higher) | OK |
| particle_precision_round_1 | 0.725900 | 0.790100 | +8.8% (better) | OK |
| particle_precision_round_2 | 0.159800 | 0.151800 | -5.0% (worse) | FAIL |
| particle_recall_round_1 | 1.0 | 1.0 | 0.0% (same) | OK |
| particle_recall_round_2 | 1.0 | 1.0 | 0.0% (same) | OK |
| total_images | 10000 | 10000 | 0.0% (same) | OK |
| total_particles | 1429 | 1429 | 0.0% (same) | OK |
| true_outlier_count | 2350 | 2350 | 0.0% (same) | OK |
| true_particle_outlier_count | 143.0 | 143.0 | 0.0% (same) | OK |

### SPA Performance
| Stage | Metric | Baseline | Current | Change | Status |
| -------- | -------- | -------- | -------- | -------- | -------- |
| dataset_generation | wall_time | 139.9s | 141.6s | +1.1% (worse) | OK |
| dataset_generation | GPU_memory | 4.9GB | 4.9GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.0GB | 5.3GB | +6.5% (worse) | OK |
| pipeline | wall_time | 824.2s | 761.1s | -7.7% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 39.1GB | 40.8GB | +4.3% (worse) | OK |
| compute_state | wall_time | 246.1s | 210.0s | -14.7% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 0.2GB | 0.0% (same) | OK |
| compute_state | CPU_memory | 42.7GB | 44.9GB | +5.1% (worse) | OK |
| metrics | wall_time | 37.5s | 37.2s | -0.9% (better) | OK |
| metrics | GPU_memory | 0.1GB | 0.1GB | 0.0% (same) | OK |
| metrics | CPU_memory | 47.2GB | 49.6GB | +5.0% (worse) | OK |

### Cryo-ET Performance
| Stage | Metric | Baseline | Current | Change | Status |
| -------- | -------- | -------- | -------- | -------- | -------- |
| dataset_generation | wall_time | 128.5s | 140.2s | +9.1% (worse) | OK |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.1GB | 5.3GB | +5.3% (worse) | OK |
| pipeline | wall_time | 1886.7s | 953.4s | -49.5% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 38.1GB | 41.4GB | +8.6% (worse) | OK |
| compute_state | wall_time | 145.9s | 207.4s | +42.1% (worse) | **REGRESSED** |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 38.2GB | 45.3GB | +18.7% (worse) | **REGRESSED** |
| metrics | wall_time | 19.9s | 26.1s | +30.9% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2694.7% (worse) | **REGRESSED** |
| metrics | CPU_memory | 41.6GB | 50.0GB | +20.1% (worse) | **REGRESSED** |

### Outlier / Trajectory Performance
| Suite | Stage | Metric | Baseline | Current | Change | Status |
| -------- | -------- | -------- | -------- | -------- | -------- | -------- |
| SPA outlier pipeline | pipeline_with_outliers | GPU_memory | 0.1GB | 74.4GB | +63498.0% (worse) | **REGRESSED** |
| PDB trajectory | pdb_trajectory | GPU_memory | 0.5GB | 77.7GB | +17012.0% (worse) | **REGRESSED** |

These suites currently only emit warning-level perf comparisons, so the table above is the full available perf output for them.

**Note**: `outliers-long` still fails on the recurring cryo-ET outlier regression: `particle_precision_round_2` is `0.1518` vs `0.1598` baseline (`-5.0% (worse)`).

Refs #28