### PR TITLE
cuda+cli: Blackwell support, --cpu actually forces CPU, XLA-autotuner docs (#131)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -121,6 +121,48 @@ RECOVAR_DISABLE_CUDA=1 recovar ...
 
 That workaround is supported, but it is not the preferred configuration.
 
+### `JaxRuntimeError: INTERNAL: Autotuning failed for HLO ... NOT_FOUND: No valid config found!`
+
+This is XLA's GPU autotuner — the part of JAX that picks an optimal CUDA
+kernel at JIT time — failing because it has no tuning data for your GPU.
+Symptoms include the message above, sometimes preceded by repeated
+`Allocator (GPU_X_bfc) ran out of memory` warnings (those are autotuner
+candidate-kernel probes failing, not real OOM).
+
+This happens on **GPUs newer than the JAX version was tuned for** —
+most often Blackwell (sm_100, sm_120: B100/B200, RTX 50-series, RTX
+PRO Blackwell) on JAX versions cut before Blackwell support landed.
+
+Workaround — disable autotuning so XLA falls back to default heuristic
+kernel selection:
+
+```bash
+export XLA_FLAGS="--xla_gpu_autotune_level=0"
+recovar ...
+```
+
+You can stack this with `RECOVAR_DISABLE_CUDA=1` if you also need to
+avoid recovar's custom kernel:
+
+```bash
+export RECOVAR_DISABLE_CUDA=1
+export XLA_FLAGS="--xla_gpu_autotune_level=0"
+recovar ...
+```
+
+If `--xla_gpu_autotune_level=0` doesn't help, two more knobs to try:
+
+```bash
+export XLA_FLAGS="--xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false"
+# or
+export XLA_FLAGS="--xla_gpu_autotune_level=0 --xla_gpu_enable_command_buffer="
+```
+
+If none of these work, your GPU is past what your JAX version's XLA can
+lower at all. The fix is upgrading JAX once a release with tuning data
+for your hardware is available — there is no recovar-side workaround.
+This is a JAX/XLA limitation, not a recovar bug.
+
 ## Pipeline issues
 
 ### Mean looks wrong

--- a/recovar/commands/run_test_all_metrics.py
+++ b/recovar/commands/run_test_all_metrics.py
@@ -1,22 +1,23 @@
-import os
-import sys
-import json
-import pickle
 import argparse
+import json
+import logging
 import math
+import os
+import pickle
+import sys
 import time
 from pathlib import Path
-import logging
-import numpy as np
-import matplotlib.pyplot as plt
+
 import jax
+import matplotlib.pyplot as plt
+import numpy as np
 import psutil
 
-from recovar import utils
-from recovar.simulation import simulator, synthetic_dataset
-from recovar.output import output, metrics, plot_utils
 import recovar.core.fourier_transform_utils as fourier_transform_utils
-from recovar.commands import pipeline, compute_state
+from recovar import utils
+from recovar.commands import compute_state, pipeline
+from recovar.output import metrics, output, plot_utils
+from recovar.simulation import simulator, synthetic_dataset
 
 LOWER_IS_BETTER_TOKENS = (
     "error",
@@ -132,9 +133,7 @@ def _stage_perf(before, after):
 # ---------------------------------------------------------------------------
 # PDB-based trajectory volume generation
 # ---------------------------------------------------------------------------
-from recovar.simulation.trajectory_generation import (
-    CHAIN_GROUPS_5NRL as _5NRL_CHAIN_GROUPS,
-    split_atom_group_by_chains as _split_atom_group_by_chains,
+from recovar.simulation.trajectory_generation import (  # noqa: E402
     generate_trajectory_volumes as generate_pdb_trajectory_volumes,
 )
 
@@ -675,7 +674,11 @@ def main():
     parser.add_argument(
         "--no-delete", action="store_true", help="Do not delete the test dataset directory after successful tests"
     )
-    parser.add_argument("--cpu", action="store_true", help="Run on CPU only (skip GPU check)")
+    parser.add_argument(
+        "--cpu",
+        action="store_true",
+        help="Force CPU-only execution. Sets JAX_PLATFORMS=cpu so JAX ignores any visible GPUs, AND passes --accept-cpu to the inner pipeline so it doesn't bail on the no-GPU check.",
+    )
     parser.add_argument("--n-images", type=float, default=5e4, help="Number of images in the test dataset")
     parser.add_argument(
         "--grid-size", type=int, default=64, help="Grid size for the test dataset (default: 64, matching 5nrl notebook)"
@@ -834,7 +837,13 @@ def main():
         except Exception as e:
             error_message(f"Error checking GPU devices: {e}")
 
-    if not args.cpu:
+    # Force CPU-only mode in any spawned subprocess. This wrapper has likely
+    # already imported jax above, so this env var doesn't affect THIS process's
+    # jax state — but it does propagate to the `recovar pipeline ...`
+    # subprocesses we spawn below, which is where the actual work happens.
+    if args.cpu:
+        os.environ["JAX_PLATFORMS"] = "cpu"
+    else:
         check_gpu()
 
     perf = {"gpu_name": _gpu_name()}

--- a/recovar/commands/run_test_dataset.py
+++ b/recovar/commands/run_test_dataset.py
@@ -22,7 +22,11 @@ def main():
     parser.add_argument(
         "--no-delete", action="store_true", help="Do not delete the test dataset directory after successful tests"
     )
-    parser.add_argument("--cpu", action="store_true", help="Run on CPU only (skip GPU check)")
+    parser.add_argument(
+        "--cpu",
+        action="store_true",
+        help="Force CPU-only execution. Sets JAX_PLATFORMS=cpu so JAX ignores any visible GPUs, AND passes --accept-cpu to the inner pipeline so it doesn't bail on the no-GPU check.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -32,6 +36,13 @@ def main():
     delete_everything = not args.no_delete
     run_on_cpu = args.cpu
     dataset_dir = args.output_dir
+
+    # Force CPU-only mode in any spawned subprocess. This wrapper itself has
+    # already imported jax above, so this env var doesn't affect THIS process's
+    # jax state — but it does propagate to the `recovar pipeline ...`
+    # subprocesses we spawn below, which is where the actual work happens.
+    if run_on_cpu:
+        os.environ["JAX_PLATFORMS"] = "cpu"
 
     BASE_CMD = f"{shlex.quote(sys.executable)} -m recovar.command_line"
 
@@ -65,6 +76,7 @@ def main():
         # Verify the CUDA kernel loads on this GPU (catches arch mismatches early)
         try:
             from recovar.cuda_backproject import cuda_available
+
             if cuda_available():
                 logger.info("CUDA backproject/project kernels: OK")
             else:

--- a/recovar/commands/run_test_outliers_pipeline.py
+++ b/recovar/commands/run_test_outliers_pipeline.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-import glob
 import logging
 import os
 import pickle
@@ -22,7 +21,11 @@ def main():
     parser.add_argument(
         "--no-delete", action="store_true", help="Do not delete the test dataset directory after successful tests"
     )
-    parser.add_argument("--cpu", action="store_true", help="Run on CPU only (skip GPU check)")
+    parser.add_argument(
+        "--cpu",
+        action="store_true",
+        help="Force CPU-only execution. Sets JAX_PLATFORMS=cpu so JAX ignores any visible GPUs, AND passes --accept-cpu to the inner pipeline so it doesn't bail on the no-GPU check.",
+    )
     parser.add_argument("--tilt-series", action="store_true", help="Test with tilt series dataset")
     parser.add_argument("--n-images", type=int, default=10000, help="Number of images to generate in test dataset")
     parser.add_argument("--k-rounds", type=int, default=2, help="Number of rounds for outlier detection pipeline")
@@ -66,6 +69,13 @@ def main():
     k_rounds = args.k_rounds
     percent_outliers = args.percent_outliers
     percent_tilt_series_outliers = args.percent_tilt_series_outliers
+
+    # Force CPU-only mode in any spawned subprocess. This wrapper has already
+    # imported jax above, so this env var doesn't affect THIS process's jax
+    # state — but it does propagate to the `recovar pipeline ...` subprocesses
+    # we spawn below, which is where the actual work happens.
+    if run_on_cpu:
+        os.environ["JAX_PLATFORMS"] = "cpu"
 
     # Base command is now "recovar" (which dispatches to the appropriate subcommand)
     BASE_CMD = "python -m recovar.command_line"

--- a/recovar/cuda/Makefile
+++ b/recovar/cuda/Makefile
@@ -23,23 +23,47 @@ endif
 
 XLA_INC    := $(shell $(PYTHON) -c "import jax.ffi; print(jax.ffi.include_dir())")
 
+# Detect nvcc major.minor so we can conditionally enable newer arches.
+# Older toolkits (e.g. CUDA 12.4) reject `compute_100` / `compute_120` with
+# "unsupported gpu architecture", so we only request them when supported.
+NVCC_VERSION := $(shell $(NVCC) --version 2>/dev/null | grep -oE 'release [0-9]+\.[0-9]+' | awk '{print $$2}')
+NVCC_MAJOR := $(word 1, $(subst ., ,$(NVCC_VERSION)))
+NVCC_MINOR := $(word 2, $(subst ., ,$(NVCC_VERSION)))
+HAS_BLACKWELL := $(shell awk -v M=$(NVCC_MAJOR) -v m=$(NVCC_MINOR) 'BEGIN{print (M>12 || (M==12 && m>=8))?"yes":"no"}')
+
 # Multi-arch covering realistic academic cryo-EM hardware:
-#   sm_70 — V100, Titan V (Volta)
-#   sm_75 — T4, RTX 20-series, Quadro RTX (Turing)
-#   sm_80 — A100, A30 (Ampere data-center)
-#   sm_86 — RTX 30-series, A40, A10 (Ampere consumer/workstation)
-#   sm_89 — RTX 40-series, L40, L4 (Ada Lovelace)
-#   sm_90 — H100, H200 (Hopper)
-# Plus a compute_75 PTX target so future archs (sm_100+) JIT forward-compatibly.
+#   sm_70  — V100, Titan V (Volta)
+#   sm_75  — T4, RTX 20-series, Quadro RTX (Turing)
+#   sm_80  — A100, A30 (Ampere data-center)
+#   sm_86  — RTX 30-series, A40, A10 (Ampere consumer/workstation)
+#   sm_89  — RTX 40-series, L40, L4 (Ada Lovelace)
+#   sm_90  — H100, H200 (Hopper)
+#   sm_100 — B100, B200, GB200 (Blackwell data-center, requires nvcc >= 12.8)
+#   sm_120 — RTX 50-series, RTX PRO Blackwell (Blackwell consumer, requires nvcc >= 12.8)
+# Plus a compute_120 PTX target (or compute_90 when nvcc < 12.8) so future
+# archs JIT forward-compatibly through the driver.
 # Pascal (sm_60/61) is opt-in: pre-Volta GPUs are increasingly rare in cryo-EM
 # clusters; users who need them can override CUDA_ARCH at make time.
-CUDA_ARCH  ?= -gencode arch=compute_70,code=sm_70 \
-              -gencode arch=compute_75,code=sm_75 \
-              -gencode arch=compute_80,code=sm_80 \
-              -gencode arch=compute_86,code=sm_86 \
-              -gencode arch=compute_89,code=sm_89 \
-              -gencode arch=compute_90,code=sm_90 \
-              -gencode arch=compute_75,code=compute_75
+CUDA_ARCH_BASE := -gencode arch=compute_70,code=sm_70 \
+                  -gencode arch=compute_75,code=sm_75 \
+                  -gencode arch=compute_80,code=sm_80 \
+                  -gencode arch=compute_86,code=sm_86 \
+                  -gencode arch=compute_89,code=sm_89 \
+                  -gencode arch=compute_90,code=sm_90
+
+ifeq ($(HAS_BLACKWELL),yes)
+CUDA_ARCH ?= $(CUDA_ARCH_BASE) \
+             -gencode arch=compute_100,code=sm_100 \
+             -gencode arch=compute_120,code=sm_120 \
+             -gencode arch=compute_120,code=compute_120
+else
+# Fall back to compute_90 PTX so the kernel can still JIT to Blackwell on
+# the user's machine even when the build toolkit is too old to emit native
+# Blackwell SASS. Driver-side JIT from compute_90 PTX to sm_100/sm_120 is
+# imperfect but better than no fallback at all.
+CUDA_ARCH ?= $(CUDA_ARCH_BASE) \
+             -gencode arch=compute_90,code=compute_90
+endif
 
 NVCC_FLAGS := -O3 -std=c++17 -Xcompiler -fPIC --shared $(CUDA_ARCH) -I$(XLA_INC)
 

--- a/tests/unit/test_cuda_arch_coverage.py
+++ b/tests/unit/test_cuda_arch_coverage.py
@@ -1,20 +1,67 @@
-"""Guard the CUDA_ARCH default — these compute caps must always be covered."""
-import re
+"""Guard the CUDA_ARCH default — these compute caps must always be covered.
+
+The Makefile builds two arch sets depending on nvcc version:
+  - CUDA_ARCH_BASE: always present (sm_70..sm_90).
+  - Blackwell extension (sm_100, sm_120, compute_120 PTX): only when
+    nvcc >= 12.8.
+  - Fallback PTX (compute_90): only when nvcc < 12.8.
+
+We test the raw Makefile text for the presence of all required gencode
+lines in both branches, since we can't easily run `make -p` in CI.
+"""
+
 from pathlib import Path
 
 
-def test_makefile_covers_v1_release_floor():
-    mk = Path("recovar/cuda/Makefile").read_text()
-    m = re.search(r"CUDA_ARCH\s*\?=((?:[^\n]*\\\n)*[^\n]*)", mk)
-    assert m, "CUDA_ARCH default not found in Makefile"
-    block = m.group(1)
+def _read_makefile() -> str:
+    return Path("recovar/cuda/Makefile").read_text()
+
+
+def test_base_arches_cover_volta_through_hopper():
+    """sm_70..sm_90 must always be in the base set, regardless of nvcc version."""
+    mk = _read_makefile()
     for sm in ("70", "75", "80", "86", "89", "90"):
-        assert f"code=sm_{sm}" in block, (
-            f"CUDA_ARCH default missing sm_{sm} cubin — "
-            f"this breaks {sm} GPUs (e.g. V100/T4/A100/etc.). "
-            f"Block was: {block}"
+        assert f"code=sm_{sm}" in mk, (
+            f"Makefile missing sm_{sm} cubin in base set — this breaks {sm} GPUs (e.g. V100/T4/A100/etc.)."
         )
-    assert "code=compute_" in block, (
-        "CUDA_ARCH default has no PTX (code=compute_XX) target — "
-        "future archs will fail with no JIT fallback."
+
+
+def test_blackwell_branch_has_sm_100_sm_120_and_ptx():
+    """When nvcc >= 12.8, build with sm_100, sm_120, and compute_120 PTX."""
+    mk = _read_makefile()
+    assert "code=sm_100" in mk, (
+        "Makefile missing sm_100 cubin (Blackwell data-center: B100/B200) — "
+        "users on those GPUs will hit 'no kernel image'."
+    )
+    assert "code=sm_120" in mk, (
+        "Makefile missing sm_120 cubin (Blackwell consumer: RTX 50/RTX PRO) — "
+        "users on those GPUs will hit 'no kernel image'."
+    )
+    assert "code=compute_120" in mk, (
+        "Makefile missing compute_120 PTX target — future post-Blackwell GPUs will have no JIT fallback."
+    )
+
+
+def test_pre_blackwell_fallback_ptx():
+    """When nvcc < 12.8, fall back to compute_90 PTX so the kernel can still
+    JIT to Blackwell on the user's machine (imperfect but better than no
+    fallback)."""
+    mk = _read_makefile()
+    assert "code=compute_90" in mk, (
+        "Makefile missing compute_90 PTX fallback for older toolkits — "
+        "users with nvcc < 12.8 on Blackwell hardware will hit 'no kernel image'."
+    )
+
+
+def test_has_blackwell_conditional_present():
+    """The HAS_BLACKWELL Make conditional must exist so older toolkits
+    don't fail the build with 'unsupported gpu architecture'."""
+    mk = _read_makefile()
+    assert "HAS_BLACKWELL" in mk, (
+        "Makefile must conditionally enable sm_100/sm_120 based on nvcc version. "
+        "Without the conditional, users with nvcc < 12.8 fail to build."
+    )
+    assert "ifeq ($(HAS_BLACKWELL),yes)" in mk, (
+        "HAS_BLACKWELL conditional structure changed; update this test or "
+        "the Makefile so the two branches stay in sync."
     )


### PR DESCRIPTION
## Summary

Three follow-ups from issue #131 after the v1.0.0 user reported a CUDA error from a Blackwell GPU on `dev`. The original v1.0.0 fix widened `CUDA_ARCH` to sm_70..sm_90 + compute_75 PTX, which covered V100/T4/A100/Ada/Hopper but **not** Blackwell. This PR closes the remaining gaps the user surfaced.

### What changes

**1. Blackwell support in the CUDA Makefile** (`recovar/cuda/Makefile`)

- Adds native sm_100 (B100/B200) and sm_120 (RTX 50 / RTX PRO Blackwell) SASS targets.
- Adds a `compute_120` PTX fallback so future post-Blackwell archs JIT forward through the driver.
- Adds a Make conditional (`HAS_BLACKWELL`) that drops the new targets when nvcc is older than 12.8, falling back to a `compute_90` PTX line so users with CUDA 12.4 toolkits don't fail with "unsupported gpu architecture" at build time.

**2. `--cpu` actually forces CPU** (`recovar/commands/run_test_*.py`)

The `--cpu` flag on the wrapper commands was misnamed — it only translated to `--accept-cpu` on the inner pipeline (which suppresses the "no GPU? error out" check). With visible GPUs, JAX still used them. So a user trying to bypass GPU issues by passing `--cpu` still hit GPU code paths — exactly what triggered the user's confusion in #131.

Fix: each wrapper now also exports `JAX_PLATFORMS=cpu`, which propagates to the spawned `recovar pipeline` subprocess. Combined with `--accept-cpu`, this genuinely runs on CPU regardless of visible GPUs. Help text on `--cpu` updated to reflect the new (correct) semantics.

**3. Troubleshooting docs for the XLA autotuner** (`docs/troubleshooting.md`)

JAX 0.9.0.1's XLA doesn't have autotuner data for Blackwell, so users on those GPUs hit `JaxRuntimeError: INTERNAL: Autotuning failed for HLO ... NOT_FOUND: No valid config found!` even after rebuilding the custom kernel. This is a JAX/XLA limitation, not a recovar bug. Document the `XLA_FLAGS=--xla_gpu_autotune_level=0` workaround plus two follow-up flags that sometimes help, and call out that upgrading JAX is the only real fix once those stop working.

Closes #131 follow-up.

## What is intentionally NOT in this PR

- A native `recovar` API change to make `RECOVAR_DISABLE_CUDA=1` selectable from a CLI flag — the env var is sufficient for now.
- A bumped JAX pin. JAX 0.9.0.1 stays the supported version; once a JAX with full Blackwell tuning lands, that's a separate PR to update the pin and remove the autotuner workaround note.

## Testing

- `tests/unit/test_cuda_arch_coverage.py` rewritten to enforce the new invariants: base arches always present, Blackwell branch contains sm_100 / sm_120 / compute_120 PTX, pre-Blackwell branch falls back to compute_90 PTX, the `HAS_BLACKWELL` Make conditional is in place. **4/4 pass.**
- Makefile conditional verified empirically by faking nvcc reporting 12.9 (Blackwell branch taken) and 12.4 (fallback branch taken).
- `pixi run mypy` clean on all four touched Python files.
- Long-test parallel suite submitted: Slurm jobs `7521497–7521508`, summary job `7521509`. The summary log will be posted as a comment when stress (the longest group) completes (~2-3h ETA).

The changes do **not** touch any code path that the long-test exercises:
- The Makefile change only takes effect when a user rebuilds their `.so`; the long-test rebuilds it once at start with the same gencode set as before, plus the new targets.
- The `--cpu` env-var fix only changes wrapper behavior in `run_test_*` commands; the long-test invokes pytest directly, not via these wrappers.
- The docs change is text only.

## Quality + performance regression tables

Generated from the most recent long-test data via `pixi run python scripts/extract_regression_tables.py`. Tables will be re-generated and replaced once the new long-test summary completes.

### SPA Quality (current vs `tests/baselines/`)

| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.026187 | 0.026234 | +0.18% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025953 | -1.12% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026100 | +0.39% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.026078 | -0.09% (better) | OK |
| embedding_squared_error_10 | 1.978306 | 1.953171 | -1.27% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.383126 | +0.91% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980249 | +0.04% (better) | OK |
| noise_max_relative_error | 2.112245 | 2.114650 | +0.11% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049131 | -3.69% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005746 | -3.61% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.478721 | +3.97% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.475346 | +5.22% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality

| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.024244 | 0.024068 | -0.73% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024057 | -0.83% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023829 | -0.81% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023824 | -0.82% (better) | OK |
| embedding_squared_error_10 | 1.460294 | 1.411756 | -3.32% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.203284 | -5.05% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.06% (better) | OK |
| noise_max_relative_error | 2.152798 | 2.140589 | -0.57% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049610 | -4.26% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005676 | -0.37% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.640464 | +0.94% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.638488 | +0.93% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

**Quality verdict: 32/32 OK across SPA + ET, several improvements (notably ET pipeline `embedding_squared_error_4` -5.05%), zero quality regressions.**

### SPA Performance (current vs baseline, H100)

| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 136.2s | 146.4s | +7.5% (worse) | OK |
| dataset_generation | GPU_memory | 4.9GB | 4.9GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.3GB | 5.6GB | +5.8% (worse) | OK |
| pipeline | wall_time | 578.5s | 580.2s | +0.3% (worse) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 42.7GB | 40.5GB | -5.0% (better) | OK |
| compute_state | wall_time | 317.3s | 221.1s | -30.3% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 46.7GB | 44.8GB | -4.2% (better) | OK |
| metrics | wall_time | 20.8s | 25.6s | +22.9% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2682.9% (worse) | **REGRESSED** |
| metrics | CPU_memory | 50.7GB | 49.5GB | -2.2% (better) | OK |

### Cryo-ET Performance

| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 128.5s | 140.7s | +9.5% (worse) | OK |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.1GB | 5.4GB | +6.6% (worse) | OK |
| pipeline | wall_time | 1886.7s | 979.1s | -48.1% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 38.1GB | 42.5GB | +11.5% (worse) | **REGRESSED** |
| compute_state | wall_time | 145.9s | 206.4s | +41.4% (worse) | **REGRESSED** |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 38.2GB | 46.4GB | +21.6% (worse) | **REGRESSED** |
| metrics | wall_time | 19.9s | 26.2s | +31.7% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2694.7% (worse) | **REGRESSED** |
| metrics | CPU_memory | 41.6GB | 51.1GB | +22.8% (worse) | **REGRESSED** |

### Performance verdict

10 entries flagged **REGRESSED**, all on `compute_state` and `metrics` (not on the main `pipeline` stage). All are pre-existing on `dev` from prior commits — none are introduced by this PR's changes (Makefile widening, `--cpu` env-var fix, and docs are not on any pipeline/compute_state/metrics code path). ET pipeline wall-time actually **improved** −48.1%. The compute_state / metrics regressions are tracked as a separate v1.0.x cleanup item and were already documented as "ship-with-known-regressions" when v1.0.0 was tagged.

## Test plan

- [ ] Wait for long-test summary `7521509` to complete.
- [ ] Re-run `pixi run python scripts/extract_regression_tables.py` and replace tables above with the fresh ones (numbers should be near-identical since none of the changes touch the pipeline code path).
- [ ] Manual: on a machine with `nvcc >= 12.8`, run `make -p` in `recovar/cuda/` and verify `CUDA_ARCH` includes `sm_100`, `sm_120`, and `compute_120`.
- [ ] Manual: on a machine with `nvcc < 12.8`, verify `make` falls back to `compute_90` PTX without error.
- [ ] Manual: `recovar run_test_dataset --cpu` on a host with visible GPUs — confirm `JAX_PLATFORMS=cpu` propagates and the inner pipeline runs on CPU only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
