### PR TITLE
Fix: graceful fallback when XDG_CACHE_HOME is unwritable (#136)

### DIFF
--- a/recovar/cuda_backproject.py
+++ b/recovar/cuda_backproject.py
@@ -24,6 +24,7 @@ import logging
 import os
 import pathlib
 import subprocess
+import tempfile
 import threading
 from contextlib import contextmanager
 from types import ModuleType
@@ -67,16 +68,87 @@ def custom_cuda_requested() -> bool:
     return not _env_flag(_DISABLE_CUSTOM_CUDA_ENV)
 
 
+_CACHE_ROOT_FALLBACK_WARNED = False
+
+
+def _path_is_writable(path: pathlib.Path) -> bool:
+    """Return True iff *path* exists or can be created and a tiny file
+    written and unlinked there.
+
+    Used to gate fallbacks in :func:`_cache_root` when the user's
+    ``XDG_CACHE_HOME`` (or ``$HOME``) points at a directory that exists
+    but cannot be written to — e.g. issue #136 where ``XDG_CACHE_HOME``
+    resolves to ``/home/levans`` but the real home is ``/mnt/home/levans``.
+    """
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except (PermissionError, OSError):
+        return False
+    probe = path / ".recovar_write_test"
+    try:
+        probe.write_text("ok")
+    except (PermissionError, OSError):
+        return False
+    try:
+        probe.unlink()
+    except (PermissionError, OSError):
+        return False
+    return True
+
+
+def _warn_cache_root_fallback(rejected: list[tuple[str, pathlib.Path]], chosen: pathlib.Path) -> None:
+    parts = ", ".join(f"{label}={path}" for label, path in rejected)
+    logger.warning(
+        "RECOVAR cuda cache: %s is not writable, falling back to %s. Set %s to silence this warning.",
+        parts,
+        chosen,
+        _CUDA_CACHE_DIR_ENV,
+    )
+
+
 def _cache_root() -> pathlib.Path:
+    """Pick a writable cache directory for the CUDA shared library.
+
+    Resolution order, each step gated on writability (except the
+    explicit override):
+
+    1. ``RECOVAR_CUDA_CACHE_DIR`` — explicit override, returned as-is.
+    2. ``$XDG_CACHE_HOME/recovar/cuda``
+    3. ``~/.cache/recovar/cuda``
+    4. ``tempfile.gettempdir()/recovar_cuda_cache/cuda`` — last-resort
+       fallback when neither of the above is writable. Logs a WARNING.
+
+    Steps 2 and 3 each attempt ``mkdir(parents=True, exist_ok=True)``
+    plus a tiny probe-file write and delete. ``PermissionError`` and
+    ``OSError`` are caught and trigger a fall-through to the next
+    candidate.
+    """
+    global _CACHE_ROOT_FALLBACK_WARNED
+
     override = os.environ.get(_CUDA_CACHE_DIR_ENV)
     if override:
         return pathlib.Path(override).expanduser()
 
+    candidates: list[tuple[str, pathlib.Path]] = []
     xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
     if xdg_cache_home:
-        return pathlib.Path(xdg_cache_home).expanduser() / "recovar" / "cuda"
+        candidates.append(("XDG_CACHE_HOME", pathlib.Path(xdg_cache_home).expanduser() / "recovar" / "cuda"))
+    candidates.append(("HOME", pathlib.Path.home().expanduser() / ".cache" / "recovar" / "cuda"))
 
-    return pathlib.Path.home().expanduser() / ".cache" / "recovar" / "cuda"
+    rejected: list[tuple[str, pathlib.Path]] = []
+    for label, path in candidates:
+        if _path_is_writable(path):
+            if rejected and not _CACHE_ROOT_FALLBACK_WARNED:
+                _warn_cache_root_fallback(rejected, path)
+                _CACHE_ROOT_FALLBACK_WARNED = True
+            return path
+        rejected.append((label, path))
+
+    fallback = pathlib.Path(tempfile.gettempdir()) / "recovar_cuda_cache" / "cuda"
+    if not _CACHE_ROOT_FALLBACK_WARNED:
+        _warn_cache_root_fallback(rejected, fallback)
+        _CACHE_ROOT_FALLBACK_WARNED = True
+    return fallback
 
 
 def _cached_lib_path() -> pathlib.Path:

--- a/tests/unit/test_cuda_cache_root_fallback.py
+++ b/tests/unit/test_cuda_cache_root_fallback.py
@@ -1,0 +1,152 @@
+"""CPU-only tests for `_cache_root` fallback when XDG_CACHE_HOME / HOME
+are unwritable (issue #136).
+
+The reporter's cluster has ``XDG_CACHE_HOME=/home/levans`` while the
+real home is ``/mnt/home/levans`` — ``/home/levans`` exists but is not
+writable, so ``recovar build_custom_cuda`` previously crashed with
+``PermissionError``. ``_cache_root`` must now probe the candidate
+directory and fall through to the next one.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from recovar import cuda_backproject
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_root_state(monkeypatch):
+    """Each test starts with a clean warning flag and no inherited
+    RECOVAR_CUDA_CACHE_DIR. Other env vars are set per test."""
+    monkeypatch.setattr(cuda_backproject, "_CACHE_ROOT_FALLBACK_WARNED", False)
+    monkeypatch.delenv("RECOVAR_CUDA_CACHE_DIR", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+
+def _make_unwritable_dir(parent: Path, name: str) -> Path:
+    d = parent / name
+    d.mkdir()
+    d.chmod(0o000)
+    return d
+
+
+def _restore(*paths: Path) -> None:
+    """Restore 0o755 perms so pytest's tmp_path cleanup can rmtree."""
+    for p in paths:
+        try:
+            p.chmod(0o755)
+        except OSError:
+            pass
+
+
+def test_xdg_unwritable_falls_back_to_home(tmp_path, monkeypatch, caplog):
+    """When XDG_CACHE_HOME points at a chmod-000 directory but HOME is
+    writable, _cache_root() returns the HOME-based path and warns."""
+    bad_xdg = _make_unwritable_dir(tmp_path, "xdg_unwritable")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    try:
+        monkeypatch.setenv("XDG_CACHE_HOME", str(bad_xdg))
+        monkeypatch.setenv("HOME", str(home))
+
+        caplog.set_level(logging.WARNING, logger=cuda_backproject.logger.name)
+        result = cuda_backproject._cache_root()
+
+        # 1. Returned path is under HOME, not the bad XDG dir
+        assert str(result).startswith(str(home)), result
+        assert str(bad_xdg) not in str(result), result
+        assert result == home / ".cache" / "recovar" / "cuda"
+
+        # 2. The chosen path is actually writable
+        assert cuda_backproject._path_is_writable(result)
+
+        # 3. A WARNING was emitted naming the bad XDG path and the
+        #    RECOVAR_CUDA_CACHE_DIR env var
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "expected a fallback warning"
+        msg = warnings[0].getMessage()
+        assert "XDG_CACHE_HOME" in msg
+        assert str(bad_xdg) in msg
+        assert "RECOVAR_CUDA_CACHE_DIR" in msg
+    finally:
+        _restore(bad_xdg)
+
+
+def test_override_wins_over_unwritable_xdg(tmp_path, monkeypatch, caplog):
+    """RECOVAR_CUDA_CACHE_DIR is the explicit user override and must be
+    returned as-is, regardless of XDG state — no probe, no warning."""
+    bad_xdg = _make_unwritable_dir(tmp_path, "xdg_unwritable")
+    override = tmp_path / "explicit" / "cuda"
+
+    try:
+        monkeypatch.setenv("XDG_CACHE_HOME", str(bad_xdg))
+        monkeypatch.setenv("RECOVAR_CUDA_CACHE_DIR", str(override))
+
+        caplog.set_level(logging.WARNING, logger=cuda_backproject.logger.name)
+        result = cuda_backproject._cache_root()
+
+        assert result == override
+        # Override wins even when its parent is missing — no probe runs
+        assert not result.exists()
+        # No fallback warning fired
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not warnings, f"unexpected fallback warnings: {warnings}"
+    finally:
+        _restore(bad_xdg)
+
+
+def test_both_xdg_and_home_unwritable_falls_back_to_tempdir(tmp_path, monkeypatch, caplog):
+    """If neither XDG nor HOME is writable, fall back to
+    `tempfile.gettempdir()/recovar_cuda_cache/cuda` and emit a WARNING
+    naming both rejected candidates."""
+    bad_xdg = _make_unwritable_dir(tmp_path, "xdg_unwritable")
+    bad_home = _make_unwritable_dir(tmp_path, "home_unwritable")
+
+    try:
+        monkeypatch.setenv("XDG_CACHE_HOME", str(bad_xdg))
+        monkeypatch.setenv("HOME", str(bad_home))
+
+        caplog.set_level(logging.WARNING, logger=cuda_backproject.logger.name)
+        result = cuda_backproject._cache_root()
+
+        expected = Path(tempfile.gettempdir()) / "recovar_cuda_cache" / "cuda"
+        assert result == expected, result
+        # Tempdir fallback is itself writable
+        assert cuda_backproject._path_is_writable(result)
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "expected a fallback warning"
+        msg = warnings[0].getMessage()
+        assert "XDG_CACHE_HOME" in msg
+        assert "HOME" in msg
+        assert str(expected) in msg
+        assert "RECOVAR_CUDA_CACHE_DIR" in msg
+    finally:
+        _restore(bad_xdg, bad_home)
+
+
+def test_path_is_writable_handles_chmod000_existing_dir(tmp_path):
+    """The probe correctly rejects an existing-but-unwritable directory
+    (the exact failure mode in #136 where /home/levans existed but was
+    not writable)."""
+    bad = _make_unwritable_dir(tmp_path, "bad")
+    try:
+        # Try a subpath that doesn't exist yet — mkdir(parents=True)
+        # should fail at the chmod-000 parent
+        target = bad / "recovar" / "cuda"
+        assert not cuda_backproject._path_is_writable(target)
+    finally:
+        _restore(bad)
+
+    # Sanity: a fresh writable directory passes
+    good = tmp_path / "good" / "recovar" / "cuda"
+    assert cuda_backproject._path_is_writable(good)
+    assert good.is_dir()
+    # Probe file was cleaned up
+    assert not (good / ".recovar_write_test").exists()


### PR DESCRIPTION
## Summary

Fixes #136. `recovar build_custom_cuda` previously crashed with
`PermissionError: [Errno 13]` when `$XDG_CACHE_HOME` resolved to a
directory the user could not write to (the reporter's cluster has
`XDG_CACHE_HOME=/home/levans` while the writable home is
`/mnt/home/levans`). `_cache_root` now probes each candidate before
returning it and falls through on `PermissionError` / `OSError`:

1. `RECOVAR_CUDA_CACHE_DIR` — explicit override, returned as-is
2. `$XDG_CACHE_HOME/recovar/cuda` — probed
3. `~/.cache/recovar/cuda` — probed
4. `tempfile.gettempdir()/recovar_cuda_cache/cuda` — last-resort, logs a `WARNING`

The probe is `mkdir(parents=True, exist_ok=True)` + tiny
`.recovar_write_test` write/delete. When fallback fires, the warning
names every rejected candidate and points the user at
`RECOVAR_CUDA_CACHE_DIR` to silence it. Downstream build helpers
(`_existing_lib_path`, `_ensure_lib_path`, `_build_file_lock`,
`build_custom_cuda`) all derive their parent dir from `_cache_root`,
so they inherit the writable root automatically — no additional
guards needed.

## Files Modified

- `recovar/cuda_backproject.py` — `_cache_root` now probes candidates;
  new `_path_is_writable` helper; new `_warn_cache_root_fallback`.
- `tests/unit/test_cuda_cache_root_fallback.py` — 4 new CPU-only tests:
  1. chmod-000 `XDG_CACHE_HOME` → falls back to HOME, emits warning naming both
  2. `RECOVAR_CUDA_CACHE_DIR` override wins regardless of XDG state, no warning
  3. Both XDG and HOME unwritable → tempdir fallback + warning
  4. `_path_is_writable` rejects chmod-000 existing dir and accepts a fresh writable one

## Tests Run

- `pixi run test-fast`: **2437 passed, 85 skipped** (15m 39s) — local
- `tests/unit/test_cuda_cache_root_fallback.py`: **4 passed** (1.75s) — local
- Long-test parallel Slurm jobs **7816486–7816495** (groups), summary **7816496**:

```
downstream      PASS   tests=  14  fail=0  time=1365s
indices         PASS   tests=   2  fail=0  time=1917s
isolated-funcs  PASS   tests=   8  fail=0  time=2s
metrics-et      PASS   tests=   1  fail=0  time=1664s
metrics-spa     PASS   tests=   1  fail=0  time=1225s
outliers-long   PASS   tests=   4  fail=0  time=2206s
pdb-traj        PASS   tests=   1  fail=0  time=1233s
smoke-tiny      FAIL   tests=  15  fail=1  time=3071s   ← known-flaky test, see below
stress          PASS   tests=   2  fail=0  time=4065s
unit            PASS   tests=2469  fail=0  time= 658s
TOTAL                  tests=2517  fail=1  time=17407s
```

### Flaky test note (`test_run_test_outliers_pipeline_tiny_regression_uses_saved_baseline`)

The single failure is in a **known-finicky self-consistency test** —
Run 1 writes a fresh baseline, Run 2 compares the same code's output
against it. The 10% tolerance gates run-to-run stochasticity in the
same code (GPU atomic-add ordering on tiny 32³, 800-image data), not
regression vs. `tests/baselines/`.

This change touches only `_cache_root()` (a one-time path lookup);
it cannot mathematically affect outlier metrics. To confirm, the test
was rerun 4× on this branch and 3× on `origin/dev` (job IDs
7820900, 7822857, 7822858, 7822628, 7822859, 7822860):

| Branch | Runs | Pass | Fail | Failing recall drop |
|--------|------|------|------|---------------------|
| `claude/cuda-cache-permission-fallback` | 4 | 2 | 2 | 0.16, 0.17 |
| `origin/dev` | 3 | 2 | 1 | 0.13 |

`origin/dev` reproduces the same failure pattern with the same
magnitude. This is pre-existing flakiness — commit `e942bdc8
"Stabilize flaky outlier regressions"` already addressed common
cases but not all — and is not introduced by this PR.

## How to Reproduce

```bash
cd /home/mg6942/myscratch/recovar_wt_136_1778186769
pixi install && pixi run install-recovar
pixi run pytest tests/unit/test_cuda_cache_root_fallback.py -v
```

To trigger the original bug from #136 manually:

```bash
mkdir -p /tmp/bad_xdg && chmod 000 /tmp/bad_xdg
XDG_CACHE_HOME=/tmp/bad_xdg pixi run python -c \
  "from recovar import cuda_backproject; print(cuda_backproject._cache_root())"
chmod 755 /tmp/bad_xdg && rmdir /tmp/bad_xdg
```

Before this PR: `PermissionError: [Errno 13]`.
After: returns `~/.cache/recovar/cuda` and emits a `WARNING`.

## Quality Comparison (current vs baseline)

### SPA Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.026187 | 0.026238 | +0.20% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025951 | -1.13% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026102 | +0.40% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.026076 | -0.10% (better) | OK |
| embedding_squared_error_10 | 1.978306 | 1.953296 | -1.26% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.383100 | +0.90% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980249 | +0.04% (better) | OK |
| noise_max_relative_error | 2.112245 | 2.114649 | +0.11% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049131 | -3.69% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005747 | -3.61% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.478798 | +3.98% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.475433 | +5.24% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.024244 | 0.024064 | -0.74% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024061 | -0.81% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023830 | -0.81% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023825 | -0.82% (better) | OK |
| embedding_squared_error_10 | 1.460294 | 1.411587 | -3.34% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.203242 | -5.07% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.06% (better) | OK |
| noise_max_relative_error | 2.152798 | 2.140589 | -0.57% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049609 | -4.26% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005677 | -0.36% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.640544 | +0.95% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.638566 | +0.94% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

All quality metrics OK; no regressions and several improvements.

## Performance Comparison (current vs baseline)

### SPA Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 136.2s | 139.0s | +2.1% (worse) | OK |
| dataset_generation | GPU_memory | 4.9GB | 4.9GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.3GB | 5.3GB | +0.7% (worse) | OK |
| pipeline | wall_time | 578.5s | 745.4s | +28.8% (worse) | **REGRESSED** |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 42.7GB | 40.6GB | -4.9% (better) | OK |
| compute_state | wall_time | 317.3s | 214.2s | -32.5% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 0.2GB | -28.5% (better) | OK |
| compute_state | CPU_memory | 46.7GB | 41.5GB | -11.3% (better) | OK |
| metrics | wall_time | 20.8s | 33.8s | +62.6% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 0.1GB | +65.8% (worse) | **REGRESSED** |
| metrics | CPU_memory | 50.7GB | 46.1GB | -8.9% (better) | OK |

### Cryo-ET Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 128.5s | 135.1s | +5.1% (worse) | OK |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.1GB | 5.1GB | +1.3% (worse) | OK |
| pipeline | wall_time | 1886.7s | 1196.5s | -36.6% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 38.1GB | 40.1GB | +5.1% (worse) | OK |
| compute_state | wall_time | 145.9s | 205.1s | +40.5% (worse) | **REGRESSED** |
| compute_state | GPU_memory | 0.2GB | 0.2GB | 0.0% (same) | OK |
| compute_state | CPU_memory | 38.2GB | 43.2GB | +13.2% (worse) | **REGRESSED** |
| metrics | wall_time | 19.9s | 34.4s | +72.7% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 0.1GB | +76.3% (worse) | **REGRESSED** |
| metrics | CPU_memory | 41.6GB | 47.9GB | -8.9% (worse) | **REGRESSED** |

The marked regressions are inconsistent in sign across SPA vs ET
(e.g. SPA pipeline +29% but ET pipeline -37%) and cannot be caused
by this change. `_cache_root()` runs once at import to pick a path
for the cached `.so`; the kernel binary itself, once loaded, is
byte-identical regardless of which directory it lives in. These
swings are cluster-node variability between baseline-capture run
and this PR's run.

Closes #136
