### PR TITLE
Issue 34: align pickle readers with NumPy-native formats

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include recovar/trajectory/_fast_marching_native.cpp
+include recovar/cuda/Makefile
+include recovar/cuda/cuda_backproject.cu
 include setup_helpers.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,12 @@ Issues = "https://github.com/ma-gilles/recovar/issues"
 where = ["."]
 include = ["recovar*"]
 
+[tool.setuptools.package-data]
+recovar = [
+    "cuda/Makefile",
+    "cuda/cuda_backproject.cu",
+]
+
 [tool.setuptools_scm]
 write_to = "recovar/_version.py"
 local_scheme = "no-local-version"

--- a/recovar/commands/compute_state.py
+++ b/recovar/commands/compute_state.py
@@ -118,7 +118,7 @@ def add_args(parser: argparse.ArgumentParser):
         "--latent-points",
         type=os.path.abspath,
         required=True,
-        help="path to latent points (.txt file). E.g., you can use the output of k-means and input output/analysis_2/centers.txt from analyze.py. Or you can make your own latent points. It should be a .txt file with shape (n_points, zdim).",
+        help="Path to latent points (.txt/.npy/.npz/.pkl). E.g. output/analysis_2/centers.txt from analyze.py, or your own array with shape (n_points, zdim).",
     )
     parser.add_argument(
         "--save-all-estimates",

--- a/recovar/commands/compute_state.py
+++ b/recovar/commands/compute_state.py
@@ -1,14 +1,16 @@
-import recovar.jax_config
+import argparse
 import logging
-import numpy as np
+import os
 import warnings
+
+import numpy as np
+
 from recovar import utils
-from recovar.output import output as o
 from recovar.heterogeneity import embedding
-import os, argparse
+from recovar.output import output as o
+from recovar.utils import parser_args
 
 logger = logging.getLogger(__name__)
-from recovar.utils import parser_args
 
 _PATH_REMAP_ATTRS = (
     "particles",

--- a/recovar/commands/compute_state.py
+++ b/recovar/commands/compute_state.py
@@ -2,9 +2,9 @@ import recovar.jax_config
 import logging
 import numpy as np
 import warnings
+from recovar import utils
 from recovar.output import output as o
 from recovar.heterogeneity import embedding
-import pickle
 import os, argparse
 
 logger = logging.getLogger(__name__)
@@ -61,22 +61,21 @@ def _auto_remap_paths(input_args, actual_result_dir: str):
 
 
 def _load_latent_points(latent_points_path):
-    """Load latent points from txt/pkl and validate numeric finite contents."""
+    """Load latent points from txt/npy/npz/pkl and validate numeric finite contents."""
     latent_points_path = os.fspath(latent_points_path)
-    if latent_points_path.endswith(".pkl"):
-        if not os.path.isfile(latent_points_path):
-            raise FileNotFoundError(f"Latent points file not found: {latent_points_path}")
-        with open(latent_points_path, "rb") as f:
-            target_zs = pickle.load(f)
-    elif latent_points_path.endswith(".txt"):
-        if not os.path.isfile(latent_points_path):
-            raise FileNotFoundError(f"Latent points file not found: {latent_points_path}")
-        with warnings.catch_warnings():
-            # Empty text files produce a UserWarning; we handle emptiness explicitly below.
-            warnings.simplefilter("ignore", category=UserWarning)
-            target_zs = np.loadtxt(latent_points_path)
-    else:
-        raise ValueError("Target zs should be a .txt or .pkl file")
+    suffix = os.path.splitext(latent_points_path)[1].lower()
+    if suffix not in (".txt", ".npy", ".npz", ".pkl"):
+        raise ValueError("Target zs should be a .txt, .npy, .npz, or .pkl file")
+
+    with warnings.catch_warnings():
+        # Empty text files produce a UserWarning; we handle emptiness explicitly below.
+        warnings.simplefilter("ignore", category=UserWarning)
+        target_zs = utils.load_serialized_payload(
+            latent_points_path,
+            name="Target zs",
+            allow_text=True,
+            npz_keys=("latent_points", "target_zs", "zs", "points"),
+        )
 
     target_zs = np.asarray(target_zs)
     try:

--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -56,33 +56,33 @@ def add_args(parser: argparse.ArgumentParser):
         "--poses",
         type=os.path.abspath,
         default=None,
-        help="Image poses (.pkl). Auto-extracted from .star/.cs if omitted",
+        help="Image poses (.pkl/.npy/.npz). Auto-extracted from .star/.cs if omitted",
     )
     data.add_argument(
         "--ctf",
-        metavar="pkl",
+        metavar="FILE",
         type=os.path.abspath,
         default=None,
-        help="CTF parameters (.pkl). Auto-extracted from .star/.cs if omitted",
+        help="CTF parameters (.pkl/.npy/.npz). Auto-extracted from .star/.cs if omitted",
     )
     data.add_argument(
         "--ind",
         type=os.path.abspath,
-        metavar="PKL",
-        help="Filter images by these indices",
+        metavar="FILE",
+        help="Filter images by these indices (.pkl/.npy/.npz/.txt)",
     )
     data.add_argument(
         "--particle-ind",
         dest="tilt_ind",
         type=os.path.abspath,
-        metavar="PKL",
-        help="Filter particles by these indices (tilt-series only)",
+        metavar="FILE",
+        help="Filter particles by these indices (.pkl/.npy/.npz/.txt; tilt-series only)",
     )
     data.add_argument(
         "--halfsets",
         default=None,
         type=os.path.abspath,
-        help="Halfset indices (.pkl). If omitted, reads _rlnRandomSubset from star file, or splits randomly",
+        help="Halfset indices (.pkl/.npy/.npz/.txt). If omitted, reads _rlnRandomSubset from star file, or splits randomly",
     )
     data.add_argument(
         "--datadir",
@@ -703,7 +703,7 @@ def standard_recovar_pipeline(args):
         if ext not in ("star", "cs"):
             raise ValueError(
                 "--poses and --ctf are required when particles file is not .star or .cs. "
-                "Provide --poses and --ctf, or use a .star/.cs particles file."
+                "Provide --poses (.pkl/.npy/.npz) and --ctf (.pkl/.npy/.npz), or use a .star/.cs particles file."
             )
         if args.poses is None:
             logger.info("No --poses provided; will auto-extract from %s", args.particles)

--- a/recovar/commands/reconstruct_from_external_embedding.py
+++ b/recovar/commands/reconstruct_from_external_embedding.py
@@ -13,6 +13,35 @@ from recovar.reconstruction import noise
 logger = logging.getLogger(__name__)
 
 
+def _load_external_embeddings(path):
+    """Load external latent coordinates from pickle or NumPy-native formats."""
+    suffix = os.path.splitext(os.fspath(path))[1].lower()
+    if suffix not in (".pkl", ".npy", ".npz"):
+        raise ValueError("Embedding should be a .pkl, .npy, or .npz file")
+    zs = utils.load_serialized_payload(
+        path,
+        name="embedding",
+        npz_keys=("latent_coords", "embedding", "embeddings", "zs"),
+    )
+
+    zs = np.asarray(zs)
+    if not np.issubdtype(zs.dtype, np.number):
+        raise ValueError("Embedding array must be numeric.")
+    try:
+        zs = zs.astype(np.float32, copy=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Embedding array must be numeric.") from exc
+    if zs.size == 0:
+        raise ValueError("Embedding array is empty.")
+    if not np.all(np.isfinite(zs)):
+        raise ValueError("Embedding array contains non-finite values (NaN/Inf).")
+    if zs.ndim == 1:
+        zs = zs[:, None]
+    if zs.ndim != 2:
+        raise ValueError(f"Embedding array must have shape (n_images, zdim); got {zs.shape}")
+    return zs
+
+
 def add_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "particles",
@@ -38,8 +67,14 @@ def add_args(parser: argparse.ArgumentParser):
         help="Dimensions of latent variable. Default=1,2,4,10,20",
     )
 
-    parser.add_argument("--poses", type=os.path.abspath, required=True, help="Image poses (.pkl)")
-    parser.add_argument("--ctf", metavar="pkl", type=os.path.abspath, required=True, help="CTF parameters (.pkl)")
+    parser.add_argument("--poses", type=os.path.abspath, required=True, help="Image poses (.pkl/.npy/.npz)")
+    parser.add_argument(
+        "--ctf",
+        metavar="pkl|npy|npz",
+        type=os.path.abspath,
+        required=True,
+        help="CTF parameters (.pkl/.npy/.npz)",
+    )
 
     group = parser.add_argument_group("Dataset loading")
     group.add_argument(
@@ -92,7 +127,7 @@ def add_args(parser: argparse.ArgumentParser):
         "--halfsets",
         default=None,
         type=os.path.abspath,
-        help="Halfset indices (.pkl). If omitted, reads _rlnRandomSubset from star file, or splits randomly",
+        help="Halfset indices (.pkl/.npy/.npz/.txt). If omitted, reads _rlnRandomSubset from star file, or splits randomly",
     )
 
     group.add_argument(
@@ -116,7 +151,7 @@ def add_args(parser: argparse.ArgumentParser):
         "--embedding",
         type=os.path.abspath,
         required=True,
-        help="Image embeddings (.pkl), e.g. z.24.pkl from cryoDRGN",
+        help="Image embeddings (.pkl/.npy/.npz), e.g. z.24.pkl from cryoDRGN or model/zdim_N/latent_coords.npy",
     )
 
     parser.add_argument(
@@ -201,7 +236,7 @@ def generate(args):
     ds = halfsets.load_halfset_dataset(dataset_spec, ind_split=ind_split)
 
     # External embeddings are expected in dataset-local (original) order.
-    zs = utils.pickle_load(args.embedding)
+    zs = _load_external_embeddings(args.embedding)
 
     target = np.loadtxt(args.target)
 

--- a/recovar/commands/reconstruct_from_external_embedding.py
+++ b/recovar/commands/reconstruct_from_external_embedding.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import time
+import warnings
 
 import numpy as np
 
@@ -42,6 +43,37 @@ def _load_external_embeddings(path):
     return zs
 
 
+def _load_target_points(path):
+    """Load target latent points from text, pickle, or NumPy-native formats."""
+    suffix = os.path.splitext(os.fspath(path))[1].lower()
+    if suffix not in (".txt", ".pkl", ".npy", ".npz"):
+        raise ValueError("Target latent points should be a .txt, .pkl, .npy, or .npz file")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        target = utils.load_serialized_payload(
+            path,
+            name="target latent points",
+            allow_text=True,
+            npz_keys=("target", "targets", "latent_points", "target_zs", "zs", "points"),
+        )
+
+    target = np.asarray(target)
+    try:
+        target = target.astype(np.float32, copy=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Target latent points must be numeric.") from exc
+    if target.ndim == 0:
+        target = target.reshape(1)
+    if target.size == 0:
+        raise ValueError("Target latent points array is empty.")
+    if not np.all(np.isfinite(target)):
+        raise ValueError("Target latent points contain non-finite values (NaN/Inf).")
+    if target.ndim > 2:
+        raise ValueError(f"Target latent points must be 1D or 2D; got {target.shape}")
+    return target
+
+
 def add_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "particles",
@@ -80,16 +112,16 @@ def add_args(parser: argparse.ArgumentParser):
     group.add_argument(
         "--ind",
         type=os.path.abspath,
-        metavar="PKL",
-        help="Filter particles by these indices",
+        metavar="FILE",
+        help="Filter particles by these indices (.pkl/.npy/.npz/.txt)",
     )
 
     group.add_argument(
         "--particle-ind",
         dest="tilt_ind",
         type=os.path.abspath,
-        metavar="PKL",
-        help="Filter particles by these indices (only for tilt-series/cryo-ET)",
+        metavar="FILE",
+        help="Filter particles by these indices (.pkl/.npy/.npz/.txt; only for tilt-series/cryo-ET)",
     )
 
     group.add_argument(
@@ -158,7 +190,7 @@ def add_args(parser: argparse.ArgumentParser):
         "--target",
         type=os.path.abspath,
         required=True,
-        help="Target latent points to evaluate kernel regression (.txt)",
+        help="Target latent points to evaluate kernel regression (.txt/.pkl/.npy/.npz)",
     )
 
     parser.add_argument(
@@ -238,7 +270,7 @@ def generate(args):
     # External embeddings are expected in dataset-local (original) order.
     zs = _load_external_embeddings(args.embedding)
 
-    target = np.loadtxt(args.target)
+    target = _load_target_points(args.target)
 
     if args.zdim1:
         target = target[:, None]

--- a/recovar/commands/run_test_dataset.py
+++ b/recovar/commands/run_test_dataset.py
@@ -1,13 +1,13 @@
 import argparse
 import logging
 import os
-import pickle
 import shlex
 import shutil
 import subprocess
 import sys
 
 import jax
+import numpy as np
 
 from recovar.output import output
 
@@ -113,7 +113,7 @@ def main():
         )
 
         run_command(
-            f"{BASE_CMD} reconstruct_from_external_embedding {_pq('tilt_test', 'test_dataset', 'particles.star')} --poses {_pq('tilt_test', 'test_dataset', 'poses.pkl')} --ctf {_pq('tilt_test', 'test_dataset', 'ctf.pkl')} --tilt-series --embedding {_pq('tilt_test', 'test_dataset', 'pipeline_tilt_output', 'embeddings.pkl')} --target {_pq('tilt_test', 'test_dataset', 'target.txt')} -o {_pq('tilt_test', 'test_dataset', 'reconstruct_tilt_output')}",
+            f"{BASE_CMD} reconstruct_from_external_embedding {_pq('tilt_test', 'test_dataset', 'particles.star')} --poses {_pq('tilt_test', 'test_dataset', 'poses.pkl')} --ctf {_pq('tilt_test', 'test_dataset', 'ctf.pkl')} --tilt-series --embedding {_pq('tilt_test', 'test_dataset', 'pipeline_tilt_output', 'model', 'zdim_2', 'latent_coords.npy')} --target {_pq('tilt_test', 'test_dataset', 'target.txt')} -o {_pq('tilt_test', 'test_dataset', 'reconstruct_tilt_output')}",
             "Test reconstruct_from_external_embedding with tilt series",
             "reconstruct_tilt",
         )
@@ -190,7 +190,7 @@ def main():
             )
 
             pipeline_output_path = _p("test_dataset", "pipeline_output")
-            embedding_2_path = _p("test_dataset", "embedding_2.pkl")
+            embedding_2_path = _p("test_dataset", "embedding_2.npy")
             if not os.path.exists(pipeline_output_path):
                 logger.error("Failed: prepare embedding for reconstruction (missing %s)", pipeline_output_path)
                 failed_functions.append("prepare_embedding_for_reconstruct")
@@ -198,8 +198,7 @@ def main():
                 try:
                     po_tmp = output.PipelineOutput(pipeline_output_path)
                     latent_coords_2 = po_tmp.get_embedding_component("latent_coords", 2)
-                    with open(embedding_2_path, "wb") as f:
-                        pickle.dump(latent_coords_2, f)
+                    np.save(embedding_2_path, latent_coords_2)
                     del po_tmp
                 except Exception as e:
                     logger.error("Failed: prepare embedding for reconstruction (%s)", e)

--- a/recovar/data_io/_index_utils.py
+++ b/recovar/data_io/_index_utils.py
@@ -14,6 +14,7 @@ series and expands to one or more local images.
 
 from __future__ import annotations
 
+import os
 import pickle
 from dataclasses import dataclass
 from typing import Iterable, Optional
@@ -63,12 +64,26 @@ def normalize_indices(
 
 
 def load_index_like(value):
-    """Return an in-memory index selection from an array-like or pickle path."""
+    """Return an in-memory index selection from an array-like or serialized path."""
     if value is None:
         return None
     if isinstance(value, (np.ndarray, list, tuple)):
         return value
-    with open(value, "rb") as handle:
+    path = os.fspath(value)
+    suffix = os.path.splitext(path)[1].lower()
+    if suffix == ".npy":
+        return np.load(path, allow_pickle=False)
+    if suffix == ".npz":
+        with np.load(path, allow_pickle=False) as archive:
+            files = list(archive.files)
+            if not files:
+                raise ValueError(f"indices .npz file is empty: {path}")
+            if len(files) == 1:
+                return archive[files[0]]
+            return [archive[key] for key in files]
+    if suffix == ".txt":
+        return np.loadtxt(path, dtype=np.int64)
+    with open(path, "rb") as handle:
         return pickle.load(handle)
 
 

--- a/recovar/data_io/_index_utils.py
+++ b/recovar/data_io/_index_utils.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import os
 import pickle
+import warnings
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
@@ -83,8 +84,15 @@ def load_index_like(value):
             return [archive[key] for key in files]
     if suffix == ".txt":
         return np.loadtxt(path, dtype=np.int64)
-    with open(path, "rb") as handle:
-        return pickle.load(handle)
+    if suffix == ".pkl":
+        warnings.warn(
+            "Loading legacy pickle index files is deprecated; prefer .npy/.npz/.txt index files.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        with open(path, "rb") as handle:
+            return pickle.load(handle)
+    raise ValueError("Indices should be provided as a .pkl, .npy, .npz, or .txt file")
 
 
 def normalize_image_indices(values, *, n_total: Optional[int] = None, name: str = "indices"):

--- a/recovar/data_io/load_utils.py
+++ b/recovar/data_io/load_utils.py
@@ -1,9 +1,9 @@
 """
-Utilities for loading CTF parameters and pose information from pickle files.
-Equivalent to cryodrgn/load
+Utilities for loading CTF parameters and pose information from pickle/NumPy files.
 """
 
 import logging
+import os
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
@@ -12,6 +12,52 @@ from recovar import utils
 from recovar.data_io._index_utils import normalize_indices
 
 logger = logging.getLogger(__name__)
+
+
+def _load_npz_arrays(path: str) -> tuple[list[str], dict[str, np.ndarray]]:
+    with np.load(path, allow_pickle=False) as archive:
+        files = list(archive.files)
+        if not files:
+            raise ValueError(f"NPZ file is empty: {path}")
+        arrays = {key: archive[key] for key in files}
+    return files, arrays
+
+
+def _load_single_array_path(path: str, *, name: str, npz_keys=()):
+    suffix = os.path.splitext(path)[1].lower()
+    if suffix == ".npy":
+        return np.load(path, allow_pickle=False)
+    if suffix == ".npz":
+        files, arrays = _load_npz_arrays(path)
+        for key in npz_keys:
+            if key in arrays:
+                return arrays[key]
+        if len(files) == 1:
+            return arrays[files[0]]
+        raise ValueError(f"{name} .npz must contain a single array or one of keys {tuple(npz_keys)}")
+    return utils.pickle_load(path)
+
+
+def _load_pose_bundle(path: str):
+    suffix = os.path.splitext(path)[1].lower()
+    if suffix != ".npz":
+        return _load_single_array_path(path, name="poses", npz_keys=("poses", "rots", "rotations"))
+
+    files, arrays = _load_npz_arrays(path)
+    rot_key = next((key for key in ("rots", "rotations", "poses") if key in arrays), None)
+    trans_key = next((key for key in ("trans", "translations") if key in arrays), None)
+    if rot_key is not None:
+        if trans_key is None:
+            return arrays[rot_key]
+        return arrays[rot_key], arrays[trans_key]
+    if len(files) == 1:
+        return arrays[files[0]]
+    if len(files) == 2:
+        return arrays[files[0]], arrays[files[1]]
+    raise ValueError(
+        "poses .npz must contain a single rotation array, rotation+translation arrays, "
+        "or named keys like rots/trans"
+    )
 
 
 def _normalize_pose_indices(ind: np.ndarray, n_total: int) -> np.ndarray:
@@ -53,8 +99,8 @@ def load_ctf_params(D: int, ctf_params_pkl: str) -> np.ndarray:
     if D % 2 != 0:
         raise ValueError(f"Image dimension D must be even, got {D}")
 
-    # Load parameters from pickle
-    ctf_params = np.asarray(utils.pickle_load(ctf_params_pkl))
+    # Load parameters from pickle/NumPy payloads.
+    ctf_params = np.asarray(_load_single_array_path(ctf_params_pkl, name="CTF parameters", npz_keys=("ctf_params", "ctf")))
     if ctf_params.ndim != 2:
         raise ValueError(f"CTF parameters must be a 2D array of shape (N, 9), got ndim={ctf_params.ndim}")
     if ctf_params.shape[0] == 0:
@@ -112,15 +158,15 @@ def load_poses(
     if len(infile) not in (1, 2):
         raise ValueError(f"Expected 1 or 2 input files, got {len(infile)}")
 
-    # Load data from pickle file(s)
+    # Load data from pickle/NumPy file(s).
     if len(infile) == 2:
         # Separate rotation and translation files
-        rot_data = utils.pickle_load(infile[0])
-        trans_data = utils.pickle_load(infile[1])
+        rot_data = _load_single_array_path(infile[0], name="rotations", npz_keys=("rots", "rotations"))
+        trans_data = _load_single_array_path(infile[1], name="translations", npz_keys=("trans", "translations"))
         poses = (rot_data, trans_data)
     else:
         # Single file - may contain tuple or just rotations
-        poses = utils.pickle_load(infile[0])
+        poses = _load_pose_bundle(infile[0])
         if not isinstance(poses, tuple):
             poses = (poses,)
 

--- a/recovar/data_io/load_utils.py
+++ b/recovar/data_io/load_utils.py
@@ -55,8 +55,7 @@ def _load_pose_bundle(path: str):
     if len(files) == 2:
         return arrays[files[0]], arrays[files[1]]
     raise ValueError(
-        "poses .npz must contain a single rotation array, rotation+translation arrays, "
-        "or named keys like rots/trans"
+        "poses .npz must contain a single rotation array, rotation+translation arrays, or named keys like rots/trans"
     )
 
 
@@ -100,7 +99,9 @@ def load_ctf_params(D: int, ctf_params_pkl: str) -> np.ndarray:
         raise ValueError(f"Image dimension D must be even, got {D}")
 
     # Load parameters from pickle/NumPy payloads.
-    ctf_params = np.asarray(_load_single_array_path(ctf_params_pkl, name="CTF parameters", npz_keys=("ctf_params", "ctf")))
+    ctf_params = np.asarray(
+        _load_single_array_path(ctf_params_pkl, name="CTF parameters", npz_keys=("ctf_params", "ctf"))
+    )
     if ctf_params.ndim != 2:
         raise ValueError(f"CTF parameters must be a 2D array of shape (N, 9), got ndim={ctf_params.ndim}")
     if ctf_params.shape[0] == 0:
@@ -159,6 +160,7 @@ def load_poses(
         raise ValueError(f"Expected 1 or 2 input files, got {len(infile)}")
 
     # Load data from pickle/NumPy file(s).
+    poses: tuple[object, ...]
     if len(infile) == 2:
         # Separate rotation and translation files
         rot_data = _load_single_array_path(infile[0], name="rotations", npz_keys=("rots", "rotations"))
@@ -176,6 +178,7 @@ def load_poses(
         raise ValueError("Rotation array must be numeric")
     if not np.all(np.isfinite(rots)):
         raise ValueError("Rotation array contains non-finite values (NaN/Inf)")
+    rot_count = int(rots.shape[0])
 
     # Validate rotation shape
     expected_rot_shape = (Nimg, 3, 3)
@@ -198,10 +201,8 @@ def load_poses(
         if not np.all(np.isfinite(trans)):
             raise ValueError("Translation array contains non-finite values (NaN/Inf)")
 
-        if len(poses[0]) != len(trans):
-            raise ValueError(
-                f"Rotation/translation count mismatch: {len(poses[0])} rotations vs {len(trans)} translations"
-            )
+        if rot_count != len(trans):
+            raise ValueError(f"Rotation/translation count mismatch: {rot_count} rotations vs {len(trans)} translations")
 
         # Apply the same pose subset as rotations to preserve row alignment.
         if pose_ind is not None:

--- a/recovar/output/output.py
+++ b/recovar/output/output.py
@@ -3,84 +3,112 @@
 import json
 import logging
 import os
-import pickle
 import time
+from typing import Optional, Tuple, Union
 
 import matplotlib
 import matplotlib.patheffects as pe
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
+import seaborn as sns
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from sklearn.cluster import KMeans
 
 import recovar.core.fourier_transform_utils as fourier_transform_utils
 import recovar.heterogeneity.latent_density as ld
 from recovar import utils
 from recovar.core import linalg
-from recovar.data_io import cryoem_dataset, halfsets
+from recovar.data_io import halfsets
 from recovar.heterogeneity import embedding, trajectory
-from recovar.output.output_paths import AnalysisPaths, ResultPaths
+from recovar.output.output_paths import ResultPaths
 from recovar.reconstruction import regularization
 
 logger = logging.getLogger(__name__)
+
+
 def get_resampled_distances(gt_vols):
     return trajectory.get_cum_curvelength(gt_vols)
 
-def resample_trajectory(gt_vols, n_vols_along_path = 6):
+
+def resample_trajectory(gt_vols, n_vols_along_path=6):
     distances_between_volumes = get_resampled_distances(gt_vols)
-    
-    # n_volumes at approximately equispaced points 
+
+    # n_volumes at approximately equispaced points
     x = np.linspace(0, distances_between_volumes[-1], n_vols_along_path)
-    gt_vols_x= np.interp(x, distances_between_volumes, np.arange(gt_vols.shape[0]), left=None, right=None, period=None)
-    
+    gt_vols_x = np.interp(x, distances_between_volumes, np.arange(gt_vols.shape[0]), left=None, right=None, period=None)
+
     indices_along_path = np.round(gt_vols_x).astype(int)
     return indices_along_path
 
 
-
 def mkdir_safe(folder):
-    os.makedirs(folder, exist_ok = True)
-    
-def save_volume(vol, path, volume_shape = None, from_ft = True, voxel_size = None):
-    volume_shape = 3*[utils.guess_grid_size_from_vol_size(vol.size)] if volume_shape is None else volume_shape
+    os.makedirs(folder, exist_ok=True)
+
+
+def save_volume(vol, path, volume_shape=None, from_ft=True, voxel_size=None):
+    volume_shape = 3 * [utils.guess_grid_size_from_vol_size(vol.size)] if volume_shape is None else volume_shape
     if from_ft:
-        vol =  np.real(fourier_transform_utils.get_idft3(vol.reshape(volume_shape)))
+        vol = np.real(fourier_transform_utils.get_idft3(vol.reshape(volume_shape)))
     else:
         vol = np.real(vol.reshape(volume_shape))
-    utils.write_mrc(path + '.mrc', vol.astype(np.float32), voxel_size = voxel_size)
-    
-def save_volumes(volumes,  save_path , volume_shape = None, from_ft = True, index_offset=0, voxel_size = None):
-    grid_size = np.round((volumes[0].shape[0])**(1/3)).astype(int)
-    volume_shape = 3*[grid_size] if volume_shape is None else volume_shape
+    utils.write_mrc(path + ".mrc", vol.astype(np.float32), voxel_size=voxel_size)
+
+
+def save_volumes(volumes, save_path, volume_shape=None, from_ft=True, index_offset=0, voxel_size=None):
+    grid_size = np.round((volumes[0].shape[0]) ** (1 / 3)).astype(int)
+    volume_shape = 3 * [grid_size] if volume_shape is None else volume_shape
     for v_idx, vol in enumerate(volumes):
-        save_volume(vol, save_path + format(index_offset + v_idx, '04d') , volume_shape, from_ft = from_ft, voxel_size = voxel_size)
+        save_volume(
+            vol, save_path + format(index_offset + v_idx, "04d"), volume_shape, from_ft=from_ft, voxel_size=voxel_size
+        )
 
 
-def sum_over_other(x, use_axis = None, *args, **kwargs):
+def sum_over_other(x, use_axis=None, *args, **kwargs):
     if use_axis is None:
         use_axis = [0, 1]
     other_axes = []
     for k in range(x.ndim):
         if k not in use_axis:
             other_axes.append(k)
-            
-    xk = np.sum(x, axis = tuple(other_axes))
+
+    xk = np.sum(x, axis=tuple(other_axes))
     return xk
+
 
 def half_slice_other(density, axes, *args, **kwargs):
     axes = [i for i in range(density.ndim) if i not in axes]
     axes = np.sort(axes)
-    for i in range(len(axes)-1, -1, -1):
-        density = np.take(density, density.shape[axes[i]] // 2, axis = axes[i])
+    for i in range(len(axes) - 1, -1, -1):
+        density = np.take(density, density.shape[axes[i]] // 2, axis=axes[i])
     return density
+
 
 def slice_at_point(density, axes, point, *args, **kwargs):
     axes = [i for i in range(density.ndim) if i not in axes]
     axes = np.sort(axes)
-    for i in range(len(axes)-1, -1, -1):
-        density = np.take(density, point[axes[i]], axis = axes[i])
+    for i in range(len(axes) - 1, -1, -1):
+        density = np.take(density, point[axes[i]], axis=axes[i])
     return density
 
 
-def plot_over_density(density, trajectories = None, latent_space_bounds = None,  subsampled = None, colors = None, plot_folder = None, cmap = 'inferno', same_st_end = True, zs = None, cov_zs = None, points = None, projection_function = None, annotate = False, slice_point = None):
+def plot_over_density(
+    density,
+    trajectories=None,
+    latent_space_bounds=None,
+    subsampled=None,
+    colors=None,
+    plot_folder=None,
+    cmap="inferno",
+    same_st_end=True,
+    zs=None,
+    cov_zs=None,
+    points=None,
+    projection_function=None,
+    annotate=False,
+    slice_point=None,
+):
     """Plot 2-D density projections with optional trajectories and cluster centers.
 
     For each pair of latent dimensions, creates a density heatmap and overlays
@@ -102,14 +130,13 @@ def plot_over_density(density, trajectories = None, latent_space_bounds = None, 
         annotate: Whether to annotate *points* with integer labels.
         slice_point: Slice coordinate for the projection function.
     """
-    colors = ['k', 'cornflowerblue', 'g' , 'r', 'b', 'w', 'c'] if colors is None else colors
+    colors = ["k", "cornflowerblue", "g", "r", "b", "w", "c"] if colors is None else colors
     path_exists = trajectories is not None
 
-    if projection_function not in ('slice', 'slice_point', 'sum', None):
+    if projection_function not in ("slice", "slice_point", "sum", None):
         raise ValueError(f"Unknown projection function: {projection_function}")
-    projection_function = half_slice_other if projection_function == 'slice' else projection_function
-    projection_function = slice_at_point if projection_function == 'slice_point' else projection_function
-
+    projection_function = half_slice_other if projection_function == "slice" else projection_function
+    projection_function = slice_at_point if projection_function == "slice_point" else projection_function
 
     projection_function = sum_over_other if projection_function is None else projection_function
 
@@ -121,162 +148,208 @@ def plot_over_density(density, trajectories = None, latent_space_bounds = None, 
         if zs is None or cov_zs is None:
             raise ValueError("zs and cov_zs are required when density is not provided")
         compute_density = True
-        
+
     if compute_density:
         num_points = 200
     else:
-        num_points= density.shape[0]
+        num_points = density.shape[0]
 
     if path_exists:
         if latent_space_bounds is None:
             raise ValueError("Need latent space bounds to plot trajectories")
         _, z_to_grid = ld.get_grid_z_mappings(latent_space_bounds, num_points)
-    
-    def plot_traj_along_axes(axes, points = None ):
+
+    def plot_traj_along_axes(axes, points=None):
         axes = tuple(axes)
-        fig, ax = plt.subplots(figsize = (8,8))
+        fig, ax = plt.subplots(figsize=(8, 8))
         ax.set_frame_on(True)
 
         axis_x = axes[0]
         axis_y = axes[1]
         if compute_density:
-            density_pl, _= ld.compute_latent_space_density_on_2_axes(zs, cov_zs, axes = axes, num_points = num_points)
+            density_pl, _ = ld.compute_latent_space_density_on_2_axes(zs, cov_zs, axes=axes, num_points=num_points)
         else:
             density_pl = projection_function(density, axes, slice_point)
-            
+
         if axis_x > axis_y:
             density_pl = density_pl.T
-            
-        ax.imshow((density_pl.T), origin='lower', cmap = cmap, interpolation = 'bilinear')
+
+        ax.imshow((density_pl.T), origin="lower", cmap=cmap, interpolation="bilinear")
         if points is not None:
             points = points.copy()
-            out_of_bounds_points = np.zeros(points.shape[0], dtype = bool)
+            out_of_bounds_points = np.zeros(points.shape[0], dtype=bool)
             for k in range(points.shape[1]):
-                out_of_bounds_points = out_of_bounds_points | (points[:,k] > density.shape[k])
-                out_of_bounds_points = out_of_bounds_points | (points[:,k] < 0)
+                out_of_bounds_points = out_of_bounds_points | (points[:, k] > density.shape[k])
+                out_of_bounds_points = out_of_bounds_points | (points[:, k] < 0)
 
-                points[:,k] = np.where(points[:,k] > density.shape[k], density.shape[k], points[:,k])
-                points[:,k] = np.where(points[:,k] < 0, 0, points[:,k])
+                points[:, k] = np.where(points[:, k] > density.shape[k], density.shape[k], points[:, k])
+                points[:, k] = np.where(points[:, k] < 0, 0, points[:, k])
 
-            ax.scatter(points[out_of_bounds_points,axis_x], points[out_of_bounds_points,axis_y], 
-                      color = 'red', s = 100, edgecolors= 'black', linewidth=1, alpha=0.8)
-            ax.scatter(points[~out_of_bounds_points,axis_x], points[~out_of_bounds_points,axis_y], 
-                      color = 'cornflowerblue', s = 100, edgecolors= 'black', linewidth=1, alpha=0.8)
+            ax.scatter(
+                points[out_of_bounds_points, axis_x],
+                points[out_of_bounds_points, axis_y],
+                color="red",
+                s=100,
+                edgecolors="black",
+                linewidth=1,
+                alpha=0.8,
+            )
+            ax.scatter(
+                points[~out_of_bounds_points, axis_x],
+                points[~out_of_bounds_points, axis_y],
+                color="cornflowerblue",
+                s=100,
+                edgecolors="black",
+                linewidth=1,
+                alpha=0.8,
+            )
             if annotate:
                 for i in range(points.shape[0]):
-                    plt.annotate(str(i), points[i, axes] + np.array([0.1, 0.1]), color='white', path_effects=[pe.withStroke(linewidth=4, foreground="black")])
+                    plt.annotate(
+                        str(i),
+                        points[i, axes] + np.array([0.1, 0.1]),
+                        color="white",
+                        path_effects=[pe.withStroke(linewidth=4, foreground="black")],
+                    )
 
         if path_exists:
             # path_grid = z_to_grid(path)
             for traj_idx, traj in enumerate(trajectories):
                 traj = z_to_grid(traj)
-                
-                plt.plot(traj[:,axis_x], traj[:,axis_y], '-', c='w', linewidth=6)
-                plt.plot(traj[:,axis_x], traj[:,axis_y], '--', c=colors[traj_idx], dashes=[3], linewidth=6)
+
+                plt.plot(traj[:, axis_x], traj[:, axis_y], "-", c="w", linewidth=6)
+                plt.plot(traj[:, axis_x], traj[:, axis_y], "--", c=colors[traj_idx], dashes=[3], linewidth=6)
                 if subsampled is not None:
                     subs = z_to_grid(subsampled[traj_idx].copy())
-                    ax.scatter(subs[:,axis_x], subs[:,axis_y], marker = 'o', c=colors[traj_idx], 
-                             edgecolors = 'w', s = 500, zorder=2, linewidth=1)
-                
-                if not same_st_end or traj_idx ==0:
+                    ax.scatter(
+                        subs[:, axis_x],
+                        subs[:, axis_y],
+                        marker="o",
+                        c=colors[traj_idx],
+                        edgecolors="w",
+                        s=500,
+                        zorder=2,
+                        linewidth=1,
+                    )
+
+                if not same_st_end or traj_idx == 0:
                     g_st = traj[0]
                     g_end = traj[-1]
-                    ax.scatter(g_st[axis_x], g_st[axis_y], marker = '*', c='w', 
-                             edgecolors = colors[traj_idx], s = 1800, zorder=2, linewidth=2)
-                    ax.scatter(g_end[axis_x], g_end[axis_y], marker = 's', c='w', 
-                             edgecolors = colors[traj_idx], s = 600, zorder=2, linewidth=2)
-                            
+                    ax.scatter(
+                        g_st[axis_x],
+                        g_st[axis_y],
+                        marker="*",
+                        c="w",
+                        edgecolors=colors[traj_idx],
+                        s=1800,
+                        zorder=2,
+                        linewidth=2,
+                    )
+                    ax.scatter(
+                        g_end[axis_x],
+                        g_end[axis_y],
+                        marker="s",
+                        c="w",
+                        edgecolors=colors[traj_idx],
+                        s=600,
+                        zorder=2,
+                        linewidth=2,
+                    )
+
         ax.axis("off")
         if plot_folder is not None:
-            save_filepath = plot_folder  + 'density_' + str(axes[0]) + str(axes[1]) + '.png'
-            plt.savefig(save_filepath, bbox_inches='tight')
+            save_filepath = plot_folder + "density_" + str(axes[0]) + str(axes[1]) + ".png"
+            plt.savefig(save_filepath, bbox_inches="tight")
             plt.close()
 
     if density is not None:
         traj_dim = density.ndim
     else:
         traj_dim = trajectories[0].shape[1] if trajectories is not None else 4
-    for k1 in range(np.min([traj_dim,3])):
-        for k2 in range(k1+1, traj_dim):
-            plot_traj_along_axes([k1, k2], points = points)
+    for k1 in range(np.min([traj_dim, 3])):
+        for k2 in range(k1 + 1, traj_dim):
+            plot_traj_along_axes([k1, k2], points=points)
 
 
-
-
-def plot_kmeans_over_density(density, centers, plot_folder = None, cmap = 'inferno' ):
-    compute_density = False
-        
-    
-    if compute_density:
-        num_points = 200
-    else:
-        num_points= density.shape[0]
-    
+def plot_kmeans_over_density(density, centers, plot_folder=None, cmap="inferno"):
     def plot_traj_along_axes(axes):
         axes = tuple(axes)
-        fig, ax = plt.subplots(figsize = (8,8))
+        fig, ax = plt.subplots(figsize=(8, 8))
         ax.set_frame_on(True)
 
         axis_x = axes[0]
         axis_y = axes[1]
-        if compute_density:
-            density_pl, _= ld.compute_latent_space_density_on_2_axes(zs, cov_zs, axes = axes, num_points = num_points)
-        else:
-            density_pl = sum_over_other(density, axes)
-            
+        density_pl = sum_over_other(density, axes)
+
         if axis_x > axis_y:
             density_pl = density_pl.T
-            
-        ax.imshow((density_pl.T), origin='lower', cmap = cmap, interpolation = 'bilinear')
-        ax.scatter(centers[:,axis_x], centers[:,axis_y], c='red', edgecolor='black', s=100, zorder=3, linewidth=1)
+
+        ax.imshow((density_pl.T), origin="lower", cmap=cmap, interpolation="bilinear")
+        ax.scatter(centers[:, axis_x], centers[:, axis_y], c="red", edgecolor="black", s=100, zorder=3, linewidth=1)
         for i in range(centers.shape[0]):
-            ax.annotate(str(i), centers[i, axes] + np.array([0.1, 0.1]), c = 'white', 
-                       fontsize=12, fontweight='bold',
-                       path_effects=[pe.withStroke(linewidth=3, foreground="black")])
-        
+            ax.annotate(
+                str(i),
+                centers[i, axes] + np.array([0.1, 0.1]),
+                c="white",
+                fontsize=12,
+                fontweight="bold",
+                path_effects=[pe.withStroke(linewidth=3, foreground="black")],
+            )
 
         ax.axis("off")
-            
+
         if plot_folder is not None:
-            save_filepath = plot_folder  + 'density_' + str(axes[0]) + str(axes[1]) + '.png'
-            plt.savefig(save_filepath, bbox_inches='tight')
+            save_filepath = plot_folder + "density_" + str(axes[0]) + str(axes[1]) + ".png"
+            plt.savefig(save_filepath, bbox_inches="tight")
             plt.close()
 
     traj_dim = centers.shape[-1]
-    for k1 in range(np.min([traj_dim,3])):
-        for k2 in range(k1+1, traj_dim):
+    for k1 in range(np.min([traj_dim, 3])):
+        for k2 in range(k1 + 1, traj_dim):
             plot_traj_along_axes([k1, k2])
 
 
-
-
-def save_covar_output_volumes(output_folder, mean, u, s, mask, volume_shape,  us_to_save = 50, us_to_var = None, voxel_size = None):
+def save_covar_output_volumes(
+    output_folder, mean, u, s, mask, volume_shape, us_to_save=50, us_to_var=None, voxel_size=None
+):
     if us_to_var is None:
         us_to_var = [4, 10, 20]
 
-    vol_dir = os.path.join(output_folder, 'volumes')
+    vol_dir = os.path.join(output_folder, "volumes")
     mkdir_safe(vol_dir)
     n_available = int(u.shape[-1])
     n_to_save = max(0, min(int(us_to_save), n_available))
-    save_volumes([u[..., k] for k in range(n_to_save)], os.path.join(vol_dir, 'eigen_pos'), volume_shape=volume_shape, voxel_size=voxel_size)
-    save_volume(mean, os.path.join(vol_dir, 'mean'), volume_shape = volume_shape,   voxel_size = voxel_size)
+    save_volumes(
+        [u[..., k] for k in range(n_to_save)],
+        os.path.join(vol_dir, "eigen_pos"),
+        volume_shape=volume_shape,
+        voxel_size=voxel_size,
+    )
+    save_volume(mean, os.path.join(vol_dir, "mean"), volume_shape=volume_shape, voxel_size=voxel_size)
 
     grid_size = int(volume_shape[0])
     # 2^24 / grid_size^3: ~1 volume at 256^3, scales up for smaller grids
     vol_batch_size = utils.safe_batch_size((2**24) / (grid_size**3))
-    n_svals = int(np.asarray(s['rescaled']).shape[0])
+    n_svals = int(np.asarray(s["rescaled"]).shape[0])
     for n_eigs in us_to_var:
         n_eigs_eff = min(int(n_eigs), n_available, n_svals)
         if n_eigs_eff <= 0:
             continue
-        u_real = linalg.batch_idft3(u[..., :n_eigs_eff], volume_shape, vol_batch_size )
-        variance_real = utils.estimate_variance(u_real.T, s['rescaled'][:n_eigs_eff])
-        save_volume(variance_real, os.path.join(vol_dir, 'variance' + str(n_eigs)), volume_shape, from_ft = False,   voxel_size = voxel_size)
+        u_real = linalg.batch_idft3(u[..., :n_eigs_eff], volume_shape, vol_batch_size)
+        variance_real = utils.estimate_variance(u_real.T, s["rescaled"][:n_eigs_eff])
+        save_volume(
+            variance_real,
+            os.path.join(vol_dir, "variance" + str(n_eigs)),
+            volume_shape,
+            from_ft=False,
+            voxel_size=voxel_size,
+        )
 
 
 # ---------------------------------------------------------------------------
 # Pipeline result building and saving
 # ---------------------------------------------------------------------------
+
 
 def build_params_dict(
     *,
@@ -344,38 +417,37 @@ def build_params_dict(
         The full command-line arguments used to run the pipeline.
     """
     return {
-        'version': '0.7',
-        'volume_shape': volume_shape,
-        'voxel_size': voxel_size,
-        's': s_rescaled,
+        "version": "0.7",
+        "volume_shape": volume_shape,
+        "voxel_size": voxel_size,
+        "s": s_rescaled,
         # Noise estimates
-        'noise_var_from_hf': np.asarray(noise_var_from_hf),
-        'noise_var_from_het_residual': (
-            np.asarray(noise_var_from_het_residual)
-            if noise_var_from_het_residual is not None else None
+        "noise_var_from_hf": np.asarray(noise_var_from_hf),
+        "noise_var_from_het_residual": (
+            np.asarray(noise_var_from_het_residual) if noise_var_from_het_residual is not None else None
         ),
-        'noise_var_used': np.asarray(noise_var_used),
-        'radial_noise_var_outside_mask': np.asarray(noise_result['radial_noise_var_outside_mask']),
-        'radial_ub_noise_var': np.asarray(noise_result['radial_ub_noise_var']),
-        'white_noise_var_outside_mask': np.asarray(noise_result['white_noise_var_outside_mask']),
-        'ub_noise_var_by_var_est': np.asarray(ub_noise_var_by_var_est),
-        'image_PS': np.asarray(noise_result['image_PS']),
-        'masked_image_PS': np.asarray(noise_result['masked_image_PS']),
+        "noise_var_used": np.asarray(noise_var_used),
+        "radial_noise_var_outside_mask": np.asarray(noise_result["radial_noise_var_outside_mask"]),
+        "radial_ub_noise_var": np.asarray(noise_result["radial_ub_noise_var"]),
+        "white_noise_var_outside_mask": np.asarray(noise_result["white_noise_var_outside_mask"]),
+        "ub_noise_var_by_var_est": np.asarray(ub_noise_var_by_var_est),
+        "image_PS": np.asarray(noise_result["image_PS"]),
+        "masked_image_PS": np.asarray(noise_result["masked_image_PS"]),
         # Variance and covariance
-        'variance_est': variance_est,
-        'variance_fsc': variance_fsc,
-        'noise_p_variance_est': noise_p_variance_est,
-        'covariance_options': covariance_options,
-        'column_fscs': column_fscs,
-        'picked_frequencies': picked_frequencies,
+        "variance_est": variance_est,
+        "variance_fsc": variance_fsc,
+        "noise_p_variance_est": noise_p_variance_est,
+        "covariance_options": covariance_options,
+        "column_fscs": column_fscs,
+        "picked_frequencies": picked_frequencies,
         # Input
-        'input_args': input_args,
+        "input_args": input_args,
     }
 
 
-def build_embedding_dict(latent_coords, latent_coords_noreg,
-                         latent_precision, latent_precision_noreg,
-                         contrasts, contrasts_noreg):
+def build_embedding_dict(
+    latent_coords, latent_coords_noreg, latent_precision, latent_precision_noreg, contrasts, contrasts_noreg
+):
     """Build the embedding dict saved as ``model/embeddings.pkl``.
 
     All six sub-dicts are keyed by zdim (int).
@@ -396,12 +468,12 @@ def build_embedding_dict(latent_coords, latent_coords_noreg,
         Per-image contrast estimates (unregularized).
     """
     return {
-        'latent_coords': latent_coords,
-        'latent_coords_noreg': latent_coords_noreg,
-        'latent_precision': latent_precision,
-        'latent_precision_noreg': latent_precision_noreg,
-        'contrasts': contrasts,
-        'contrasts_noreg': contrasts_noreg,
+        "latent_coords": latent_coords,
+        "latent_coords_noreg": latent_coords_noreg,
+        "latent_precision": latent_precision,
+        "latent_precision_noreg": latent_precision_noreg,
+        "contrasts": contrasts,
+        "contrasts_noreg": contrasts_noreg,
     }
 
 
@@ -453,9 +525,12 @@ def save_pipeline_results(
 
 # Embedding field names that are saved as .npy files per zdim
 _EMBEDDING_FIELDS = [
-    'latent_coords', 'latent_coords_noreg',
-    'latent_precision', 'latent_precision_noreg',
-    'contrasts', 'contrasts_noreg',
+    "latent_coords",
+    "latent_coords_noreg",
+    "latent_precision",
+    "latent_precision_noreg",
+    "contrasts",
+    "contrasts_noreg",
 ]
 
 
@@ -508,6 +583,7 @@ def _load_embeddings_per_zdim(paths):
     Returns None if no zdim directories are found.
     """
     import re
+
     model_dir = paths.model_dir
     if not os.path.isdir(model_dir):
         return None
@@ -543,15 +619,16 @@ def write_metadata_json(paths, result):
     inspect run parameters without unpickling.
     """
     import datetime
+
     try:
         from recovar import __version__
     except ImportError:
         __version__ = "unknown"
 
     zdims = []
-    input_args = result.get('input_args')
+    input_args = result.get("input_args")
     if input_args is not None:
-        zdims_raw = getattr(input_args, 'zdim', None)
+        zdims_raw = getattr(input_args, "zdim", None)
         if zdims_raw is not None:
             zdims = [int(z) for z in zdims_raw]
 
@@ -559,38 +636,38 @@ def write_metadata_json(paths, result):
     downsample_applied = None
     original_particles = None
     if input_args is not None:
-        downsample_applied = getattr(input_args, '_downsample_applied', None)
-        original_particles = getattr(input_args, '_original_particles', None)
+        downsample_applied = getattr(input_args, "_downsample_applied", None)
+        original_particles = getattr(input_args, "_original_particles", None)
 
     metadata = {
-        'recovar_version': str(__version__),
-        'params_version': result.get('version', 'unknown'),
-        'saved_at': datetime.datetime.now().isoformat(),
-        'volume_shape': list(result.get('volume_shape', [])),
-        'voxel_size': float(result.get('voxel_size', 0)),
-        'zdims_computed': zdims,
-        'downsample_applied': downsample_applied,
-        'original_particles_file': original_particles,
-        'files': {
-            'params': 'model/params.pkl',
-            'embeddings': 'model/zdim_{N}/{latent_coords,latent_precision,contrasts}.npy',
-            'embeddings_legacy': 'model/embeddings.pkl',
-            'covariance_cols': 'model/covariance_cols.pkl',
-            'halfsets': 'model/halfsets.pkl',
-            'particles_halfsets': 'model/particles_halfsets.pkl',
-            'mean_volume': 'output/volumes/mean.mrc',
-            'mask': 'output/volumes/mask.mrc',
+        "recovar_version": str(__version__),
+        "params_version": result.get("version", "unknown"),
+        "saved_at": datetime.datetime.now().isoformat(),
+        "volume_shape": list(result.get("volume_shape", [])),
+        "voxel_size": float(result.get("voxel_size", 0)),
+        "zdims_computed": zdims,
+        "downsample_applied": downsample_applied,
+        "original_particles_file": original_particles,
+        "files": {
+            "params": "model/params.pkl",
+            "embeddings": "model/zdim_{N}/{latent_coords,latent_precision,contrasts}.npy",
+            "embeddings_legacy": "model/embeddings.pkl",
+            "covariance_cols": "model/covariance_cols.pkl",
+            "halfsets": "model/halfsets.pkl",
+            "particles_halfsets": "model/particles_halfsets.pkl",
+            "mean_volume": "output/volumes/mean.mrc",
+            "mask": "output/volumes/mask.mrc",
         },
     }
 
     try:
-        with open(paths.metadata, 'w') as f:
+        with open(paths.metadata, "w") as f:
             json.dump(metadata, f, indent=2)
     except (IOError, OSError, TypeError) as e:
         logger.warning("Could not write metadata.json: %s", e)
 
 
-def kmeans_analysis(output_folder, zs, n_clusters = 20):
+def kmeans_analysis(output_folder, zs, n_clusters=20):
     """Run k-means clustering on latent coordinates and save scatter plots.
 
     Generates annotated and unannotated scatter plots for all pairwise
@@ -605,35 +682,52 @@ def kmeans_analysis(output_folder, zs, n_clusters = 20):
         Tuple of (labels, centers) from k-means clustering.
     """
     reorder = zs.shape[1] != 1
-    labels, centers = cluster_kmeans(zs, n_clusters, reorder = reorder)
+    labels, centers = cluster_kmeans(zs, n_clusters, reorder=reorder)
     mkdir_safe(output_folder)
 
-    def plot_axes(axes = [0,1]):
-        fig,ax = scatter_annotate(zs[:,axes[0]], zs[:,axes[1]], centers=centers[:,axes], centers_ind=None, annotate=True, labels=None, alpha=0.1, s=1)
+    def plot_axes(axes=[0, 1]):
+        fig, ax = scatter_annotate(
+            zs[:, axes[0]],
+            zs[:, axes[1]],
+            centers=centers[:, axes],
+            centers_ind=None,
+            annotate=True,
+            labels=None,
+            alpha=0.1,
+            s=1,
+        )
         fig.set_figheight(6)
         fig.set_figwidth(6)
         ax.set_xticks([], [])
         ax.set_yticks([], [])
         if output_folder is not None:
-            plt.savefig(output_folder + 'PC_'+str(axes[0]) + str(axes[1])+'.png' )
+            plt.savefig(output_folder + "PC_" + str(axes[0]) + str(axes[1]) + ".png")
             plt.close()
 
-        fig,ax = scatter_annotate(zs[:,axes[0]], zs[:,axes[1]], centers=centers[:,axes], centers_ind=None, annotate=False, labels=None, alpha=0.1, s=2)
+        fig, ax = scatter_annotate(
+            zs[:, axes[0]],
+            zs[:, axes[1]],
+            centers=centers[:, axes],
+            centers_ind=None,
+            annotate=False,
+            labels=None,
+            alpha=0.1,
+            s=2,
+        )
         fig.set_figheight(6)
         fig.set_figwidth(6)
         ax.set_xticks([], [])
         ax.set_yticks([], [])
         if output_folder is not None:
-            plt.savefig(output_folder + 'PC_'+str(axes[0]) + str(axes[1])+'no_annotate.png' )
+            plt.savefig(output_folder + "PC_" + str(axes[0]) + str(axes[1]) + "no_annotate.png")
             plt.close()
 
-    for k in range(1,zs.shape[-1]):
-        plot_axes(axes = [0,k])
+    for k in range(1, zs.shape[-1]):
+        plot_axes(axes=[0, k])
     if zs.shape[-1] > 2:
-        plot_axes(axes = [1,2])
-    
-    return centers, labels
+        plot_axes(axes=[1, 2])
 
+    return centers, labels
 
 
 def plot_umap(output_folder, zs, centers):
@@ -647,44 +741,79 @@ def plot_umap(output_folder, zs, centers):
         zs: Latent coordinates, shape (n_particles, n_dims).
         centers: Cluster centers, shape (n_clusters, n_dims).
     """
-    def plot_axes(axes = [0,1]):
-        fig,ax = scatter_annotate(zs[:,axes[0]], zs[:,axes[1]], centers=centers[:,axes], centers_ind=None, annotate=True, labels=None, alpha=0.1, s=1)
+
+    def plot_axes(axes=[0, 1]):
+        fig, ax = scatter_annotate(
+            zs[:, axes[0]],
+            zs[:, axes[1]],
+            centers=centers[:, axes],
+            centers_ind=None,
+            annotate=True,
+            labels=None,
+            alpha=0.1,
+            s=1,
+        )
         fig.set_figheight(6)
         fig.set_figwidth(6)
         ax.set_xticks([], [])
         ax.set_yticks([], [])
         if output_folder is not None:
-            plt.savefig(output_folder + 'kmeans_centers.png' )
+            plt.savefig(output_folder + "kmeans_centers.png")
             plt.close()
 
-        fig,ax = scatter_annotate(zs[:,axes[0]], zs[:,axes[1]], centers=centers[:,axes], centers_ind=None, annotate=False, labels=None, alpha=0.1, s=2)
+        fig, ax = scatter_annotate(
+            zs[:, axes[0]],
+            zs[:, axes[1]],
+            centers=centers[:, axes],
+            centers_ind=None,
+            annotate=False,
+            labels=None,
+            alpha=0.1,
+            s=2,
+        )
         fig.set_figheight(6)
         fig.set_figwidth(6)
         ax.set_xticks([], [])
         ax.set_yticks([], [])
         if output_folder is not None:
-            plt.savefig(output_folder + 'kmeans_centers_no_annotate.png' )
+            plt.savefig(output_folder + "kmeans_centers_no_annotate.png")
             plt.close()
 
         import seaborn as sns
 
-        g = sns.jointplot(x=zs[:,0], y=zs[:,1], alpha=.1, s=1)
-        g.set_axis_labels('UMAP1', 'UMAP2')
+        g = sns.jointplot(x=zs[:, 0], y=zs[:, 1], alpha=0.1, s=1)
+        g.set_axis_labels("UMAP1", "UMAP2")
         if output_folder is not None:
-            plt.savefig(output_folder + 'sns.png' )
+            plt.savefig(output_folder + "sns.png")
             plt.close()
 
-        g = sns.jointplot(x=zs[:,0], y=zs[:,1], kind='hex')
-        g.set_axis_labels('UMAP1', 'UMAP2')
+        g = sns.jointplot(x=zs[:, 0], y=zs[:, 1], kind="hex")
+        g.set_axis_labels("UMAP1", "UMAP2")
         if output_folder is not None:
-            plt.savefig(output_folder + 'sns_hex.png' )
+            plt.savefig(output_folder + "sns_hex.png")
             plt.close()
 
-    plot_axes(axes = [0,1])
+    plot_axes(axes=[0, 1])
 
 
-
-def compute_and_save_reweighted(dataset, path_subsampled, zs, cov_zs,  output_folder, B_factor, n_bins = 30, n_min_particles = 100, embedding_option = 'cov_dist', save_all_estimates = False, maskrad_fraction= 20, apply_global_filtering=False, fsc_mask = None, fsc_mask_radius = None, fsc_mask_edgewidth = None, vol_prefix="state"):
+def compute_and_save_reweighted(
+    dataset,
+    path_subsampled,
+    zs,
+    cov_zs,
+    output_folder,
+    B_factor,
+    n_bins=30,
+    n_min_particles=100,
+    embedding_option="cov_dist",
+    save_all_estimates=False,
+    maskrad_fraction=20,
+    apply_global_filtering=False,
+    fsc_mask=None,
+    fsc_mask_radius=None,
+    fsc_mask_edgewidth=None,
+    vol_prefix="state",
+):
     """Compute reweighted volume estimates and save with standardized organization.
 
     Primary volumes (filtered, half-maps) are placed directly in
@@ -698,6 +827,7 @@ def compute_and_save_reweighted(dataset, path_subsampled, zs, cov_zs,  output_fo
         obtained lazily via ``dataset.get_halfset(k)``.
     """
     from recovar.output.output_paths import VolumeOutputPaths
+
     ds = dataset
 
     if n_min_particles is None:
@@ -705,6 +835,7 @@ def compute_and_save_reweighted(dataset, path_subsampled, zs, cov_zs,  output_fo
 
     mkdir_safe(output_folder)
     from recovar.heterogeneity import heterogeneity_volume, latent_density
+
     n_vols = path_subsampled.shape[0]
 
     for k in range(n_vols):
@@ -715,82 +846,114 @@ def compute_and_save_reweighted(dataset, path_subsampled, zs, cov_zs,  output_fo
         latent_points = path_subsampled[k][None]
         np.savetxt(vol_paths.latent_coords, latent_points)
 
-        if embedding_option == 'llh':
-            log_likelihoods = latent_density.compute_latent_log_likelihood(latent_points, zs, cov_zs)[...,0]
+        if embedding_option == "llh":
+            log_likelihoods = latent_density.compute_latent_log_likelihood(latent_points, zs, cov_zs)[..., 0]
             heterogeneity_distances = log_likelihoods - np.min(log_likelihoods)
-        elif embedding_option == 'cov_dist':
-            heterogeneity_distances = latent_density.compute_latent_quadratic_forms_in_batch(latent_points, zs, cov_zs)[...,0]
-        elif embedding_option == 'dist':
-            cov_zs = cov_zs*0 + np.eye(ndim)
-            heterogeneity_distances = latent_density.compute_latent_log_likelihood(latent_points, zs, cov_zs)[...,0]
+        elif embedding_option == "cov_dist":
+            heterogeneity_distances = latent_density.compute_latent_quadratic_forms_in_batch(latent_points, zs, cov_zs)[
+                ..., 0
+            ]
+        elif embedding_option == "dist":
+            cov_zs = cov_zs * 0 + np.eye(ndim)
+            heterogeneity_distances = latent_density.compute_latent_log_likelihood(latent_points, zs, cov_zs)[..., 0]
         else:
             raise ValueError("Unknown embed option")
 
-        heterogeneity_distances = ds.split_halfset_array(
-            heterogeneity_distances, per_particle=ds.tilt_series_flag)
+        heterogeneity_distances = ds.split_halfset_array(heterogeneity_distances, per_particle=ds.tilt_series_flag)
 
         locres_maskrad = ds.grid_size * ds.voxel_size / maskrad_fraction
-        logger.info("Mask radius fraction = %s. Setting locres_maskrad = locres_sampling = box_size * voxel_size / %s = %.1f Angstroms. Using %d particles for template.", maskrad_fraction, maskrad_fraction, locres_maskrad, n_min_particles)
-        heterogeneity_volume.make_volumes_kernel_estimate_local(heterogeneity_distances, ds, vol_paths, ndim, n_bins, B_factor, tau=None, n_min_particles=n_min_particles, locres_sampling=locres_maskrad, locres_maskrad=locres_maskrad, locres_edgwidth=0, upsampling_for_ests=1, use_mask_ests=False, grid_correct_ests=False, save_all_estimates=save_all_estimates, metric_used='locshellmost_likely', use_fast_rfft=True)
+        logger.info(
+            "Mask radius fraction = %s. Setting locres_maskrad = locres_sampling = box_size * voxel_size / %s = %.1f Angstroms. Using %d particles for template.",
+            maskrad_fraction,
+            maskrad_fraction,
+            locres_maskrad,
+            n_min_particles,
+        )
+        heterogeneity_volume.make_volumes_kernel_estimate_local(
+            heterogeneity_distances,
+            ds,
+            vol_paths,
+            ndim,
+            n_bins,
+            B_factor,
+            tau=None,
+            n_min_particles=n_min_particles,
+            locres_sampling=locres_maskrad,
+            locres_maskrad=locres_maskrad,
+            locres_edgwidth=0,
+            upsampling_for_ests=1,
+            use_mask_ests=False,
+            grid_correct_ests=False,
+            save_all_estimates=save_all_estimates,
+            metric_used="locshellmost_likely",
+            use_fast_rfft=True,
+        )
 
         logger.info("Done with volume %d: %s", k, vol_paths.stem)
 
-    np.savetxt(os.path.join(output_folder, 'latent_coords.txt'), path_subsampled)
+    np.savetxt(os.path.join(output_folder, "latent_coords.txt"), path_subsampled)
 
 
 def plot_loglikelihood_over_scatter(path_subsampled, zs, cov_zs, save_path):
     likelihoods = ld.compute_latent_quadratic_forms(path_subsampled, zs, cov_zs)
     vmax = np.max(likelihoods)
-    vmin = np.max([np.min(likelihoods),  1e-8 *np.max(likelihoods)])
+    vmin = np.max([np.min(likelihoods), 1e-8 * np.max(likelihoods)])
     plt.ioff()
     for k in range(likelihoods.shape[1]):
-        fig, ax = plt.subplots(figsize = (8,8))
-        
+        fig, ax = plt.subplots(figsize=(8, 8))
+
         # Create hexbin density plot for background
         try:
-            ax.hexbin(zs[:,0], zs[:,1], gridsize=30, alpha=0.3, cmap='Blues', mincnt=1)
+            ax.hexbin(zs[:, 0], zs[:, 1], gridsize=30, alpha=0.3, cmap="Blues", mincnt=1)
         except (ValueError, TypeError):
             pass
-        
-        greater_x = likelihoods[:,k] > vmin
-        ax.scatter(zs[~greater_x,0], zs[~greater_x,1], c='black', alpha = 0.3, s = 2, edgecolors='none')  
 
-        scatter = ax.scatter(zs[greater_x,0], zs[greater_x,1], c= likelihoods[greater_x,k], cmap='rainbow', 
-                           s = 5, alpha = 0.8, norm=matplotlib.colors.LogNorm(vmin=vmin, vmax=vmax, clip = True), 
-                           edgecolors='none')
+        greater_x = likelihoods[:, k] > vmin
+        ax.scatter(zs[~greater_x, 0], zs[~greater_x, 1], c="black", alpha=0.3, s=2, edgecolors="none")
+
+        scatter = ax.scatter(
+            zs[greater_x, 0],
+            zs[greater_x, 1],
+            c=likelihoods[greater_x, k],
+            cmap="rainbow",
+            s=5,
+            alpha=0.8,
+            norm=matplotlib.colors.LogNorm(vmin=vmin, vmax=vmax, clip=True),
+            edgecolors="none",
+        )
 
         # Add grid and improve styling
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor('white')
-        ax.set_xlabel('PC1', fontweight='bold')
-        ax.set_ylabel('PC2', fontweight='bold')
-        ax.set_title(f'Likelihood Analysis - Component {k}', fontweight='bold')
-        
+        ax.set_facecolor("white")
+        ax.set_xlabel("PC1", fontweight="bold")
+        ax.set_ylabel("PC2", fontweight="bold")
+        ax.set_title(f"Likelihood Analysis - Component {k}", fontweight="bold")
+
         # Add colorbar
-        plt.colorbar(scatter, ax=ax, label='Likelihood')
+        plt.colorbar(scatter, ax=ax, label="Likelihood")
 
         ax.set_xticks([])
         ax.set_yticks([])
-        save_filepath = save_path +  format(k, '04d') + '.png'
-        plt.savefig(save_filepath, bbox_inches='tight', dpi=300)
+        save_filepath = save_path + format(k, "04d") + ".png"
+        plt.savefig(save_filepath, bbox_inches="tight", dpi=300)
         plt.close(fig)
 
 
 def load_results_new(datadir):
-    model_folder = datadir +'model'  + '/'
-    return utils.pickle_load(model_folder + 'results.pkl')
+    model_folder = datadir + "model" + "/"
+    return utils.pickle_load(model_folder + "results.pkl")
 
 
 class PipelineOutput:
     def __init__(self, result_path):
-        self.result_path = result_path.rstrip('/') + '/'
-        self.paths = ResultPaths(self.result_path.rstrip('/'))
+        self.result_path = result_path.rstrip("/") + "/"
+        self.paths = ResultPaths(self.result_path.rstrip("/"))
         self.params = utils.pickle_load(self.paths.params)
         self.embedding = None
         self.embedding_loaded = False
         self._embedding_key_cache = {}
         self._embedding_halfsets_cache = None
-        self.version = str(self.params['version']) if 'version' in self.params else '0'
+        self.version = str(self.params["version"]) if "version" in self.params else "0"
 
     def _ensure_embedding_raw_loaded(self):
         if self.embedding is not None:
@@ -826,14 +989,14 @@ class PipelineOutput:
     def _get_embedding_halfsets(self):
         if self._embedding_halfsets_cache is not None:
             return self._embedding_halfsets_cache
-        if self.version == '0':
+        if self.version == "0":
             self._embedding_halfsets_cache = (None, None)
             return self._embedding_halfsets_cache
-        if self.version == '0.1':
-            particle_halfsets = np.concatenate(self.get('halfsets'))
+        if self.version == "0.1":
+            particle_halfsets = np.concatenate(self.get("halfsets"))
         else:
-            particle_halfsets = np.concatenate(self.get('particles_halfsets'))
-        image_halfsets = np.concatenate(self.get('halfsets'))
+            particle_halfsets = np.concatenate(self.get("particles_halfsets"))
+        image_halfsets = np.concatenate(self.get("halfsets"))
         self._embedding_halfsets_cache = (particle_halfsets, image_halfsets)
         return self._embedding_halfsets_cache
 
@@ -841,10 +1004,7 @@ class PipelineOutput:
         self._ensure_embedding_raw_loaded()
         if entry not in self.embedding:
             available = [k for k in self.embedding.keys()] if self.embedding else []
-            raise KeyError(
-                f"Embedding entry '{entry}' not found. "
-                f"Available entries: {available}"
-            )
+            raise KeyError(f"Embedding entry '{entry}' not found. Available entries: {available}")
         return list(self.embedding[entry].keys())
 
     def has_embedding_entry(self, entry):
@@ -874,9 +1034,9 @@ class PipelineOutput:
             raise KeyError(f"Embedding key {key} not found in {entry}.")
 
         values = self.embedding[entry][key]
-        if self.version != '0':
+        if self.version != "0":
             particle_halfsets, image_halfsets = self._get_embedding_halfsets()
-            if entry.startswith('contrasts') and self._use_image_halfsets_for_unshared_tilt_contrast():
+            if entry.startswith("contrasts") and self._use_image_halfsets_for_unshared_tilt_contrast():
                 values = values[np.sort(image_halfsets)]
             else:
                 values = values[np.sort(particle_halfsets)]
@@ -898,14 +1058,14 @@ class PipelineOutput:
         """
         self._ensure_embedding_raw_loaded()
 
-        if self.version != '0':
+        if self.version != "0":
             halfsets, image_halfsets = self._get_embedding_halfsets()
             sorted_halfsets = np.sort(halfsets)
             sorted_image_halfsets = np.sort(image_halfsets)
 
             for entry in self.embedding:
                 for key in self.embedding[entry]:
-                    if entry.startswith('contrasts') and self._use_image_halfsets_for_unshared_tilt_contrast():
+                    if entry.startswith("contrasts") and self._use_image_halfsets_for_unshared_tilt_contrast():
                         self.embedding[entry][key] = self.embedding[entry][key][sorted_image_halfsets]
                     else:
                         self.embedding[entry][key] = self.embedding[entry][key][sorted_halfsets]
@@ -917,13 +1077,13 @@ class PipelineOutput:
         vols_dir = self.paths.volumes_dir
         if not os.path.isdir(vols_dir):
             return []
-        prefix = 'eigen_pos'
-        suffix = '.mrc'
+        prefix = "eigen_pos"
+        suffix = ".mrc"
         indices = []
         for name in os.listdir(vols_dir):
             if not (name.startswith(prefix) and name.endswith(suffix)):
                 continue
-            num_str = name[len(prefix):-len(suffix)]
+            num_str = name[len(prefix) : -len(suffix)]
             if num_str.isdigit():
                 indices.append(int(num_str))
         indices.sort()
@@ -942,14 +1102,14 @@ class PipelineOutput:
 
     def get_u_real(self, n_pcs=50):
         selected_indices = self._select_saved_eigenvector_indices(n_pcs)
-        out = np.empty([len(selected_indices), *(self.params['volume_shape'])], dtype=np.float32)
+        out = np.empty([len(selected_indices), *(self.params["volume_shape"])], dtype=np.float32)
         for i, eig_idx in enumerate(selected_indices):
             out[i] = utils.load_mrc(self.paths.eigenvector(eig_idx))
         return out
 
     def get_u(self, n_pcs=50):
         selected_indices = self._select_saved_eigenvector_indices(n_pcs)
-        vol_size = int(np.prod(self.params['volume_shape']))
+        vol_size = int(np.prod(self.params["volume_shape"]))
         out = np.empty((len(selected_indices), vol_size), dtype=np.complex64)
         for i, eig_idx in enumerate(selected_indices):
             vol = utils.load_mrc(self.paths.eigenvector(eig_idx))
@@ -957,9 +1117,12 @@ class PipelineOutput:
         return out
 
     _EMBEDDING_ENTRIES = (
-        'latent_coords', 'latent_coords_noreg',
-        'latent_precision', 'latent_precision_noreg',
-        'contrasts', 'contrasts_noreg',
+        "latent_coords",
+        "latent_coords_noreg",
+        "latent_precision",
+        "latent_precision_noreg",
+        "contrasts",
+        "contrasts_noreg",
     )
 
     def get(self, key):
@@ -968,66 +1131,66 @@ class PipelineOutput:
                 self.load_embedding()
             return self.embedding[key]
 
-        elif key == 'unsorted_embedding':
+        elif key == "unsorted_embedding":
             return utils.pickle_load(self.paths.embeddings)
 
-        elif key in ('u', 'u_real'):
-            return self.get_u_real(50) if key == 'u_real' else self.get_u(50)
+        elif key in ("u", "u_real"):
+            return self.get_u_real(50) if key == "u_real" else self.get_u(50)
 
-        elif key == 'mean':
+        elif key == "mean":
             return fourier_transform_utils.get_dft3(utils.load_mrc(self.paths.mean_volume)).reshape(-1)
 
-        elif key == 'mean_halfmaps':
+        elif key == "mean_halfmaps":
             half1 = fourier_transform_utils.get_dft3(utils.load_mrc(self.paths.mean_half1_unfil)).reshape(-1)
             half2 = fourier_transform_utils.get_dft3(utils.load_mrc(self.paths.mean_half2_unfil)).reshape(-1)
             return half1, half2
 
-        elif key == 'image_snr':
-            vol_shape = self.get('volume_shape')
-            PS = regularization.average_over_shells(np.abs(self.get('mean').reshape(vol_shape)) ** 2, vol_shape)
-            return utils.make_radial_image(PS / self.get('noise_var_used'), tuple(vol_shape[:2]))
+        elif key == "image_snr":
+            vol_shape = self.get("volume_shape")
+            PS = regularization.average_over_shells(np.abs(self.get("mean").reshape(vol_shape)) ** 2, vol_shape)
+            return utils.make_radial_image(PS / self.get("noise_var_used"), tuple(vol_shape[:2]))
 
-        elif key == 'image_snr_radial':
-            vol_shape = self.get('volume_shape')
-            PS = regularization.average_over_shells(np.abs(self.get('mean').reshape(vol_shape)) ** 2, vol_shape)
-            return PS / self.get('noise_var_used')
+        elif key == "image_snr_radial":
+            vol_shape = self.get("volume_shape")
+            PS = regularization.average_over_shells(np.abs(self.get("mean").reshape(vol_shape)) ** 2, vol_shape)
+            return PS / self.get("noise_var_used")
 
-        elif key == 'variance':
+        elif key == "variance":
             return utils.load_mrc(self.paths.variance(10))
-        elif key == 'variance20':
+        elif key == "variance20":
             return utils.load_mrc(self.paths.variance(20))
-        elif key == 'focus_mask':
+        elif key == "focus_mask":
             return utils.load_mrc(self.paths.focus_mask_volume)
-        elif key == 'volume_mask':
+        elif key == "volume_mask":
             return utils.load_mrc(self.paths.mask_volume)
-        elif key == 'dilated_volume_mask':
+        elif key == "dilated_volume_mask":
             return utils.load_mrc(self.paths.dilated_mask_volume)
-        elif key == 'covariance_cols':
+        elif key == "covariance_cols":
             return utils.pickle_load(self.paths.covariance_cols)
 
-        elif key in ('dataset', 'lazy_dataset'):
+        elif key in ("dataset", "lazy_dataset"):
             ds = halfsets.load_halfset_dataset_from_args(
-                self.get('input_args'),
-                lazy='lazy' in key,
-                ind_split=self.get('halfsets'),
+                self.get("input_args"),
+                lazy="lazy" in key,
+                ind_split=self.get("halfsets"),
             )
-            add_noise_to_loaded_dataset(ds, self.get('noise_var_used'))
+            add_noise_to_loaded_dataset(ds, self.get("noise_var_used"))
             return ds
 
-        elif key == 'halfsets':
+        elif key == "halfsets":
             return utils.pickle_load(self.paths.halfsets)
-        elif key == 'particles_halfsets':
-            if self.version == '0.1':
+        elif key == "particles_halfsets":
+            if self.version == "0.1":
                 return utils.pickle_load(self.paths.halfsets)
             else:
                 return utils.pickle_load(self.paths.particles_halfsets)
 
-        elif key == 'input_args':
+        elif key == "input_args":
             return self._get_input_args()
 
-        elif key in ('density', 'latent_space_bounds', 'pc_metric', 'contrasts_for_second'):
+        elif key in ("density", "latent_space_bounds", "pc_metric", "contrasts_for_second"):
             return self.params.get(key, None)
-        elif key in ('std_image_PS', 'std_masked_image_PS'):
+        elif key in ("std_image_PS", "std_masked_image_PS"):
             return self.params.get(key, None)
 
         elif key in self.params:
@@ -1038,7 +1201,24 @@ class PipelineOutput:
     def keys(self):
         keys = list(self.params.keys())
         keys += list(self._EMBEDDING_ENTRIES)
-        keys += ['u', 'u_real', 'mean', 'volume_mask', 'dilated_volume_mask', 'covariance_cols', 'dataset', 'lazy_dataset', 'variance', 'variance20', 'focus_mask', 'image_snr', 'mean_halfmaps', 'halfsets', 'input_args', 'unsorted_embedding']
+        keys += [
+            "u",
+            "u_real",
+            "mean",
+            "volume_mask",
+            "dilated_volume_mask",
+            "covariance_cols",
+            "dataset",
+            "lazy_dataset",
+            "variance",
+            "variance20",
+            "focus_mask",
+            "image_snr",
+            "mean_halfmaps",
+            "halfsets",
+            "input_args",
+            "unsorted_embedding",
+        ]
         return keys
 
 
@@ -1048,7 +1228,20 @@ def add_noise_to_loaded_dataset(ds, noise_variance):
     else:
         ds.set_variable_radial_noise_model(noise_variance)
 
-def make_trajectory_plots_from_results(pipeline_output, basis_size, output_folder, cryos = None, z_st = None, z_end = None, gt_volumes= None, n_vols_along_path = 6, plot_llh = False,  input_density = None, latent_space_bounds = None):
+
+def make_trajectory_plots_from_results(
+    pipeline_output,
+    basis_size,
+    output_folder,
+    cryos=None,
+    z_st=None,
+    z_end=None,
+    gt_volumes=None,
+    n_vols_along_path=6,
+    plot_llh=False,
+    input_density=None,
+    latent_space_bounds=None,
+):
     """Compute minimum-energy trajectories and generate volume/density plots.
 
     Finds optimal paths between start and end latent coordinates (or between
@@ -1087,8 +1280,15 @@ def make_trajectory_plots_from_results(pipeline_output, basis_size, output_folde
         density,
         zs,
         cov_zs,
-        z_st, z_end, latent_space_bounds, output_folder,
-        gt_volumes= None, n_vols_along_path = n_vols_along_path, plot_llh = plot_llh, use_input_density = input_density is not None)
+        z_st,
+        z_end,
+        latent_space_bounds,
+        output_folder,
+        gt_volumes=None,
+        n_vols_along_path=n_vols_along_path,
+        plot_llh=plot_llh,
+        use_input_density=input_density is not None,
+    )
 
 
 def _resolve_trajectory_plot_inputs(pipeline_output, basis_size, cryos, input_density, latent_space_bounds):
@@ -1111,7 +1311,19 @@ def _resolve_trajectory_plot_inputs(pipeline_output, basis_size, cryos, input_de
     return cryos, zs, cov_zs, density, latent_space_bounds
 
 
-def make_trajectory_plots(density, zs, cov_zs, z_st, z_end, latent_space_bounds, output_folder, gt_volumes= None, n_vols_along_path = 6, plot_llh = False, use_input_density =False):
+def make_trajectory_plots(
+    density,
+    zs,
+    cov_zs,
+    z_st,
+    z_end,
+    latent_space_bounds,
+    output_folder,
+    gt_volumes=None,
+    n_vols_along_path=6,
+    plot_llh=False,
+    use_input_density=False,
+):
 
     latent_space_bounds = ld.compute_latent_space_bounds(zs) if latent_space_bounds is None else latent_space_bounds
 
@@ -1121,25 +1333,54 @@ def make_trajectory_plots(density, zs, cov_zs, z_st, z_end, latent_space_bounds,
         logger.warning("density dimension is less than zs dimension, truncate zs dimension")
         basis_size = density.ndim
 
-    zs = zs[:,:basis_size]
-    cov_zs = cov_zs[:,:basis_size,:basis_size]
+    zs = zs[:, :basis_size]
+    cov_zs = cov_zs[:, :basis_size, :basis_size]
 
-    mkdir_safe(output_folder + 'density/')
-    if basis_size >1:
+    mkdir_safe(output_folder + "density/")
+    if basis_size > 1:
         if not use_input_density:
-            path_z = trajectory.compute_high_dimensional_path(zs, cov_zs, z_st, z_end, density_low_dim=density,
-                                                    density_eps = 1e-5, max_dim = basis_size, percentile_bound = 1, num_points = 50, 
-                                                    use_log_density = False)
+            path_z = trajectory.compute_high_dimensional_path(
+                zs,
+                cov_zs,
+                z_st,
+                z_end,
+                density_low_dim=density,
+                density_eps=1e-5,
+                max_dim=basis_size,
+                percentile_bound=1,
+                num_points=50,
+                use_log_density=False,
+            )
         else:
-            path_z = trajectory.compute_fixed_dimensional_path(z_st, z_end, density, latent_space_bounds, density_eps = 1e-5, debug_plot = False, density_option = "kde", use_log_density = False)
+            path_z = trajectory.compute_fixed_dimensional_path(
+                z_st,
+                z_end,
+                density,
+                latent_space_bounds,
+                density_eps=1e-5,
+                debug_plot=False,
+                density_option="kde",
+                use_log_density=False,
+            )
 
-        path_subsampled = trajectory.subsample_path(path_z, n_pts = n_vols_along_path)    
+        path_subsampled = trajectory.subsample_path(path_z, n_pts=n_vols_along_path)
 
         logger.info("after path %.1fs", time.time() - st_time)
         inp_dens = density if use_input_density else None
-        plot_over_density(inp_dens, [path_z],latent_space_bounds,  subsampled = [path_subsampled[1:-1] ] , colors = ['cornflowerblue'], plot_folder = output_folder + 'density/', cmap = 'inferno', same_st_end = False, zs = zs, cov_zs = cov_zs)
+        plot_over_density(
+            inp_dens,
+            [path_z],
+            latent_space_bounds,
+            subsampled=[path_subsampled[1:-1]],
+            colors=["cornflowerblue"],
+            plot_folder=output_folder + "density/",
+            cmap="inferno",
+            same_st_end=False,
+            zs=zs,
+            cov_zs=cov_zs,
+        )
     else:
-        path_z = np.linspace(z_st, z_end, n_vols_along_path)[...,0]
+        path_z = np.linspace(z_st, z_end, n_vols_along_path)[..., 0]
         path_subsampled = path_z
 
     st_time = time.time()
@@ -1152,12 +1393,17 @@ def make_trajectory_plots(density, zs, cov_zs, z_st, z_end, latent_space_bounds,
         density_on_path = ld.compute_latent_space_density_at_pts(path_z, zs, cov_zs) + np.nan
         density_on_path_subs = ld.compute_latent_space_density_at_pts(path_subsampled, zs, cov_zs) + np.nan
 
-    densities = { 'density' :  density_on_path.tolist(), 'path' : path_z.tolist(), 'density_subsampled': density_on_path_subs.tolist(), 'path_subsampled' : path_subsampled.tolist(), } 
-    with open(output_folder + '/path.json', 'w') as f:
+    densities = {
+        "density": density_on_path.tolist(),
+        "path": path_z.tolist(),
+        "density_subsampled": density_on_path_subs.tolist(),
+        "path_subsampled": path_subsampled.tolist(),
+    }
+    with open(output_folder + "/path.json", "w") as f:
         json.dump(densities, f)
 
     if plot_llh:
-        plot_loglikelihood_over_scatter(path_subsampled, zs, cov_zs, save_path = output_folder)
+        plot_loglikelihood_over_scatter(path_subsampled, zs, cov_zs, save_path=output_folder)
 
     logger.info("after all plots %.1fs", time.time() - st_time)
     return path_z, path_subsampled
@@ -1165,24 +1411,26 @@ def make_trajectory_plots(density, zs, cov_zs, z_st, z_end, latent_space_bounds,
 
 def density_on_grid(points, density, bounds):
     import jax.scipy
-    _, z_to_grid = ld.get_grid_z_mappings(bounds, num_points = density.shape[0])
+
+    _, z_to_grid = ld.get_grid_z_mappings(bounds, num_points=density.shape[0])
     path_grid = z_to_grid(points)
     return jax.scipy.ndimage.map_coordinates(density, path_grid.T, order=1)
 
 
 def vol_to_z(gt_volumes, u, mean, basis_size):
-    coords = ((np.conj(u[:,:basis_size].T) @ (gt_volumes - mean).T).T).real
+    coords = ((np.conj(u[:, :basis_size].T) @ (gt_volumes - mean).T).T).real
     return coords
 
 
-
-def plot_trajectories_over_scatter(trajectories,  subsampled = None, colors = None, plot_folder = None, cmap = 'inferno', same_st_end = True, zs = None, cov_zs = None ):
-    colors = ['k', 'cornflowerblue'] if colors is None else colors
+def plot_trajectories_over_scatter(
+    trajectories, subsampled=None, colors=None, plot_folder=None, cmap="inferno", same_st_end=True, zs=None, cov_zs=None
+):
+    colors = ["k", "cornflowerblue"] if colors is None else colors
     path_exists = trajectories is not None
-        
+
     def plot_traj_along_axes(axes):
         axes = tuple(axes)
-        fig, ax = plt.subplots(figsize = (8,8))
+        fig, ax = plt.subplots(figsize=(8, 8))
         ax.set_frame_on(True)
 
         axis_x = axes[0]
@@ -1190,61 +1438,84 @@ def plot_trajectories_over_scatter(trajectories,  subsampled = None, colors = No
 
         # Create hexbin density plot for background
         try:
-            ax.hexbin(zs[:,axis_x], zs[:,axis_y], gridsize=30, alpha=0.3, cmap='Blues', mincnt=1)
+            ax.hexbin(zs[:, axis_x], zs[:, axis_y], gridsize=30, alpha=0.3, cmap="Blues", mincnt=1)
         except (ValueError, TypeError):
             pass
-        
+
         # Main scatter plot with improved styling
-        ax.scatter(zs[:,axis_x], zs[:,axis_y], s=1, alpha=0.6, c='cornflowerblue', edgecolors='none')
-        
+        ax.scatter(zs[:, axis_x], zs[:, axis_y], s=1, alpha=0.6, c="cornflowerblue", edgecolors="none")
+
         if path_exists:
             # path_grid = z_to_grid(path)
             for traj_idx, traj in enumerate(trajectories):
-                                
-                ax.plot(traj[:,axis_x], traj[:,axis_y], '-o', c=colors[traj_idx], linewidth=3, zorder=3, markersize=4)
+                ax.plot(traj[:, axis_x], traj[:, axis_y], "-o", c=colors[traj_idx], linewidth=3, zorder=3, markersize=4)
                 # plt.plot(traj[:,axis_x], traj[:,axis_y], '--', c=colors[traj_idx], dashes=[3], linewidth=6)
 
                 if subsampled is not None:
                     subs = subsampled[traj_idx]
                     if subs is not None:
-                        ax.scatter(subs[:,axis_x], subs[:,axis_y], marker = '>', c=colors[traj_idx], 
-                                 edgecolors = 'w', s = 200, zorder=3, linewidth=1)
+                        ax.scatter(
+                            subs[:, axis_x],
+                            subs[:, axis_y],
+                            marker=">",
+                            c=colors[traj_idx],
+                            edgecolors="w",
+                            s=200,
+                            zorder=3,
+                            linewidth=1,
+                        )
 
-            # for traj_idx, traj in enumerate(trajectories):
-                if not same_st_end or traj_idx ==0:
+                # for traj_idx, traj in enumerate(trajectories):
+                if not same_st_end or traj_idx == 0:
                     g_st = traj[0]
                     g_end = traj[-1]
-                    ax.scatter(g_st[axis_x], g_st[axis_y], marker = '*', c='w', 
-                             edgecolors = colors[traj_idx], s = 1800, zorder=2, linewidth=2)
-                    ax.scatter(g_end[axis_x], g_end[axis_y], marker = 's', c='w', 
-                             edgecolors = colors[traj_idx], s = 600, zorder=2, linewidth=2)
+                    ax.scatter(
+                        g_st[axis_x],
+                        g_st[axis_y],
+                        marker="*",
+                        c="w",
+                        edgecolors=colors[traj_idx],
+                        s=1800,
+                        zorder=2,
+                        linewidth=2,
+                    )
+                    ax.scatter(
+                        g_end[axis_x],
+                        g_end[axis_y],
+                        marker="s",
+                        c="w",
+                        edgecolors=colors[traj_idx],
+                        s=600,
+                        zorder=2,
+                        linewidth=2,
+                    )
 
         # Add grid and improve styling
         ax.grid(True, alpha=0.3)
-        ax.set_facecolor('white')
-        ax.set_xlabel(f'PC{axis_x+1}', fontweight='bold')
-        ax.set_ylabel(f'PC{axis_y+1}', fontweight='bold')
-        ax.set_title(f'PC{axis_x+1} vs PC{axis_y+1}', fontweight='bold')
-            
+        ax.set_facecolor("white")
+        ax.set_xlabel(f"PC{axis_x + 1}", fontweight="bold")
+        ax.set_ylabel(f"PC{axis_y + 1}", fontweight="bold")
+        ax.set_title(f"PC{axis_x + 1} vs PC{axis_y + 1}", fontweight="bold")
+
         if plot_folder is not None:
-            save_filepath = plot_folder  + 'density_' + str(axes[0]) + str(axes[1]) + '.png'
-            plt.savefig(save_filepath, bbox_inches='tight', dpi=300)
+            save_filepath = plot_folder + "density_" + str(axes[0]) + str(axes[1]) + ".png"
+            plt.savefig(save_filepath, bbox_inches="tight", dpi=300)
             plt.close()
 
     traj_dim = trajectories[0].shape[1] if trajectories is not None else 4
-    for k1 in range(np.min([traj_dim,3])):
-        for k2 in range(k1+1, traj_dim):
+    for k1 in range(np.min([traj_dim, 3])):
+        for k2 in range(k1 + 1, traj_dim):
             plot_traj_along_axes([k1, k2])
 
 
 def umap_latent_space(zs):
     import umap
+
     st_time = time.time()
     n_components = np.min([zs.shape[1], 2])
     mapper = umap.UMAP(n_components=n_components, random_state=42).fit(zs)
     logger.info("time to umap: %.1fs", time.time() - st_time)
     return mapper
-
 
 
 def standard_pipeline_plots(po, zdim_key, output_folder):
@@ -1259,38 +1530,39 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
         output_folder: Directory to save plots into.
     """
     from recovar.output import plot_utils
+
     mkdir_safe(output_folder)
-    plot_utils.plot_summary_t(po, n_eigs = 10, filename = os.path.join(output_folder, "mean_variance_eigenvolume_plots.png"))
+    plot_utils.plot_summary_t(
+        po, n_eigs=10, filename=os.path.join(output_folder, "mean_variance_eigenvolume_plots.png")
+    )
 
     import matplotlib.pyplot as plt
 
     # Contrast histogram
     fig, ax = plt.subplots(figsize=(8, 6))
     plot_utils.plot_contrast_histogram(
-        po.get_embedding_component('contrasts', zdim_key),
+        po.get_embedding_component("contrasts", zdim_key),
         ax=ax,
         zdim_key=zdim_key,
     )
-    plt.savefig(os.path.join(output_folder, 'contrast_histogram.png'), bbox_inches='tight')
+    plt.savefig(os.path.join(output_folder, "contrast_histogram.png"), bbox_inches="tight")
     plt.close()
 
     # Eigenvalue spectrum
     fig, ax = plt.subplots(figsize=(8, 6))
-    plot_utils.plot_eigenvalues(po.get('s'), ax=ax)
-    plt.savefig(os.path.join(output_folder, 'eigenvalues.png'), bbox_inches='tight')
+    plot_utils.plot_eigenvalues(po.get("s"), ax=ax)
+    plt.savefig(os.path.join(output_folder, "eigenvalues.png"), bbox_inches="tight")
     plt.close()
 
     # Mean FSC
-    plt.figure(figsize = (8,8))
-    ax = plot_utils.plot_mean_fsc(po,None)
-    plt.savefig(os.path.join(output_folder, 'mean_fsc.png'), bbox_inches='tight')
+    plt.figure(figsize=(8, 8))
+    ax = plot_utils.plot_mean_fsc(po, None)
+    plt.savefig(os.path.join(output_folder, "mean_fsc.png"), bbox_inches="tight")
     plt.close()
-
-
 
     # Load latent coordinates with robust error handling
     try:
-        latent_keys = list(po.get_embedding_keys('latent_coords'))
+        latent_keys = list(po.get_embedding_keys("latent_coords"))
         if len(latent_keys) == 0:
             logger.warning("No latent coordinates found in pipeline output. Skipping PC analysis.")
             return
@@ -1298,24 +1570,24 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
         if latent_key != 4:
             logger.info("Using latent space with key %s instead of 4", latent_key)
 
-        z = np.asarray(po.get_embedding_component('latent_coords', latent_key))
+        z = np.asarray(po.get_embedding_component("latent_coords", latent_key))
         if z.ndim != 2:
             logger.warning("Invalid latent coordinates data. Skipping PC analysis.")
             return
-            
+
         logger.info("Latent space shape: %s", z.shape)
         logger.info("Number of particles: %d", z.shape[0])
         logger.info("Latent dimensions: %d", z.shape[1])
-        
+
         # Validate data quality
         if z.shape[0] < 10:
             logger.warning("Too few particles (%d) for meaningful PC analysis. Skipping.", z.shape[0])
             return
-            
+
         if z.shape[1] < 2:
             logger.warning("Too few dimensions (%d) for PC analysis. Skipping.", z.shape[1])
             return
-            
+
         # Check for NaN or infinite values
         if np.any(np.isnan(z)) or np.any(np.isinf(z)):
             logger.warning("Latent coordinates contain NaN or infinite values. Attempting to clean data.")
@@ -1323,7 +1595,7 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
             if z.shape[0] < 10:
                 logger.warning("Too few valid particles after cleaning. Skipping PC analysis.")
                 return
-                
+
     except (KeyError, FileNotFoundError, ValueError) as e:
         logger.error("Error loading latent coordinates: %s", e)
         return
@@ -1333,13 +1605,13 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
     if max_pcs < 2:
         logger.warning("Only %d dimensions available, cannot create pairwise plots.", max_pcs)
         return
-        
+
     # Calculate number of subplots needed
     n_combinations = max_pcs * (max_pcs - 1) // 2
     if n_combinations == 0:
         logger.warning("No valid PC combinations to plot.")
         return
-        
+
     # Create appropriate subplot layout
     if n_combinations <= 3:
         n_rows, n_cols = 1, n_combinations
@@ -1347,9 +1619,9 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
         n_rows, n_cols = 2, 3
     else:
         n_rows, n_cols = 3, 3
-        
+
     try:
-        fig, axes = plt.subplots(n_rows, n_cols, figsize=(6*n_cols, 6*n_rows))
+        fig, axes = plt.subplots(n_rows, n_cols, figsize=(6 * n_cols, 6 * n_rows))
         if n_combinations == 1:
             axes = [axes]
         else:
@@ -1359,7 +1631,7 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
         return
 
     # Generate pairwise combinations
-    combinations = [(i, j) for i in range(max_pcs) for j in range(i+1, max_pcs)]
+    combinations = [(i, j) for i in range(max_pcs) for j in range(i + 1, max_pcs)]
 
     for idx, (i, j) in enumerate(combinations):
         if idx >= len(axes):
@@ -1370,29 +1642,27 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
             y_data = z[:, j]
 
             if np.any(np.isnan(x_data)) or np.any(np.isnan(y_data)):
-                logger.warning("Skipping PC%d vs PC%d due to NaN values", i+1, j+1)
+                logger.warning("Skipping PC%d vs PC%d due to NaN values", i + 1, j + 1)
                 continue
 
             if np.any(np.isinf(x_data)) or np.any(np.isinf(y_data)):
-                logger.warning("Skipping PC%d vs PC%d due to infinite values", i+1, j+1)
+                logger.warning("Skipping PC%d vs PC%d due to infinite values", i + 1, j + 1)
                 continue
 
             # Hexbin density + scatter (consistent with scatter_annotate)
             try:
                 if len(x_data) > 50:
-                    axes[idx].hexbin(x_data, y_data, gridsize=30,
-                                   alpha=0.3, cmap='Blues', mincnt=1)
+                    axes[idx].hexbin(x_data, y_data, gridsize=30, alpha=0.3, cmap="Blues", mincnt=1)
             except (ValueError, TypeError) as e:
-                logger.debug("Could not add hexbin for PC%d vs PC%d: %s", i+1, j+1, e)
-            axes[idx].scatter(x_data, y_data, alpha=0.3, s=0.5,
-                            c='cornflowerblue', edgecolors='none', rasterized=True)
-            axes[idx].set_xlabel(f'PC{i+1}')
-            axes[idx].set_ylabel(f'PC{j+1}')
-            axes[idx].set_title(f'PC{i+1} vs PC{j+1}', fontweight='bold')
+                logger.debug("Could not add hexbin for PC%d vs PC%d: %s", i + 1, j + 1, e)
+            axes[idx].scatter(x_data, y_data, alpha=0.3, s=0.5, c="cornflowerblue", edgecolors="none", rasterized=True)
+            axes[idx].set_xlabel(f"PC{i + 1}")
+            axes[idx].set_ylabel(f"PC{j + 1}")
+            axes[idx].set_title(f"PC{i + 1} vs PC{j + 1}", fontweight="bold")
             axes[idx].grid(True, alpha=0.3)
 
         except (ValueError, TypeError, IndexError) as e:
-            logger.error("Error plotting PC%d vs PC%d: %s", i+1, j+1, e)
+            logger.error("Error plotting PC%d vs PC%d: %s", i + 1, j + 1, e)
             axes[idx].set_visible(False)
 
     # Hide unused subplots
@@ -1400,14 +1670,14 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
         axes[idx].set_visible(False)
 
     try:
-        plt.suptitle(f'Principal Component Space Analysis ({max_pcs}D)', fontsize=16, fontweight='bold')
+        plt.suptitle(f"Principal Component Space Analysis ({max_pcs}D)", fontsize=16, fontweight="bold")
         plt.tight_layout()
-        
+
         # Save with error handling
-        output_path = os.path.join(output_folder, 'principal_component_space_analysis.png')
-        plt.savefig(output_path, bbox_inches='tight', dpi=300)
+        output_path = os.path.join(output_folder, "principal_component_space_analysis.png")
+        plt.savefig(output_path, bbox_inches="tight", dpi=300)
         logger.info("PC analysis plot saved to %s", output_path)
-        
+
     except (OSError, ValueError) as e:
         logger.error("Error saving PC analysis plot: %s", e)
     finally:
@@ -1416,16 +1686,9 @@ def standard_pipeline_plots(po, zdim_key, output_folder):
     # Consolidated summary plot
     try:
         plot_utils.plot_pipeline_summary(po, zdim_key, output_folder)
-        logger.info("Pipeline summary plot saved to %s", os.path.join(output_folder, 'pipeline_summary.png'))
+        logger.info("Pipeline summary plot saved to %s", os.path.join(output_folder, "pipeline_summary.png"))
     except (KeyError, FileNotFoundError, ValueError, TypeError) as e:
         logger.warning("Could not generate pipeline summary plot: %s", e)
-
-
-from typing import Optional, Union, Tuple
-from sklearn.cluster import KMeans
-import seaborn as sns
-from matplotlib.figure import Figure, Axes
-import numpy.typing as npt
 
 
 def scatter_annotate(
@@ -1435,7 +1698,7 @@ def scatter_annotate(
     centers_ind: Optional[np.ndarray] = None,
     annotate: bool = True,
     labels: Optional[np.ndarray] = None,
-    alpha: Union[float, np.ndarray, None] = 0.6,
+    alpha: Optional[float] = 0.6,
     s: Union[float, np.ndarray, None] = 1,
     colors: Union[list, str, None] = None,
 ) -> Tuple[Figure, Axes]:
@@ -1472,6 +1735,7 @@ def scatter_annotate(
     ax.set_facecolor("white")
     return fig, ax
 
+
 def get_nearest_point(
     data: np.ndarray, query: np.ndarray, chunk_size: Optional[int] = None
 ) -> Tuple[npt.NDArray[np.float32], np.ndarray]:
@@ -1507,9 +1771,7 @@ def get_nearest_point(
     return data[ind], ind
 
 
-def cluster_kmeans(
-    z: np.ndarray, K: int, on_data: bool = True, reorder: bool = True
-) -> Tuple[np.ndarray, np.ndarray]:
+def cluster_kmeans(z: np.ndarray, K: int, on_data: bool = True, reorder: bool = True) -> Tuple[np.ndarray, np.ndarray]:
     """K-means clustering of z into K clusters.
 
     Returns (labels, centers). If reorder=True, clusters are sorted by

--- a/recovar/output/output.py
+++ b/recovar/output/output.py
@@ -537,7 +537,7 @@ def _load_embeddings_per_zdim(paths):
 
 
 def write_metadata_json(paths, result):
-    """Write a human-readable JSON manifest alongside the pickle files.
+    """Write a human-readable JSON manifest alongside the model files.
 
     This file is not loaded by the pipeline -- it exists for users to quickly
     inspect run parameters without unpickling.
@@ -573,7 +573,8 @@ def write_metadata_json(paths, result):
         'original_particles_file': original_particles,
         'files': {
             'params': 'model/params.pkl',
-            'embeddings': 'model/embeddings.pkl',
+            'embeddings': 'model/zdim_{N}/{latent_coords,latent_precision,contrasts}.npy',
+            'embeddings_legacy': 'model/embeddings.pkl',
             'covariance_cols': 'model/covariance_cols.pkl',
             'halfsets': 'model/halfsets.pkl',
             'particles_halfsets': 'model/particles_halfsets.pkl',
@@ -777,10 +778,7 @@ def plot_loglikelihood_over_scatter(path_subsampled, zs, cov_zs, save_path):
 
 def load_results_new(datadir):
     model_folder = datadir +'model'  + '/'
-    output_folder = datadir +'output'  + '/'
-    with open(model_folder + 'results.pkl', 'rb') as f:
-        results = pickle.load(f)
-    return results
+    return utils.pickle_load(model_folder + 'results.pkl')
 
 
 class PipelineOutput:

--- a/recovar/utils/helpers.py
+++ b/recovar/utils/helpers.py
@@ -370,6 +370,56 @@ def pickle_load(file):
         return pickle.load(f)
 
 
+def load_serialized_payload(file, *, name="payload", allow_text=False, npz_keys=(), allow_multiple=False):
+    """Load a backward-compatible payload from pickle or NumPy-native formats.
+
+    Parameters
+    ----------
+    file : path-like
+        Input file to load.
+    name : str
+        Human-readable name used in error messages.
+    allow_text : bool
+        Whether ``.txt`` files are accepted via ``np.loadtxt``.
+    npz_keys : sequence of str
+        Preferred keys to use when loading ``.npz`` archives.
+    allow_multiple : bool
+        Whether ``.npz`` archives with multiple arrays may return a list of
+        arrays when no preferred key is present.
+    """
+    path = os.fspath(file)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"{name} file not found: {path}")
+
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".pkl":
+        return pickle_load(path)
+    if ext == ".npy":
+        return np.load(path, allow_pickle=False)
+    if ext == ".npz":
+        with np.load(path, allow_pickle=False) as archive:
+            files = list(archive.files)
+            if not files:
+                raise ValueError(f"{name} .npz file is empty: {path}")
+            for key in npz_keys:
+                if key in archive:
+                    return archive[key]
+            if len(files) == 1:
+                return archive[files[0]]
+            if allow_multiple:
+                return [archive[key] for key in files]
+            raise ValueError(
+                f"{name} .npz file must contain a single array or one of the keys {tuple(npz_keys)}"
+            )
+    if ext == ".txt" and allow_text:
+        return np.loadtxt(path)
+
+    allowed = [".pkl", ".npy", ".npz"]
+    if allow_text:
+        allowed.append(".txt")
+    raise ValueError(f"{name} should be a {'/'.join(allowed)} file")
+
+
 def get_variances(covariance_cols, picked_frequencies=None):
     volume_shape = guess_vol_shape_from_vol_size(covariance_cols.shape[-1])
 

--- a/recovar/utils/helpers.py
+++ b/recovar/utils/helpers.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import os
 import pickle
+import warnings
 from dataclasses import dataclass
 
 import jax
@@ -366,6 +367,11 @@ def pickle_dump(object, file):
 
 
 def pickle_load(file):
+    warnings.warn(
+        "Loading legacy RECOVAR pickle files is deprecated; prefer .npy/.npz-based outputs when available.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     with open(file, "rb") as f:
         return pickle.load(f)
 

--- a/recovar/utils/helpers.py
+++ b/recovar/utils/helpers.py
@@ -5,12 +5,13 @@ import logging
 import os
 import pickle
 import warnings
+from collections import namedtuple
 from dataclasses import dataclass
 
 import jax
 import jax.numpy as jnp
-import mrcfile
 import more_itertools
+import mrcfile
 import numpy as np
 import pandas as pd
 import psutil
@@ -301,8 +302,6 @@ def get_column_batch_size(grid_size, gpu_memory):
     return int(batch_size)
 
 
-from collections import namedtuple
-
 BatchSizes = namedtuple("BatchSizes", ["image", "volume", "column"])
 
 
@@ -414,9 +413,7 @@ def load_serialized_payload(file, *, name="payload", allow_text=False, npz_keys=
                 return archive[files[0]]
             if allow_multiple:
                 return [archive[key] for key in files]
-            raise ValueError(
-                f"{name} .npz file must contain a single array or one of the keys {tuple(npz_keys)}"
-            )
+            raise ValueError(f"{name} .npz file must contain a single array or one of the keys {tuple(npz_keys)}")
     if ext == ".txt" and allow_text:
         return np.loadtxt(path)
 

--- a/tests/unit/test_commands_analyze_state.py
+++ b/tests/unit/test_commands_analyze_state.py
@@ -1,9 +1,9 @@
 import os
 from types import SimpleNamespace
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-import matplotlib.pyplot as plt
 
 from recovar.commands import analyze as analyze_cmd
 from recovar.commands import compute_state as compute_state_cmd

--- a/tests/unit/test_commands_analyze_state.py
+++ b/tests/unit/test_commands_analyze_state.py
@@ -1609,6 +1609,8 @@ def test_compute_state_add_args_requires_latent_points():
     import argparse
 
     parser = compute_state_cmd.add_args(argparse.ArgumentParser())
+    action = parser._option_string_actions["--latent-points"]
+    assert ".txt/.npy/.npz/.pkl" in action.help
     parsed = parser.parse_args(
         [
             "/tmp/result_dir",

--- a/tests/unit/test_commands_analyze_state.py
+++ b/tests/unit/test_commands_analyze_state.py
@@ -785,7 +785,7 @@ def test_compute_state_rejects_unknown_latent_extension(monkeypatch, tmp_path):
         fsc_mask_edgewidth=None,
     )
 
-    with pytest.raises(ValueError, match="Target zs should be a .txt or .pkl file"):
+    with pytest.raises(ValueError, match=r"Target zs should be a \.txt, \.npy, \.npz, or \.pkl file"):
         compute_state_cmd.compute_state(args)
 
 
@@ -933,7 +933,7 @@ def test_compute_state_rejects_missing_latent_points_file(monkeypatch, tmp_path)
         fsc_mask_radius=None,
         fsc_mask_edgewidth=None,
     )
-    with pytest.raises(FileNotFoundError, match="Latent points file not found"):
+    with pytest.raises(FileNotFoundError, match="Target zs file not found"):
         compute_state_cmd.compute_state(args)
 
 
@@ -1388,6 +1388,26 @@ def test_compute_state_rejects_missing_contrasts_or_cov_zs_key(monkeypatch, tmp_
     )
     with pytest.raises(ValueError, match="zdim 2 from provided latent points is not found"):
         compute_state_cmd.compute_state(args)
+
+
+def test_load_latent_points_accepts_npy(tmp_path):
+    latent_points = np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32)
+    latent_path = tmp_path / "latent.npy"
+    np.save(latent_path, latent_points)
+
+    out = compute_state_cmd._load_latent_points(str(latent_path))
+
+    np.testing.assert_array_equal(out, latent_points)
+
+
+def test_load_latent_points_accepts_npz_named_key(tmp_path):
+    latent_points = np.array([[0.5, 1.5]], dtype=np.float32)
+    latent_path = tmp_path / "latent.npz"
+    np.savez(latent_path, latent_points=latent_points)
+
+    out = compute_state_cmd._load_latent_points(str(latent_path))
+
+    np.testing.assert_array_equal(out, latent_points)
 
 
 def test_compute_state_rejects_missing_cov_zs_key(monkeypatch, tmp_path):

--- a/tests/unit/test_commands_misc.py
+++ b/tests/unit/test_commands_misc.py
@@ -449,7 +449,9 @@ def test_run_test_dataset_tilt_only_emits_tilt_commands(monkeypatch, tmp_path):
     assert any("make_test_dataset" in cmd and "--tilt-series" in cmd for cmd in commands)
     assert any("pipeline" in cmd and "--tilt-series" in cmd for cmd in commands)
     assert any("reconstruct_from_external_embedding" in cmd and "--tilt-series" in cmd for cmd in commands)
-    assert any("model/zdim_2/latent_coords.npy" in cmd for cmd in commands if "reconstruct_from_external_embedding" in cmd)
+    assert any(
+        "model/zdim_2/latent_coords.npy" in cmd for cmd in commands if "reconstruct_from_external_embedding" in cmd
+    )
     assert not any("estimate_conformational_density" in cmd for cmd in commands)
 
 

--- a/tests/unit/test_commands_misc.py
+++ b/tests/unit/test_commands_misc.py
@@ -449,6 +449,7 @@ def test_run_test_dataset_tilt_only_emits_tilt_commands(monkeypatch, tmp_path):
     assert any("make_test_dataset" in cmd and "--tilt-series" in cmd for cmd in commands)
     assert any("pipeline" in cmd and "--tilt-series" in cmd for cmd in commands)
     assert any("reconstruct_from_external_embedding" in cmd and "--tilt-series" in cmd for cmd in commands)
+    assert any("model/zdim_2/latent_coords.npy" in cmd for cmd in commands if "reconstruct_from_external_embedding" in cmd)
     assert not any("estimate_conformational_density" in cmd for cmd in commands)
 
 
@@ -583,6 +584,8 @@ def test_run_test_dataset_all_tests_bad_embeddings_payload_skips_reconstruct(mon
 
     embeddings_path = tmp_path / "test_dataset" / "pipeline_output" / "model" / "embeddings.pkl"
     embeddings_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(embeddings_path.parent / "params.pkl", "wb") as f:
+        pickle.dump({"input_args": SimpleNamespace(zdim=[2])}, f)
     with open(embeddings_path, "wb") as f:
         # Missing "latent_coords" key should cause reconstruction prep to fail gracefully.
         pickle.dump({"not_latent_coords": {}}, f)
@@ -785,7 +788,7 @@ def test_run_test_dataset_all_tests_quotes_reconstruct_paths_with_spaces(monkeyp
 
     reconstruct_cmds = [c for c in commands if "reconstruct_from_external_embedding" in c]
     assert reconstruct_cmds
-    quoted_embedding = shlex.quote(str(outdir / "test_dataset" / "embedding_2.pkl"))
+    quoted_embedding = shlex.quote(str(outdir / "test_dataset" / "embedding_2.npy"))
     quoted_target = shlex.quote(str(outdir / "test_dataset" / "target.txt"))
     assert any(f"--embedding {quoted_embedding} " in c for c in reconstruct_cmds)
     assert any(f"--target {quoted_target} " in c for c in reconstruct_cmds)

--- a/tests/unit/test_commands_pipeline.py
+++ b/tests/unit/test_commands_pipeline.py
@@ -73,6 +73,15 @@ def test_pipeline_registers_ctf():
     assert "--ctf" in actions
 
 
+def test_pipeline_help_strings_list_numpy_and_text_fallbacks():
+    actions = _parser_with_pipeline_args()._option_string_actions
+    assert ".pkl/.npy/.npz" in actions["--poses"].help
+    assert ".pkl/.npy/.npz" in actions["--ctf"].help
+    assert ".pkl/.npy/.npz/.txt" in actions["--ind"].help
+    assert ".pkl/.npy/.npz/.txt" in actions["--particle-ind"].help
+    assert ".pkl/.npy/.npz/.txt" in actions["--halfsets"].help
+
+
 def test_pipeline_registers_mask():
     actions = _parser_with_pipeline_args()._option_string_actions
     assert "--mask" in actions

--- a/tests/unit/test_commands_reconstruct_external.py
+++ b/tests/unit/test_commands_reconstruct_external.py
@@ -55,6 +55,15 @@ def test_registers_target_arg():
     assert "--target" in _parser()._option_string_actions
 
 
+def test_reconstruct_help_strings_list_supported_serialized_formats():
+    actions = _parser()._option_string_actions
+    assert ".pkl/.npy/.npz" in actions["--poses"].help
+    assert ".pkl/.npy/.npz" in actions["--ctf"].help
+    assert ".pkl/.npy/.npz/.txt" in actions["--ind"].help
+    assert ".pkl/.npy/.npz/.txt" in actions["--particle-ind"].help
+    assert ".txt/.pkl/.npy/.npz" in actions["--target"].help
+
+
 # ---------------------------------------------------------------------------
 # Optional arguments with sensible defaults
 # ---------------------------------------------------------------------------
@@ -112,3 +121,23 @@ def test_load_external_embeddings_rejects_bad_shape(tmp_path):
 
     with pytest.raises(ValueError, match="must have shape"):
         rfe_cmd._load_external_embeddings(str(path))
+
+
+def test_load_target_points_accepts_npy(tmp_path):
+    target = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    path = tmp_path / "target.npy"
+    np.save(path, target)
+
+    out = rfe_cmd._load_target_points(str(path))
+
+    np.testing.assert_array_equal(out, target)
+
+
+def test_load_target_points_accepts_npz_named_key(tmp_path):
+    target = np.array([0.5, 1.5], dtype=np.float32)
+    path = tmp_path / "target.npz"
+    np.savez(path, target=target)
+
+    out = rfe_cmd._load_target_points(str(path))
+
+    np.testing.assert_array_equal(out, target)

--- a/tests/unit/test_commands_reconstruct_external.py
+++ b/tests/unit/test_commands_reconstruct_external.py
@@ -5,6 +5,7 @@ Covers argument registration and external embedding loading helpers.
 """
 
 import argparse
+
 import numpy as np
 import pytest
 

--- a/tests/unit/test_commands_reconstruct_external.py
+++ b/tests/unit/test_commands_reconstruct_external.py
@@ -1,10 +1,11 @@
 """
 Unit tests for recovar.commands.reconstruct_from_external_embedding.
 
-Covers argument registration via add_args() only – no actual reconstruction.
+Covers argument registration and external embedding loading helpers.
 """
 
 import argparse
+import numpy as np
 import pytest
 
 pytest.importorskip("jax")  # module imports jax at top level
@@ -82,3 +83,32 @@ def test_tilt_series_is_boolean_flag():
     if action is None:
         pytest.skip("--tilt-series not in parser")
     assert action.const is True  # store_true
+
+
+def test_load_external_embeddings_accepts_npy(tmp_path):
+    emb = np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32)
+    path = tmp_path / "embedding.npy"
+    np.save(path, emb)
+
+    out = rfe_cmd._load_external_embeddings(str(path))
+
+    np.testing.assert_array_equal(out, emb)
+
+
+def test_load_external_embeddings_accepts_npz_named_key(tmp_path):
+    emb = np.array([[1.0, 2.0]], dtype=np.float32)
+    path = tmp_path / "embedding.npz"
+    np.savez(path, latent_coords=emb)
+
+    out = rfe_cmd._load_external_embeddings(str(path))
+
+    np.testing.assert_array_equal(out, emb)
+
+
+def test_load_external_embeddings_rejects_bad_shape(tmp_path):
+    emb = np.zeros((2, 2, 2), dtype=np.float32)
+    path = tmp_path / "embedding.npy"
+    np.save(path, emb)
+
+    with pytest.raises(ValueError, match="must have shape"):
+        rfe_cmd._load_external_embeddings(str(path))

--- a/tests/unit/test_index_utils_loading.py
+++ b/tests/unit/test_index_utils_loading.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 import pytest
 
@@ -36,3 +38,23 @@ def test_load_index_like_accepts_txt(tmp_path):
     out = load_index_like(str(path))
 
     np.testing.assert_array_equal(out, np.array([2, 4, 6], dtype=np.int64))
+
+
+def test_load_index_like_warns_for_legacy_pickle(tmp_path):
+    indices = np.array([0, 4, 8], dtype=np.int32)
+    path = tmp_path / "indices.pkl"
+    with open(path, "wb") as handle:
+        pickle.dump(indices, handle)
+
+    with pytest.warns(DeprecationWarning, match="legacy pickle index files"):
+        out = load_index_like(str(path))
+
+    np.testing.assert_array_equal(out, indices)
+
+
+def test_load_index_like_rejects_unknown_suffix(tmp_path):
+    path = tmp_path / "indices.bin"
+    path.write_bytes(b"not-a-supported-index-file")
+
+    with pytest.raises(ValueError, match=r"\.pkl, \.npy, \.npz, or \.txt"):
+        load_index_like(str(path))

--- a/tests/unit/test_index_utils_loading.py
+++ b/tests/unit/test_index_utils_loading.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from recovar.data_io._index_utils import load_index_like
+
+pytestmark = pytest.mark.unit
+
+
+def test_load_index_like_accepts_npy(tmp_path):
+    indices = np.array([1, 3, 5], dtype=np.int32)
+    path = tmp_path / "indices.npy"
+    np.save(path, indices)
+
+    out = load_index_like(str(path))
+
+    np.testing.assert_array_equal(out, indices)
+
+
+def test_load_index_like_accepts_multiarray_npz(tmp_path):
+    half0 = np.array([0, 2], dtype=np.int32)
+    half1 = np.array([1, 3], dtype=np.int32)
+    path = tmp_path / "halfsets.npz"
+    np.savez(path, halfset_0=half0, halfset_1=half1)
+
+    out = load_index_like(str(path))
+
+    assert len(out) == 2
+    np.testing.assert_array_equal(out[0], half0)
+    np.testing.assert_array_equal(out[1], half1)
+
+
+def test_load_index_like_accepts_txt(tmp_path):
+    path = tmp_path / "indices.txt"
+    np.savetxt(path, np.array([2, 4, 6], dtype=np.int32), fmt="%d")
+
+    out = load_index_like(str(path))
+
+    np.testing.assert_array_equal(out, np.array([2, 4, 6], dtype=np.int64))

--- a/tests/unit/test_load_utils.py
+++ b/tests/unit/test_load_utils.py
@@ -3,9 +3,10 @@ import pytest
 
 pytest.importorskip("jax")
 
-from recovar.data_io import load_utils
 from helpers import tiny_synthetic
+
 from recovar import utils
+from recovar.data_io import load_utils
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_load_utils.py
+++ b/tests/unit/test_load_utils.py
@@ -78,6 +78,28 @@ def test_load_ctf_params_rejects_nonfinite_payload(monkeypatch):
         load_utils.load_ctf_params(D=64, ctf_params_pkl="dummy.pkl")
 
 
+def test_load_ctf_params_accepts_npy(tmp_path):
+    ctf = np.array([[128, 1.5, 10000, 11000, 0.0, 300, 2.7, 0.1, 0.0]], dtype=np.float32)
+    path = tmp_path / "ctf.npy"
+    np.save(path, ctf)
+
+    out = load_utils.load_ctf_params(D=64, ctf_params_pkl=str(path))
+
+    assert out.shape == (1, 8)
+    assert np.allclose(out[:, 0], 3.0)
+
+
+def test_load_ctf_params_accepts_npz_named_key(tmp_path):
+    ctf = np.array([[128, 1.5, 10000, 11000, 0.0, 300, 2.7, 0.1, 0.0]], dtype=np.float32)
+    path = tmp_path / "ctf.npz"
+    np.savez(path, ctf_params=ctf)
+
+    out = load_utils.load_ctf_params(D=64, ctf_params_pkl=str(path))
+
+    assert out.shape == (1, 8)
+    assert np.allclose(out[:, 0], 3.0)
+
+
 def test_load_poses_single_file_with_translations_scales_by_D(monkeypatch):
     rots = np.repeat(np.eye(3, dtype=np.float32)[None, :, :], 3, axis=0)
     trans_frac = np.array([[0.0, 0.5], [1.0, 0.25], [0.1, 0.2]], dtype=np.float32)
@@ -106,6 +128,31 @@ def test_load_poses_two_file_input(monkeypatch):
     rots_out, trans_out, _ = load_utils.load_poses(["rots.pkl", "trans.pkl"], Nimg=2, D=64)
     assert np.allclose(rots_out, rots)
     assert np.allclose(trans_out, trans_frac * 64)
+
+
+def test_load_poses_accepts_single_npy_rotation_file(tmp_path):
+    rots = np.repeat(np.eye(3, dtype=np.float32)[None, :, :], 2, axis=0)
+    path = tmp_path / "rots.npy"
+    np.save(path, rots)
+
+    rots_out, trans_out, D_out = load_utils.load_poses(str(path), Nimg=2, D=64)
+
+    assert D_out == 64
+    assert trans_out is None
+    np.testing.assert_allclose(rots_out, rots)
+
+
+def test_load_poses_accepts_single_npz_bundle(tmp_path):
+    rots = np.repeat(np.eye(3, dtype=np.float32)[None, :, :], 2, axis=0)
+    trans_frac = np.array([[0.25, 0.75], [0.5, 0.5]], dtype=np.float32)
+    path = tmp_path / "poses.npz"
+    np.savez(path, rots=rots, trans=trans_frac)
+
+    rots_out, trans_out, D_out = load_utils.load_poses(str(path), Nimg=2, D=64)
+
+    assert D_out == 64
+    np.testing.assert_allclose(rots_out, rots)
+    np.testing.assert_allclose(trans_out, trans_frac * 64)
 
 
 def test_load_poses_accepts_list_payload_and_applies_indices(monkeypatch):

--- a/tests/unit/test_output_helpers.py
+++ b/tests/unit/test_output_helpers.py
@@ -1,10 +1,13 @@
+import json
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
-from types import SimpleNamespace
 
 pytest.importorskip("jax")
 from recovar import utils
 from recovar.output import output
+from recovar.output.output_paths import ResultPaths
 
 pytestmark = pytest.mark.unit
 
@@ -259,6 +262,26 @@ def test_pipeline_output_get_u_real_caps_to_50_saved_eigenvectors(tmp_path, monk
     u_real = po.get("u_real")
     assert u_real.shape == (50, 2, 2, 2)
     assert len(calls) == 50
+
+
+def test_write_metadata_json_advertises_per_zdim_embeddings(tmp_path):
+    result_path = tmp_path / "pipeline_output"
+    paths = ResultPaths(str(result_path))
+    paths.ensure_model_dir()
+
+    output.write_metadata_json(
+        paths,
+        {
+            "version": "0.2",
+            "input_args": SimpleNamespace(zdim=[2, 4]),
+            "volume_shape": (8, 8, 8),
+            "voxel_size": 1.5,
+        },
+    )
+
+    metadata = json.loads((result_path / "model" / "metadata.json").read_text())
+    assert metadata["files"]["embeddings"] == "model/zdim_{N}/{latent_coords,latent_precision,contrasts}.npy"
+    assert metadata["files"]["embeddings_legacy"] == "model/embeddings.pkl"
 
 
 def test_pipeline_output_get_u_real_raises_when_no_eigenvectors_saved(tmp_path):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+# ruff: noqa: E402
 jax = pytest.importorskip("jax")
 jnp = pytest.importorskip("jax.numpy")
 pytest.importorskip("mrcfile")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -197,7 +197,8 @@ def test_options_and_pickle_helpers(tmp_path):
     path = tmp_path / "obj.pkl"
     obj = {"a": 1, "b": [1, 2]}
     utils.pickle_dump(obj, path)
-    assert utils.pickle_load(path) == obj
+    with pytest.warns(DeprecationWarning, match="legacy RECOVAR pickle files"):
+        assert utils.pickle_load(path) == obj
 
 
 def test_get_variances_and_batch_index_helpers():


### PR DESCRIPTION
## Summary

Scoped incremental progress on #34. RECOVAR already writes embeddings as per-zdim `.npy` files; this PR aligns readers, tests, packaging metadata, and user-facing help with that existing output format while keeping backward-compatible pickle fallback.

This branch now also fixes the packaging/CI fallout that showed up on the first draft:

- accept `.npy/.npz` alongside legacy `.pkl` in downstream loaders that still forced pickle round-trips
- update downstream/test-harness paths to read `model/zdim_{N}/*.npy` instead of synthesizing fresh `embeddings.pkl`
- add deprecation warnings on legacy pickle reads and stop silently treating unknown index suffixes as pickle
- refresh stale CLI help text and `model/metadata.json` so user-facing docs match the actual supported/output formats
- include `recovar/cuda/Makefile` and `recovar/cuda/cuda_backproject.cu` in both `sdist` and wheel artifacts
- fix changed-file CI gates on this branch (`ruff format`, `ruff check`, `mypy`)

## Test Results

### Changed-File CI Gates (commit `dac6ae16`)

Command:
`pixi run bash scripts/check_changed_python.sh --base origin/dev --format --lint --typecheck`

| Check | Result | Delta | Status |
| --- | --- | --- | --- |
| Ruff format | pass | better | OK |
| Ruff lint | pass | better | OK |
| Mypy | pass | better | OK |

### Targeted Local Validation (commit `dac6ae16`)

Command:
`NVCC=/usr/local/cuda/bin/nvcc PATH=/usr/local/cuda/bin:$PATH pixi run python -m pytest tests/unit/test_packaging_metadata.py tests/unit/test_utils.py tests/unit/test_index_utils_loading.py tests/unit/test_commands_pipeline.py tests/unit/test_commands_analyze_state.py tests/unit/test_commands_reconstruct_external.py tests/unit/test_output_helpers.py tests/unit/test_load_utils.py tests/unit/test_commands_misc.py`

| Slice | Result | Delta | Status | Notes |
| --- | --- | --- | --- | --- |
| targeted reader/help/metadata/packaging/tests | 196 passed | better | OK | includes packaging metadata regression |

### Long-Test Validation (Slurm jobs `6944040`-`6944050` on commit `dac6ae16`)

Command:
`SLURMO_DIR=/scratch/gpfs/GILLES/mg6942/slurmo ./scripts/run_tests_parallel.sh long-test`

Summary log:
`/scratch/gpfs/GILLES/mg6942/slurmo/recovar-summary-6944050.out`

| Group | Result | Tests | Failures | Delta | Status | Notes |
| --- | --- | ---: | ---: | --- | --- | --- |
| `unit` | PASS | 2462 | 0 | better | OK | packaging regression fixed |
| `smoke-tiny` | PASS | 13 | 0 | same | OK | |
| `downstream` | PASS | 14 | 0 | same | OK | |
| `metrics-spa` | PASS | 1 | 0 | same | OK | |
| `metrics-et` | PASS | 1 | 0 | same | OK | |
| `pdb-traj` | PASS | 1 | 0 | same | OK | |
| `indices` | PASS | 2 | 0 | same | OK | |
| `stress` | PASS | 2 | 0 | same | OK | |
| `isolated-funcs` | PASS | 8 | 0 | same | OK | |
| `outliers-long` | FAIL | 4 | 1 | same | FAIL | cryo-ET regression baseline only |
| `TOTAL` | FAIL | 2508 | 1 | better | FAIL | validation incomplete due outliers |

## Regression Tables

### Compatibility / UX / Packaging

| Area | Baseline | Current | Delta | Status |
| --- | --- | --- | --- | --- |
| `compute_state --latent-points` contract | help text implied `.txt` only | help text now matches `.txt/.npy/.npz/.pkl` support | better | OK |
| `reconstruct_from_external_embedding --target` contract | `.txt` only | `.txt/.pkl/.npy/.npz` | better | OK |
| `pipeline` dataset-loading help | stale `.pkl` wording for poses/ctf/indices/halfsets | help text now matches accepted `.pkl/.npy/.npz/.txt` inputs | better | OK |
| `metadata.json` embeddings entry | `model/embeddings.pkl` | `model/zdim_{N}/{latent_coords,latent_precision,contrasts}.npy` plus legacy entry | better | OK |
| `_index_utils.load_index_like` unknown suffix handling | implicit pickle fallback | explicit supported-suffix error | better | OK |
| legacy pickle visibility | silent read path | deprecation warning on pickle reads | better | OK |
| packaging metadata test | wheel missing CUDA build files | `sdist` and wheel now include CUDA build files | better | OK |
| changed-file CI gates | failed on format/lint/mypy | pass | better | OK |

### Available Performance Output

The full available performance output from `run_tests_parallel.sh long-test` for this branch was per-group wall time only; the suite did not emit a historical perf baseline for comparison.

| Group | Metric | Current | Delta | Status |
| --- | --- | ---: | --- | --- |
| `unit` | wall time | 634.5s | info | OK |
| `smoke-tiny` | wall time | 2523.3s | info | OK |
| `downstream` | wall time | 1600.5s | info | OK |
| `metrics-spa` | wall time | 1053.9s | info | OK |
| `metrics-et` | wall time | 1396.6s | info | OK |
| `pdb-traj` | wall time | 1067.8s | info | OK |
| `indices` | wall time | 1626.7s | info | OK |
| `stress` | wall time | 3253.9s | info | OK |
| `isolated-funcs` | wall time | 3.5s | info | OK |
| `outliers-long` | wall time | 1943.6s | info | FAIL |
| `TOTAL` | wall time | 15104.2s | info | FAIL |

## Perf Warnings / Validation Gaps

- `run_tests_parallel.sh long-test` only emitted per-group wall times for this run; no historical perf baseline or model-quality delta table was available from that suite, so the table above is the full available perf output.
- The only remaining failing group is `outliers-long`.
- Current failing metric from `/scratch/gpfs/GILLES/mg6942/slurmo/recovar-outliers-long-6944045.out`:
  - `particle_precision_round_2`: `0.1508` vs baseline `0.1598` (`-5.6%`, allowed `-5.0%`) -> worse

## Checklist

- [x] Tests pass (`pixi run test-fast` at minimum)
- [x] No modifications to `tests/baselines/`
- [x] No tolerance widening in tests
- [x] Regression table included (if applicable)

Refs #34
