### PR TITLE
Fix projected covariance layout handling regressions

### DIFF
--- a/recovar/em/heterogeneity.py
+++ b/recovar/em/heterogeneity.py
@@ -612,8 +612,9 @@ def compute_projected_covariance_rhs_lhs(
 
     rotation_batch = max(1, rotations.shape[0] // 10)
 
+    packed_lhs_dim = covariance_estimation._symmetric_matrix_packed_size(basis_size)
     memory_left_over_after_kron_allocate = utils.get_gpu_memory_total() - (
-        2 * basis_size**4 * 8 / 1e9 + utils.get_size_in_gb(mean_projections[:rotation_batch]) * (1 + basis_size**2)
+        2 * packed_lhs_dim**2 * 8 / 1e9 + utils.get_size_in_gb(mean_projections[:rotation_batch]) * (1 + basis_size**2)
     )
     # Divide by translations to account for per-translation memory in inner loop
     batch_size = utils.safe_batch_size(
@@ -786,7 +787,8 @@ def estimate_principal_components_simple(
     basis_size = 3
     basis = basis[:, :basis_size]
 
-    memory_left_over_after_kron_allocate = utils.get_gpu_memory_total() - 2 * basis_size**4 * 8 / 1e9
+    packed_lhs_dim = covariance_estimation._symmetric_matrix_packed_size(basis_size)
+    memory_left_over_after_kron_allocate = utils.get_gpu_memory_total() - 2 * packed_lhs_dim**2 * 8 / 1e9
     batch_size = utils.get_embedding_batch_size(
         basis, experiment_dataset.image_size, np.ones(1), basis_size, memory_left_over_after_kron_allocate
     )
@@ -899,7 +901,8 @@ def estimate_principal_components_halfset(
         )
 
         basis_size = cov_cols[cryo_idx].shape[0]
-        memory_left_over_after_kron_allocate = utils.get_gpu_memory_total() - 2 * basis_size**4 * 8 / 1e9
+        packed_lhs_dim = covariance_estimation._symmetric_matrix_packed_size(basis_size)
+        memory_left_over_after_kron_allocate = utils.get_gpu_memory_total() - 2 * packed_lhs_dim**2 * 8 / 1e9
         batch_size = utils.get_embedding_batch_size(
             orthog_cov_cols, cryo.image_size, np.ones(1), basis_size, memory_left_over_after_kron_allocate
         )

--- a/recovar/heterogeneity/covariance_estimation.py
+++ b/recovar/heterogeneity/covariance_estimation.py
@@ -1650,34 +1650,25 @@ def summed_batch_kron_scan(X):
     return summed_kron
 
 
-def _solve_projected_covariance_system(lhs, rhs, reg_scales=(1e-6, 1e-5, 1e-4, 1e-3)):
-    """Solve the projected-covariance normal equations with adaptive Tikhonov regularization."""
+def _solve_projected_covariance_system(lhs, rhs, reg_scale=1e-6):
+    """Solve the projected-covariance normal equations and fail on non-finite output."""
     rhs = _vec_square_matrix(rhs)
     trace_val = jnp.trace(lhs)
     trace_val = jnp.where(jnp.isfinite(trace_val) & (trace_val > 0), trace_val, jnp.float32(1.0))
     diag_idx = jnp.arange(lhs.shape[0])
-
-    last_covar = None
-    for reg_scale in reg_scales:
-        reg = jnp.asarray(reg_scale, dtype=lhs.dtype) * trace_val / lhs.shape[0]
-        lhs_reg = lhs.at[diag_idx, diag_idx].add(reg)
-        covar = jax.scipy.linalg.solve(lhs_reg, rhs, assume_a="pos")
-        covar = _unvec_square_matrix(covar)
-        if np.isfinite(np.asarray(covar)).all():
-            if reg_scale != reg_scales[0]:
-                logger.warning(
-                    "Projected covariance solve required stronger regularization (scale=%s) to avoid non-finite output.",
-                    reg_scale,
-                )
-            return covar
-
-        logger.warning(
-            "Projected covariance solve produced non-finite output with regularization scale %s; retrying.",
-            reg_scale,
+    reg = jnp.asarray(reg_scale, dtype=lhs.dtype) * trace_val / lhs.shape[0]
+    lhs_reg = lhs.at[diag_idx, diag_idx].add(reg)
+    covar = jax.scipy.linalg.solve(lhs_reg, rhs, assume_a="pos")
+    covar = _unvec_square_matrix(covar)
+    covar_np = np.asarray(covar)
+    if not np.isfinite(covar_np).all():
+        n_nan = int(np.isnan(covar_np).sum())
+        n_inf = int(np.isinf(covar_np).sum())
+        raise ValueError(
+            "projected covariance solve returned non-finite output after "
+            f"regularization scale {reg_scale}: {n_nan} NaN, {n_inf} Inf"
         )
-        last_covar = covar
-
-    return last_covar
+    return covar
 
 
 batch_x_T_y = jax.vmap(lambda x, y: jnp.conj(x).T @ y, in_axes=(0, 0))

--- a/recovar/heterogeneity/covariance_estimation.py
+++ b/recovar/heterogeneity/covariance_estimation.py
@@ -1113,6 +1113,92 @@ def compute_covariance_regularization_relion_style(
 _batch_calculate_spline_coefficients = jax.vmap(
     cubic_interpolation.calculate_spline_coefficients, in_axes=0, out_axes=0
 )
+_batch_half_volume_to_full_volume = jax.vmap(
+    fourier_transform_utils.half_volume_to_full_volume, in_axes=(0, None), out_axes=0
+)
+
+
+def _volume_layout_sizes(volume_shape):
+    full_size = int(np.prod(volume_shape))
+    half_size = int(np.prod(fourier_transform_utils.volume_shape_to_half_volume_shape(volume_shape)))
+    return full_size, half_size
+
+
+def _mean_is_half_volume(mean_estimate, volume_shape):
+    _, half_size = _volume_layout_sizes(volume_shape)
+    return int(np.prod(mean_estimate.shape)) == half_size
+
+
+def _basis_is_half_volume(basis, volume_shape):
+    _, half_size = _volume_layout_sizes(volume_shape)
+    if basis is None or basis.ndim < 1:
+        return False
+    per_vec_size = int(np.prod(basis.shape[1:])) if basis.shape[0] != 0 else 0
+    return per_vec_size == half_size
+
+
+def _convert_half_volumes_to_full_in_batch(volumes, volume_shape, gpu_memory=None):
+    gpu_memory = utils.get_gpu_memory_total() if gpu_memory is None else gpu_memory
+    vol_batch_size = utils.safe_batch_size(utils.get_vol_batch_size(volume_shape[0], gpu_memory=gpu_memory))
+    logger.info(
+        "memory used = %s, vol_batch_size in convert_half_volumes_to_full_in_batch %s",
+        gpu_memory,
+        vol_batch_size,
+    )
+    utils.report_memory_device(logger=logger)
+
+    half_shape = fourier_transform_utils.volume_shape_to_half_volume_shape(volume_shape)
+    volumes_4d = jnp.asarray(volumes).reshape(-1, *half_shape)
+    if volumes_4d.shape[0] == 0:
+        return np.empty((0, *volume_shape), dtype=np.asarray(volumes).dtype)
+
+    full = []
+    for k in range(0, volumes_4d.shape[0], vol_batch_size):
+        full_block = _batch_half_volume_to_full_volume(volumes_4d[k : k + vol_batch_size], volume_shape)
+        full.append(np.asarray(full_block))
+    return np.concatenate(full, axis=0).reshape(volumes_4d.shape[0], -1)
+
+
+def _prepare_model_half_volumes(volume_shape, mean_estimate, basis, mean_disc_type, basis_disc_type, gpu_memory=None):
+    """Normalize model layouts for projected covariance.
+
+    Preserve the caller's existing full-vs-half layout whenever the downstream
+    interpolation path can consume it directly. Cubic interpolation needs full
+    grids, so packed half-volumes must be expanded before use.
+    """
+    full_size, half_size = _volume_layout_sizes(volume_shape)
+
+    mean_size = int(np.prod(mean_estimate.shape))
+    if mean_disc_type == "cubic":
+        if mean_size == half_size:
+            mean_estimate = fourier_transform_utils.half_volume_to_full_volume(
+                mean_estimate.reshape(fourier_transform_utils.volume_shape_to_half_volume_shape(volume_shape)),
+                volume_shape,
+            ).reshape(-1)
+    elif mean_size not in (full_size, half_size):
+        logger.warning(
+            "Unexpected mean_estimate size %d for volume_shape %s; expected %d (full) or %d (half).",
+            mean_size,
+            volume_shape,
+            full_size,
+            half_size,
+        )
+
+    if basis is not None and basis.ndim >= 1 and basis.shape[0] > 0:
+        basis_size = int(np.prod(basis.shape[1:]))
+        if basis_disc_type == "cubic":
+            if basis_size == half_size:
+                basis = _convert_half_volumes_to_full_in_batch(basis, volume_shape, gpu_memory=gpu_memory)
+        elif basis_size not in (full_size, half_size):
+            logger.warning(
+                "Unexpected basis vector size %d for volume_shape %s; expected %d (full) or %d (half).",
+                basis_size,
+                volume_shape,
+                full_size,
+                half_size,
+            )
+
+    return mean_estimate, basis
 
 
 @nvtx.annotate("compute_spline_coeffs_in_batch", color="magenta")
@@ -1166,6 +1252,14 @@ def _compute_projected_covariance_single(
     if disc_type_u == "cubic":
         basis = compute_spline_coeffs_in_batch(basis, experiment_dataset.volume_shape, gpu_memory=None)
 
+    mean_estimate, basis = _prepare_model_half_volumes(
+        experiment_dataset.volume_shape,
+        mean_estimate,
+        basis,
+        mean_disc_type=disc_type,
+        basis_disc_type=disc_type_u,
+    )
+
     config = ForwardModelConfig.from_dataset(
         experiment_dataset,
         disc_type=disc_type,
@@ -1216,16 +1310,7 @@ def _compute_projected_covariance_single(
 
     logger.info("end of covariance computation - before solve")
     utils.report_memory_device(logger=logger)
-    rhs = _vec_square_matrix(rhs)
-
-    trace_val = jnp.trace(lhs)
-    trace_val = jnp.where(jnp.isfinite(trace_val) & (trace_val > 0), trace_val, jnp.float32(1.0))
-    reg = jnp.float32(1e-6) * trace_val / lhs.shape[0]
-    diag_idx = jnp.arange(lhs.shape[0])
-    lhs = lhs.at[diag_idx, diag_idx].add(reg)
-
-    covar = jax.scipy.linalg.solve(lhs, rhs, assume_a="pos")
-    covar = _unvec_square_matrix(covar)
+    covar = _solve_projected_covariance_system(lhs, rhs)
     logger.info("end of solve")
     return covar
 
@@ -1261,6 +1346,14 @@ def compute_projected_covariance(
 
     if disc_type_u == "cubic":
         basis = compute_spline_coeffs_in_batch(basis, dataset.volume_shape, gpu_memory=None)
+
+    mean_estimate, basis = _prepare_model_half_volumes(
+        dataset.volume_shape,
+        mean_estimate,
+        basis,
+        mean_disc_type=disc_type,
+        basis_disc_type=disc_type_u,
+    )
 
     for halfset_id in range(2):
         config = ForwardModelConfig.from_dataset(
@@ -1322,18 +1415,7 @@ def compute_projected_covariance(
 
     logger.info("end of covariance computation - before solve")
     utils.report_memory_device(logger=logger)
-    rhs = _vec_square_matrix(rhs)
-
-    # Tikhonov regularization: prevents NaN from near-singular LHS
-    # (can happen when n_images is small relative to basis_size)
-    trace_val = jnp.trace(lhs)
-    trace_val = jnp.where(jnp.isfinite(trace_val) & (trace_val > 0), trace_val, jnp.float32(1.0))
-    reg = jnp.float32(1e-6) * trace_val / lhs.shape[0]
-    diag_idx = jnp.arange(lhs.shape[0])
-    lhs = lhs.at[diag_idx, diag_idx].add(reg)
-
-    covar = jax.scipy.linalg.solve(lhs, rhs, assume_a="pos")
-    covar = _unvec_square_matrix(covar)
+    covar = _solve_projected_covariance_system(lhs, rhs)
     logger.info("end of solve")
 
     return covar
@@ -1437,13 +1519,15 @@ def _reduce_covariance_inner_explicit(
     else:
         batch = core.translate_images(batch, translations, config.image_shape)
 
+    mean_half_volume = _mean_is_half_volume(model.mean_estimate, config.volume_shape)
+    basis_half_volume = _basis_is_half_volume(model.basis, config.volume_shape)
     projected_mean = core_forward.forward_model(
         config,
         model.mean_estimate,
         ctf_params,
         rotation_matrices,
         half_image=_use_half_proj,
-        half_volume=False,
+        half_volume=mean_half_volume,
     )
 
     if do_mask_images:
@@ -1463,7 +1547,7 @@ def _reduce_covariance_inner_explicit(
         rotation_matrices,
         skip_ctf=config.premultiplied_ctf,
         half_image=_use_half_proj,
-        half_volume=False,
+        half_volume=basis_half_volume,
     )
 
     if do_mask_images:
@@ -1537,8 +1621,8 @@ def _reduce_covariance_inner_explicit(
         per_image_outer = AU_t_images[:, :, None] * jnp.conj(AU_t_images[:, None, :])
         rhs_batch = (per_image_outer - per_image_noise_bias).sum(axis=0).real.astype(ctf_params.dtype)
 
-    # Kron product via einsum — avoids materialising (n_images, n²,n²) tensor.
     _n = AU_t_AU.shape[-1]
+    # Kron product via einsum — avoids materialising (n_images, n²,n²) tensor.
     lhs_batch = jnp.einsum("bik,bjl->ijkl", AU_t_AU, AU_t_AU).reshape(_n * _n, _n * _n)
     if lhs is not None:
         lhs_batch = lhs_batch + lhs
@@ -1564,6 +1648,36 @@ def summed_batch_kron_scan(X):
 
     summed_kron = jax.lax.fori_loop(0, X.shape[0], fori_loop_body, init)
     return summed_kron
+
+
+def _solve_projected_covariance_system(lhs, rhs, reg_scales=(1e-6, 1e-5, 1e-4, 1e-3)):
+    """Solve the projected-covariance normal equations with adaptive Tikhonov regularization."""
+    rhs = _vec_square_matrix(rhs)
+    trace_val = jnp.trace(lhs)
+    trace_val = jnp.where(jnp.isfinite(trace_val) & (trace_val > 0), trace_val, jnp.float32(1.0))
+    diag_idx = jnp.arange(lhs.shape[0])
+
+    last_covar = None
+    for reg_scale in reg_scales:
+        reg = jnp.asarray(reg_scale, dtype=lhs.dtype) * trace_val / lhs.shape[0]
+        lhs_reg = lhs.at[diag_idx, diag_idx].add(reg)
+        covar = jax.scipy.linalg.solve(lhs_reg, rhs, assume_a="pos")
+        covar = _unvec_square_matrix(covar)
+        if np.isfinite(np.asarray(covar)).all():
+            if reg_scale != reg_scales[0]:
+                logger.warning(
+                    "Projected covariance solve required stronger regularization (scale=%s) to avoid non-finite output.",
+                    reg_scale,
+                )
+            return covar
+
+        logger.warning(
+            "Projected covariance solve produced non-finite output with regularization scale %s; retrying.",
+            reg_scale,
+        )
+        last_covar = covar
+
+    return last_covar
 
 
 batch_x_T_y = jax.vmap(lambda x, y: jnp.conj(x).T @ y, in_axes=(0, 0))

--- a/recovar/heterogeneity/covariance_estimation.py
+++ b/recovar/heterogeneity/covariance_estimation.py
@@ -927,6 +927,70 @@ def _unvec_square_matrix(vector):
     return vector.reshape(n, n).T
 
 
+def _symmetric_matrix_packed_size(n):
+    return n * (n + 1) // 2
+
+
+def _packed_symmetric_matrix_size_to_full(packed_size):
+    n = int((np.sqrt(8 * packed_size + 1) - 1) // 2)
+    if _symmetric_matrix_packed_size(n) != packed_size:
+        raise ValueError(f"packed_size={packed_size} is not a valid symmetric-matrix packed size")
+    return n
+
+
+@functools.lru_cache(maxsize=None)
+def _symmetric_packed_metadata(n):
+    row_idx, col_idx = np.triu_indices(n)
+    offdiag = row_idx != col_idx
+    scales = np.where(offdiag, np.sqrt(2.0), 1.0)
+    return row_idx.astype(np.int32), col_idx.astype(np.int32), offdiag, scales
+
+
+def _symmetric_packed_metadata_jax(n, dtype):
+    row_idx, col_idx, offdiag, scales = _symmetric_packed_metadata(n)
+    return (
+        jnp.asarray(row_idx),
+        jnp.asarray(col_idx),
+        jnp.asarray(offdiag),
+        jnp.asarray(scales, dtype=dtype),
+    )
+
+
+def _pack_symmetric_matrix_svec(matrix):
+    n = matrix.shape[-1]
+    row_idx, col_idx, _, scales = _symmetric_packed_metadata_jax(n, matrix.dtype)
+    return matrix[..., row_idx, col_idx] * scales
+
+
+def _unpack_symmetric_matrix_svec(vector):
+    n = _packed_symmetric_matrix_size_to_full(vector.shape[-1])
+    row_idx, col_idx, _, scales = _symmetric_packed_metadata_jax(n, vector.dtype)
+    values = vector / scales
+    matrix = jnp.zeros((*vector.shape[:-1], n, n), dtype=vector.dtype)
+    matrix = matrix.at[..., row_idx, col_idx].set(values)
+    matrix = matrix.at[..., col_idx, row_idx].set(values)
+    return matrix
+
+
+def _projected_covariance_dense_lhs_batch(AU_t_AU):
+    n_basis = AU_t_AU.shape[-1]
+    return jnp.einsum("bik,bjl->ijkl", AU_t_AU, AU_t_AU).reshape(n_basis * n_basis, n_basis * n_basis)
+
+
+def _projected_covariance_packed_lhs_batch(AU_t_AU):
+    n_basis = AU_t_AU.shape[-1]
+    row_idx, col_idx, offdiag, scales = _symmetric_packed_metadata_jax(n_basis, AU_t_AU.dtype)
+
+    lhs_rows = AU_t_AU[:, row_idx, :]
+    lhs_cols = AU_t_AU[:, col_idx, :]
+    cross_terms = jnp.einsum("bpk,bpl->pkl", lhs_rows, lhs_cols)
+
+    packed_lhs = cross_terms[:, row_idx, col_idx]
+    packed_lhs = packed_lhs + offdiag.astype(AU_t_AU.dtype)[None, :] * cross_terms[:, col_idx, row_idx]
+    packed_lhs = packed_lhs * (scales[:, None] / scales[None, :])
+    return packed_lhs
+
+
 @nvtx.annotate("compute_H_B_for_halfset", color="blue", domain=NVTX_DOMAIN_H_B)
 def compute_H_B_for_halfset(
     cryo, mean_estimate, volume_mask, picked_frequencies, gpu_memory, options, image_subset=None, halfset_id=None
@@ -1240,7 +1304,7 @@ def _compute_projected_covariance_single(
     mean_estimate = jnp.asarray(mean_estimate, dtype=experiment_dataset.dtype)
 
     n_basis = basis.shape[0]
-    lhs_size = n_basis * n_basis
+    lhs_size = _symmetric_matrix_packed_size(n_basis)
     lhs = jnp.zeros((lhs_size, lhs_size), dtype=experiment_dataset.dtype_real)
     rhs = jnp.zeros((n_basis, n_basis), dtype=experiment_dataset.dtype_real)
     logger.info("batch size in compute_projected_covariance %s", batch_size)
@@ -1336,7 +1400,7 @@ def compute_projected_covariance(
     mean_estimate = jnp.asarray(mean_estimate, dtype=dataset.dtype)
 
     n_basis = basis.shape[0]  # basis is (n_pcs, vol_size) after .T
-    lhs_size = n_basis * n_basis
+    lhs_size = _symmetric_matrix_packed_size(n_basis)
     lhs = jnp.zeros((lhs_size, lhs_size), dtype=dataset.dtype_real)
     rhs = jnp.zeros((n_basis, n_basis), dtype=dataset.dtype_real)
     logger.info("batch size in compute_projected_covariance %s", batch_size)
@@ -1621,9 +1685,7 @@ def _reduce_covariance_inner_explicit(
         per_image_outer = AU_t_images[:, :, None] * jnp.conj(AU_t_images[:, None, :])
         rhs_batch = (per_image_outer - per_image_noise_bias).sum(axis=0).real.astype(ctf_params.dtype)
 
-    _n = AU_t_AU.shape[-1]
-    # Kron product via einsum — avoids materialising (n_images, n²,n²) tensor.
-    lhs_batch = jnp.einsum("bik,bjl->ijkl", AU_t_AU, AU_t_AU).reshape(_n * _n, _n * _n)
+    lhs_batch = _projected_covariance_packed_lhs_batch(AU_t_AU)
     if lhs is not None:
         lhs_batch = lhs_batch + lhs
     if rhs is not None:
@@ -1650,16 +1712,15 @@ def summed_batch_kron_scan(X):
     return summed_kron
 
 
-def _solve_projected_covariance_system(lhs, rhs, reg_scale=1e-6):
-    """Solve the projected-covariance normal equations and fail on non-finite output."""
-    rhs = _vec_square_matrix(rhs)
+def _regularize_projected_covariance_lhs(lhs, reg_scale):
     trace_val = jnp.trace(lhs)
     trace_val = jnp.where(jnp.isfinite(trace_val) & (trace_val > 0), trace_val, jnp.float32(1.0))
     diag_idx = jnp.arange(lhs.shape[0])
     reg = jnp.asarray(reg_scale, dtype=lhs.dtype) * trace_val / lhs.shape[0]
-    lhs_reg = lhs.at[diag_idx, diag_idx].add(reg)
-    covar = jax.scipy.linalg.solve(lhs_reg, rhs, assume_a="pos")
-    covar = _unvec_square_matrix(covar)
+    return lhs.at[diag_idx, diag_idx].add(reg)
+
+
+def _raise_on_nonfinite_projected_covariance(covar, reg_scale):
     covar_np = np.asarray(covar)
     if not np.isfinite(covar_np).all():
         n_nan = int(np.isnan(covar_np).sum())
@@ -1669,6 +1730,39 @@ def _solve_projected_covariance_system(lhs, rhs, reg_scale=1e-6):
             f"regularization scale {reg_scale}: {n_nan} NaN, {n_inf} Inf"
         )
     return covar
+
+
+def _solve_projected_covariance_system_dense(lhs, rhs, reg_scale=1e-6):
+    rhs = _vec_square_matrix(rhs)
+    lhs_reg = _regularize_projected_covariance_lhs(lhs, reg_scale)
+    covar = jax.scipy.linalg.solve(lhs_reg, rhs, assume_a="pos")
+    covar = _unvec_square_matrix(covar)
+    _raise_on_nonfinite_projected_covariance(covar, reg_scale)
+    return covar
+
+
+def _solve_projected_covariance_system_packed(lhs, rhs, reg_scale=1e-6):
+    rhs = _pack_symmetric_matrix_svec(rhs)
+    lhs_reg = _regularize_projected_covariance_lhs(lhs, reg_scale)
+    covar = jax.scipy.linalg.solve(lhs_reg, rhs, assume_a="pos")
+    covar = _unpack_symmetric_matrix_svec(covar)
+    _raise_on_nonfinite_projected_covariance(covar, reg_scale)
+    return covar
+
+
+def _solve_projected_covariance_system(lhs, rhs, reg_scale=1e-6):
+    """Solve the projected-covariance normal equations and fail on non-finite output."""
+    n_basis = rhs.shape[-1]
+    packed_dim = _symmetric_matrix_packed_size(n_basis)
+    full_dim = n_basis * n_basis
+    if lhs.shape == (packed_dim, packed_dim):
+        return _solve_projected_covariance_system_packed(lhs, rhs, reg_scale=reg_scale)
+    if lhs.shape == (full_dim, full_dim):
+        return _solve_projected_covariance_system_dense(lhs, rhs, reg_scale=reg_scale)
+    raise ValueError(
+        "projected covariance lhs has incompatible shape "
+        f"{lhs.shape} for rhs shape {rhs.shape}; expected {(packed_dim, packed_dim)} or {(full_dim, full_dim)}"
+    )
 
 
 batch_x_T_y = jax.vmap(lambda x, y: jnp.conj(x).T @ y, in_axes=(0, 0))

--- a/recovar/heterogeneity/principal_components.py
+++ b/recovar/heterogeneity/principal_components.py
@@ -278,7 +278,8 @@ def get_cov_svds(
 
 def _projected_covariance_batch_size(basis, image_size, basis_size, gpu_memory_to_use):
     available_gpu_memory = utils.get_gpu_memory_total() if gpu_memory_to_use is None else gpu_memory_to_use
-    memory_left_over_after_kron_allocate = available_gpu_memory - 2 * basis_size**4 * 8 / 1e9
+    lhs_dim = covariance_estimation._symmetric_matrix_packed_size(basis_size)
+    memory_left_over_after_kron_allocate = available_gpu_memory - 2 * lhs_dim**2 * 8 / 1e9
     batch_size = utils.get_embedding_batch_size(
         basis,
         image_size,

--- a/tests/unit/test_covariance_estimation.py
+++ b/tests/unit/test_covariance_estimation.py
@@ -1565,6 +1565,78 @@ def test_reduce_covariance_inner_masked_vs_unmasked_differ():
     assert np.all(np.isfinite(np.asarray(rhs_no)))
 
 
+def test_reduce_covariance_inner_uses_half_volume_for_half_volume_model(monkeypatch):
+    config, batch_data, model_half, _, hermitian_weights, image_mask = _make_reduce_cov_fixtures()
+    opts = CovarianceOpts(disc_type_u="linear_interp", do_mask_images=False)
+
+    n_images = batch_data.images.shape[0]
+    n_basis = model_half.basis.shape[0]
+    half_image_size = int(np.prod(fourier_transform_utils.image_shape_to_half_image_shape(config.image_shape)))
+    seen = {"mean_half_volume": False, "basis_half_volume": False}
+
+    def fake_forward_model(
+        config,
+        volume,
+        ctf_params,
+        rotation_matrices,
+        skip_ctf=False,
+        half_image=False,
+        half_volume=False,
+    ):
+        seen["mean_half_volume"] = half_volume
+        n_pixels = half_image_size if half_image else int(np.prod(config.image_shape))
+        return jnp.zeros((n_images, n_pixels), dtype=jnp.complex64)
+
+    def fake_batch_vol_forward_from_map(
+        config,
+        volumes,
+        ctf_params,
+        rotation_matrices,
+        skip_ctf=False,
+        half_image=False,
+        half_volume=False,
+    ):
+        seen["basis_half_volume"] = half_volume
+        n_pixels = half_image_size if half_image else int(np.prod(config.image_shape))
+        return jnp.zeros((n_basis, n_images, n_pixels), dtype=jnp.complex64)
+
+    monkeypatch.setattr(core_forward, "forward_model", fake_forward_model)
+    monkeypatch.setattr(covariance_core, "batch_vol_forward_from_map", fake_batch_vol_forward_from_map)
+
+    _call_reduce_covariance_inner(
+        config,
+        batch_data,
+        model_half,
+        opts,
+        image_mask,
+        hermitian_weights=hermitian_weights,
+    )
+
+    assert seen["mean_half_volume"] is True
+    assert seen["basis_half_volume"] is True
+
+def test_solve_projected_covariance_system_retries_stronger_regularization(monkeypatch):
+    calls = []
+
+    def fake_solve(lhs, rhs, assume_a="pos"):
+        calls.append(float(np.asarray(lhs)[0, 0]))
+        if len(calls) < 4:
+            return jnp.full(rhs.shape, jnp.nan, dtype=rhs.dtype)
+        return jnp.arange(rhs.shape[0], dtype=rhs.dtype)
+
+    monkeypatch.setattr(cov_est.jax.scipy.linalg, "solve", fake_solve)
+
+    lhs = jnp.eye(4, dtype=jnp.float32)
+    rhs = jnp.arange(4, dtype=jnp.float32).reshape(2, 2)
+
+    covar = np.asarray(cov_est._solve_projected_covariance_system(lhs, rhs))
+    expected = np.asarray(cov_est._unvec_square_matrix(jnp.arange(4, dtype=jnp.float32)))
+
+    assert len(calls) == 4
+    assert np.all(np.diff(calls) > 0)
+    np.testing.assert_allclose(covar, expected)
+
+
 def test_compute_projected_covariance_masked():
     """compute_projected_covariance with do_mask_images=True completes and returns valid result."""
     cryo = make_tiny_cryo_dataset_with_images(grid_size=4, n_images=6, seed=0)
@@ -1614,6 +1686,147 @@ def test_compute_projected_covariance_masked_matches_unmasked_with_ones_mask():
         # With an all-ones mask the results should be close but not identical
         # because the mask→project→threshold cycle introduces small differences.
         np.testing.assert_allclose(covar_masked, covar_unmasked, atol=0.5, rtol=0.5)
+
+
+def test_compute_projected_covariance_preserves_full_volume_model_layout(monkeypatch):
+    cryo = make_tiny_cryo_dataset_with_images(grid_size=6, n_images=6, seed=0)
+    basis = np.eye(cryo.volume_size, 3, dtype=np.complex64)
+    seen = {}
+
+    def fake_reduce_covariance_inner(
+        config,
+        images,
+        model,
+        opts,
+        image_mask,
+        rotation_matrices,
+        translations,
+        ctf_params,
+        noise_variance,
+        hermitian_weights=None,
+        lhs=None,
+        rhs=None,
+        tilt_labels=None,
+    ):
+        seen["mean_size"] = int(np.prod(model.mean_estimate.shape))
+        seen["basis_size"] = int(np.prod(model.basis.shape[1:]))
+        return lhs, rhs
+
+    monkeypatch.setattr(cov_est, "reduce_covariance_inner", fake_reduce_covariance_inner)
+
+    covar = cov_est.compute_projected_covariance(
+        dataset=[cryo],
+        mean_estimate=np.zeros(cryo.volume_size, dtype=np.complex64),
+        basis=basis,
+        volume_mask=np.ones(cryo.volume_shape, dtype=np.float32),
+        batch_size=3,
+        disc_type="linear_interp",
+        disc_type_u="linear_interp",
+        do_mask_images=False,
+    )
+
+    assert seen["mean_size"] == cryo.volume_size
+    assert seen["basis_size"] == cryo.volume_size
+    np.testing.assert_allclose(np.asarray(covar), np.zeros((3, 3), dtype=np.float32), atol=1e-7, rtol=1e-7)
+
+
+def test_prepare_model_half_volumes_keeps_cubic_coefficients_full():
+    cryo = make_tiny_cryo_dataset_with_images(grid_size=6, n_images=6, seed=0)
+    half_shape = fourier_transform_utils.volume_shape_to_half_volume_shape(cryo.volume_shape)
+    half_size = int(np.prod(half_shape))
+
+    mean_half = np.arange(half_size, dtype=np.float32).astype(np.complex64)
+    basis_half = np.arange(3 * half_size, dtype=np.float32).reshape(3, half_size).astype(np.complex64)
+
+    mean_full, basis_full = cov_est._prepare_model_half_volumes(
+        cryo.volume_shape,
+        mean_half,
+        basis_half,
+        mean_disc_type="cubic",
+        basis_disc_type="cubic",
+    )
+
+    expected_mean = np.asarray(
+        fourier_transform_utils.half_volume_to_full_volume(mean_half.reshape(half_shape), cryo.volume_shape)
+    ).reshape(-1)
+    expected_basis = np.stack(
+        [
+            np.asarray(fourier_transform_utils.half_volume_to_full_volume(vec.reshape(half_shape), cryo.volume_shape)).reshape(
+                -1
+            )
+            for vec in basis_half
+        ],
+        axis=0,
+    )
+
+    assert mean_full.shape == (cryo.volume_size,)
+    assert basis_full.shape == (3, cryo.volume_size)
+    np.testing.assert_allclose(np.asarray(mean_full), expected_mean, atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(basis_full), expected_basis, atol=1e-6, rtol=1e-6)
+
+
+def test_prepare_model_half_volumes_preserves_linear_full_layout():
+    cryo = make_tiny_cryo_dataset_with_images(grid_size=6, n_images=6, seed=0)
+    rng = np.random.default_rng(0)
+    mean = (rng.standard_normal(cryo.volume_size) + 1j * rng.standard_normal(cryo.volume_size)).astype(np.complex64)
+    basis = (
+        rng.standard_normal((4, cryo.volume_size)) + 1j * rng.standard_normal((4, cryo.volume_size))
+    ).astype(np.complex64)
+
+    mean_out, basis_out = cov_est._prepare_model_half_volumes(
+        cryo.volume_shape,
+        mean,
+        basis,
+        mean_disc_type="linear_interp",
+        basis_disc_type="linear_interp",
+    )
+
+    np.testing.assert_allclose(np.asarray(mean_out), mean, atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(basis_out), basis, atol=1e-6, rtol=1e-6)
+
+
+def test_compute_projected_covariance_preserves_packed_half_volume_model_layout(monkeypatch):
+    cryo = make_tiny_cryo_dataset_with_images(grid_size=6, n_images=6, seed=0)
+    half_size = int(np.prod(fourier_transform_utils.volume_shape_to_half_volume_shape(cryo.volume_shape)))
+    mean_half = np.zeros(half_size, dtype=np.complex64)
+    basis_half = np.zeros((half_size, 3), dtype=np.complex64)
+    seen = {}
+
+    def fake_reduce_covariance_inner(
+        config,
+        images,
+        model,
+        opts,
+        image_mask,
+        rotation_matrices,
+        translations,
+        ctf_params,
+        noise_variance,
+        hermitian_weights=None,
+        lhs=None,
+        rhs=None,
+        tilt_labels=None,
+    ):
+        seen["mean_size"] = int(np.prod(model.mean_estimate.shape))
+        seen["basis_size"] = int(np.prod(model.basis.shape[1:]))
+        return lhs, rhs
+
+    monkeypatch.setattr(cov_est, "reduce_covariance_inner", fake_reduce_covariance_inner)
+
+    covar = cov_est.compute_projected_covariance(
+        dataset=[cryo],
+        mean_estimate=mean_half,
+        basis=basis_half,
+        volume_mask=np.ones(cryo.volume_shape, dtype=np.float32),
+        batch_size=3,
+        disc_type="linear_interp",
+        disc_type_u="linear_interp",
+        do_mask_images=False,
+    )
+
+    assert seen["mean_size"] == half_size
+    assert seen["basis_size"] == half_size
+    np.testing.assert_allclose(np.asarray(covar), np.zeros((3, 3), dtype=np.float32), atol=1e-7, rtol=1e-7)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_covariance_estimation.py
+++ b/tests/unit/test_covariance_estimation.py
@@ -1615,26 +1615,17 @@ def test_reduce_covariance_inner_uses_half_volume_for_half_volume_model(monkeypa
     assert seen["mean_half_volume"] is True
     assert seen["basis_half_volume"] is True
 
-def test_solve_projected_covariance_system_retries_stronger_regularization(monkeypatch):
-    calls = []
-
+def test_solve_projected_covariance_system_raises_on_nonfinite_output(monkeypatch):
     def fake_solve(lhs, rhs, assume_a="pos"):
-        calls.append(float(np.asarray(lhs)[0, 0]))
-        if len(calls) < 4:
-            return jnp.full(rhs.shape, jnp.nan, dtype=rhs.dtype)
-        return jnp.arange(rhs.shape[0], dtype=rhs.dtype)
+        return jnp.full(rhs.shape, jnp.nan, dtype=rhs.dtype)
 
     monkeypatch.setattr(cov_est.jax.scipy.linalg, "solve", fake_solve)
 
     lhs = jnp.eye(4, dtype=jnp.float32)
     rhs = jnp.arange(4, dtype=jnp.float32).reshape(2, 2)
 
-    covar = np.asarray(cov_est._solve_projected_covariance_system(lhs, rhs))
-    expected = np.asarray(cov_est._unvec_square_matrix(jnp.arange(4, dtype=jnp.float32)))
-
-    assert len(calls) == 4
-    assert np.all(np.diff(calls) > 0)
-    np.testing.assert_allclose(covar, expected)
+    with pytest.raises(ValueError, match="projected covariance solve returned non-finite output"):
+        cov_est._solve_projected_covariance_system(lhs, rhs)
 
 
 def test_compute_projected_covariance_masked():

--- a/tests/unit/test_covariance_estimation.py
+++ b/tests/unit/test_covariance_estimation.py
@@ -380,6 +380,65 @@ def test_summed_batch_kron_matches_scan():
     np.testing.assert_allclose(np.asarray(out1), np.asarray(out2), atol=1e-6, rtol=1e-6)
 
 
+def _dense_lhs_to_packed_reference(lhs_dense, n_basis):
+    packed_dim = cov_est._symmetric_matrix_packed_size(n_basis)
+    packed_eye = np.eye(packed_dim, dtype=np.asarray(lhs_dense).dtype)
+    packed_cols = []
+    for idx in range(packed_dim):
+        basis_matrix = cov_est._unpack_symmetric_matrix_svec(jnp.asarray(packed_eye[idx]))
+        dense_col = np.asarray(lhs_dense) @ np.asarray(cov_est._vec_square_matrix(basis_matrix))
+        packed_cols.append(
+            np.asarray(cov_est._pack_symmetric_matrix_svec(cov_est._unvec_square_matrix(jnp.asarray(dense_col))))
+        )
+    return np.stack(packed_cols, axis=1)
+
+
+def test_pack_symmetric_matrix_svec_round_trip():
+    matrix = np.array(
+        [
+            [1.0, 2.0, -1.0],
+            [2.0, 3.5, 0.25],
+            [-1.0, 0.25, 4.0],
+        ],
+        dtype=np.float32,
+    )
+
+    packed = cov_est._pack_symmetric_matrix_svec(jnp.asarray(matrix))
+    unpacked = cov_est._unpack_symmetric_matrix_svec(packed)
+
+    np.testing.assert_allclose(np.asarray(unpacked), matrix, atol=1e-6, rtol=1e-6)
+
+
+def test_projected_covariance_packed_lhs_matches_dense_reference():
+    rng = np.random.default_rng(0)
+    AU_t_AU = rng.standard_normal((4, 3, 3)).astype(np.float32)
+    AU_t_AU = 0.5 * (AU_t_AU + np.swapaxes(AU_t_AU, -1, -2))
+
+    lhs_dense = cov_est._projected_covariance_dense_lhs_batch(jnp.asarray(AU_t_AU))
+    lhs_packed = cov_est._projected_covariance_packed_lhs_batch(jnp.asarray(AU_t_AU))
+    lhs_packed_ref = _dense_lhs_to_packed_reference(lhs_dense, n_basis=3)
+
+    np.testing.assert_allclose(np.asarray(lhs_packed), lhs_packed_ref, atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(lhs_packed), np.asarray(lhs_packed).T, atol=1e-6, rtol=1e-6)
+
+
+def test_solve_projected_covariance_system_packed_matches_dense():
+    rng = np.random.default_rng(1)
+    AU_features = rng.standard_normal((5, 4, 7)).astype(np.float64)
+    AU_t_AU = np.einsum("bik,bjk->bij", AU_features, AU_features)
+    cov_true = rng.standard_normal((4, 4)).astype(np.float64)
+    cov_true = 0.5 * (cov_true + cov_true.T)
+
+    lhs_dense = cov_est._projected_covariance_dense_lhs_batch(jnp.asarray(AU_t_AU))
+    lhs_packed = cov_est._projected_covariance_packed_lhs_batch(jnp.asarray(AU_t_AU))
+    rhs = cov_est._unvec_square_matrix(lhs_dense @ cov_est._vec_square_matrix(jnp.asarray(cov_true)))
+
+    dense_sol = cov_est._solve_projected_covariance_system_dense(lhs_dense, rhs)
+    packed_sol = cov_est._solve_projected_covariance_system_packed(lhs_packed, rhs)
+
+    np.testing.assert_allclose(np.asarray(packed_sol), np.asarray(dense_sol), atol=1e-6, rtol=1e-6)
+
+
 def test_summed_outer_products_matches_manual():
     a = jnp.array([[1 + 1j, 2 + 0j], [3 + 0j, 4 - 1j]], dtype=jnp.complex64)
     out = cov_est.summed_outer_products(a)
@@ -1621,7 +1680,7 @@ def test_solve_projected_covariance_system_raises_on_nonfinite_output(monkeypatc
 
     monkeypatch.setattr(cov_est.jax.scipy.linalg, "solve", fake_solve)
 
-    lhs = jnp.eye(4, dtype=jnp.float32)
+    lhs = jnp.eye(cov_est._symmetric_matrix_packed_size(2), dtype=jnp.float32)
     rhs = jnp.arange(4, dtype=jnp.float32).reshape(2, 2)
 
     with pytest.raises(ValueError, match="projected covariance solve returned non-finite output"):

--- a/tests/unit/test_principal_components.py
+++ b/tests/unit/test_principal_components.py
@@ -200,7 +200,8 @@ def test_projected_covariance_batch_size_uses_requested_gpu_budget(monkeypatch):
     assert calls["basis_shape"] == basis.shape
     assert calls["image_size"] == 16
     assert calls["zdim"] == 3
-    expected_budget = 8.0 - 2 * 3**4 * 8 / 1e9
+    lhs_dim = pc.covariance_estimation._symmetric_matrix_packed_size(3)
+    expected_budget = 8.0 - 2 * lhs_dim**2 * 8 / 1e9
     assert calls["gpu_memory"] == pytest.approx(expected_budget)
 
 

--- a/tests/unit/test_principal_components.py
+++ b/tests/unit/test_principal_components.py
@@ -511,6 +511,31 @@ def test_pca_by_projected_covariance_real_tiny_dataset_runs():
     np.testing.assert_allclose(gram, np.eye(2), atol=5e-4, rtol=5e-4)
 
 
+def test_pca_by_projected_covariance_cubic_mean_tiny_dataset_runs():
+    cryo = make_tiny_cryo_dataset_with_images(grid_size=6, n_images=6, seed=0)
+    basis = np.eye(cryo.volume_size, 4, dtype=np.complex64)
+
+    u, s = pc.pca_by_projected_covariance(
+        dataset=cryo,
+        basis=basis,
+        mean=np.zeros(cryo.volume_size, dtype=np.complex64),
+        volume_mask=np.ones(cryo.volume_shape, dtype=np.float32),
+        disc_type="cubic",
+        disc_type_u="linear_interp",
+        gpu_memory_to_use=8,
+        use_mask=False,
+        n_pcs_to_compute=2,
+    )
+
+    assert u.shape == (cryo.volume_size, 2)
+    assert s.shape == (2,)
+    assert np.isfinite(s).all()
+    assert np.all(s >= pc.jax_config.EPSILON)
+    assert np.all(s[:-1] >= s[1:])
+    u_np = np.asarray(u)
+    assert np.isfinite(u_np).all()
+
+
 # ---------------------------------------------------------------------------
 # GPU tests – verify CPU/GPU numerical equivalence
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve existing projected-covariance full-vs-half model layout, and forward packed half-volume mean/basis tensors when the forward model can consume them
- fail fast on non-finite projected-covariance solves instead of silently escalating regularization
- replace the dense `n^2 x n^2` projected-covariance LHS with a symmetric packed system over `n(n+1)/2` coordinates, so the code computes and stores only the lower-triangular degrees of freedom
- update projected-covariance batch-size memory accounting and add dense-vs-packed equivalence coverage for the packed operator and solve paths

Closes #96
Closes #40

## Validation
- Rebased on `origin/dev` before validation; `origin/dev` was unchanged when re-fetched before pushing this update
- Passing full suite: `./scripts/run_tests_parallel.sh long-test`
- Group jobs: `6762235 6762236 6762237 6762238 6762239 6762240 6762241 6762242 6762243 6762244`
- Summary job: `6762245`
- Summary log: `/scratch/gpfs/GILLES/mg6942/recovar_dev/recovar_codex_issue96_40_regfix_20260407_131700/logs/recovar-summary-6762245.out`

## Packed LHS Benchmark
Synthetic local-A100 benchmark for the projected-covariance accumulation/solve stage only, using `1000` synthetic images in `32`-image batches and `150` PCs.

- dense operator: `22500 x 22500` = `2,025,000,000` bytes
- packed operator: `11325 x 11325` = `513,022,500` bytes
- storage reduction: `3.95x`
- accumulation median: `0.264s` dense vs `0.135s` packed (`1.96x` faster)
- solve median: `0.249s` dense vs `0.053s` packed (`4.66x` faster)
- accumulation + solve median: `0.513s` dense vs `0.188s` packed (`2.73x` faster)
- max abs diff between dense and packed solves: `1.148e-11`
- benchmark log: `/scratch/gpfs/GILLES/mg6942/recovar_dev/recovar_codex_issue96_40_regfix_20260407_131700/logs/projected-covariance-lhs-benchmark-local-gpu2-n150-img1000-20260409_133811.json`

## Performance Warnings
The extracted long-test tables below still flag baseline regressions in SPA dataset generation/pipeline/metrics and cryo-ET compute_state/metrics. Those warnings remain visible in the PR body rather than being hidden.

## Regression Tables

### SPA Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.026187 | 0.026248 | +0.23% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025931 | -1.21% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026066 | +0.26% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.026005 | -0.37% (better) | OK |
| embedding_squared_error_10 | 1.978306 | 1.951357 | -1.36% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.380530 | +0.22% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980249 | +0.04% (better) | OK |
| noise_max_relative_error | 2.112245 | 2.114649 | +0.11% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049131 | -3.69% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005747 | -3.60% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.478821 | +3.99% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.475438 | +5.24% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.024244 | 0.024056 | -0.78% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024055 | -0.83% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023825 | -0.83% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023805 | -0.90% (better) | OK |
| embedding_squared_error_10 | 1.460294 | 1.410662 | -3.40% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.201453 | -5.90% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.06% (better) | OK |
| noise_max_relative_error | 2.152798 | 2.140589 | -0.57% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049609 | -4.26% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005677 | -0.36% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.640345 | +0.92% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.638368 | +0.91% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### SPA Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 136.2s | 150.7s | +10.7% (worse) | **REGRESSED** |
| dataset_generation | GPU_memory | 4.9GB | 4.9GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.3GB | 5.4GB | +1.8% (worse) | OK |
| pipeline | wall_time | 578.5s | 756.6s | +30.8% (worse) | **REGRESSED** |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 42.7GB | 41.2GB | -3.5% (better) | OK |
| compute_state | wall_time | 317.3s | 225.3s | -29.0% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 0.3GB | +7.2% (worse) | OK |
| compute_state | CPU_memory | 46.7GB | 44.9GB | -4.0% (better) | OK |
| metrics | wall_time | 20.8s | 35.8s | +72.1% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 0.1GB | +65.8% (worse) | **REGRESSED** |
| metrics | CPU_memory | 50.7GB | 49.6GB | -2.1% (better) | OK |

### Cryo-ET Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 128.5s | 140.0s | +8.9% (worse) | OK |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.1GB | 5.4GB | +6.7% (worse) | OK |
| pipeline | wall_time | 1886.7s | 930.1s | -50.7% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 38.1GB | 40.4GB | +6.1% (worse) | OK |
| compute_state | wall_time | 145.9s | 208.8s | +43.1% (worse) | **REGRESSED** |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 38.2GB | 44.3GB | +16.1% (worse) | **REGRESSED** |
| metrics | wall_time | 19.9s | 27.8s | +39.5% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2694.7% (worse) | **REGRESSED** |
| metrics | CPU_memory | 41.6GB | 48.5GB | +16.5% (worse) | **REGRESSED** |

