### PR TITLE
Fix all-ones dilated mask when keep_input_mask=True

### DIFF
--- a/recovar/core/mask.py
+++ b/recovar/core/mask.py
@@ -69,6 +69,12 @@ def masking_options(
 
         if keep_input_mask:
             volume_mask = input_mask
+            # Use a separate boolean base for dilation, keeping the (soft) input
+            # mask intact for soft masking. A mask loaded from an .mrc carries tiny
+            # (~1e-8) nonzero roundoff in almost every voxel, and binary_dilation
+            # treats any nonzero as foreground -- dilating the raw float directly
+            # blows the dilated mask up to all-ones.
+            dilation_base = input_mask > 0.5
         else:
             logger.info("Using input mask")
             if mask_dilation_iter > 0:
@@ -82,8 +88,9 @@ def masking_options(
             logger.info("Thresholding mask at 0.5 and softening with cosine kernel of radius %d pixels", kernel_size)
             input_mask = input_mask > 0.5
             volume_mask = soften_volume_mask(input_mask, kernel_size)
+            dilation_base = input_mask
 
-        dilated_volume_mask = binary_dilation(input_mask, iterations=dilated_mask_dilations_iter)
+        dilated_volume_mask = binary_dilation(dilation_base, iterations=dilated_mask_dilations_iter)
         dilated_volume_mask = soften_volume_mask(dilated_volume_mask, kernel_size)
 
     elif volume_mask_option == "from_halfmaps":
@@ -116,8 +123,7 @@ def masking_options(
 # ---------------------------------------------------------------------------
 
 
-def make_mask(volume, *, threshold="auto", lowpass_sigma=None, extend=None,
-              soft_edge=3, cleanup=True):
+def make_mask(volume, *, threshold="auto", lowpass_sigma=None, extend=None, soft_edge=3, cleanup=True):
     """Create a solvent mask from a 3-D real-space volume.
 
     Follows the same conceptual pipeline as RELION's ``relion_mask_create``:
@@ -206,8 +212,9 @@ def make_mask(volume, *, threshold="auto", lowpass_sigma=None, extend=None,
         thresh_val = float(threshold)
 
     binary = (filtered > thresh_val) & radial
-    logger.info("Mask threshold: %.4g  (%.1f%% of voxels inside radial mask)",
-                thresh_val, 100.0 * binary.sum() / radial.sum())
+    logger.info(
+        "Mask threshold: %.4g  (%.1f%% of voxels inside radial mask)", thresh_val, 100.0 * binary.sum() / radial.sum()
+    )
 
     # --- 3. Morphological cleanup ---
     if cleanup:
@@ -260,8 +267,7 @@ def make_mask_from_half_maps(halfmap1, halfmap2, smax=3, method="auto", **kwargs
     """
     if method == "local_correlation":
         soft_edge = kwargs.get("soft_edge", 2)
-        return _make_mask_from_half_maps_local_corr(halfmap1, halfmap2, smax=smax,
-                                                     soft_edge=soft_edge)
+        return _make_mask_from_half_maps_local_corr(halfmap1, halfmap2, smax=smax, soft_edge=soft_edge)
 
     avg = (np.asarray(halfmap1) + np.asarray(halfmap2)) / 2.0
     return make_mask(avg, **kwargs)

--- a/tests/unit/test_core_mask.py
+++ b/tests/unit/test_core_mask.py
@@ -591,3 +591,35 @@ class TestReferenceEquivalence:
         )
         np.testing.assert_array_equal(got_binary, exp_binary)
         np.testing.assert_allclose(got_soft, exp_soft)
+
+
+def test_keep_input_mask_dilated_not_all_ones(tmp_path):
+    """Regression: masking_options(keep_input_mask=True) must threshold before
+    dilation. A mask loaded from an .mrc carries ~1e-8 nonzero roundoff in
+    (almost) every voxel; binary_dilation treats any nonzero as foreground, so
+    without an explicit threshold the dilated solvent mask blows up to all-ones.
+    That all-ones mask silently corrupts the variance/covariance estimate
+    downstream (flat PCA spectrum, washed-out latent embedding).
+    """
+    N = 32
+    coords = np.indices((N, N, N)) - N / 2
+    r = np.sqrt((coords**2).sum(0))
+    blob = (r < 5).astype(np.float32)
+    # Mimic an .mrc loaded from disk: tiny nonzero roundoff almost everywhere.
+    soft = blob.copy()
+    soft[soft == 0] = 1e-8
+    soft[0, 0, 0] = -2.8e-8
+    mrc_path = tmp_path / "soft_mask.mrc"
+    utils.write_mrc(str(mrc_path), soft, voxel_size=1.0)
+
+    volume_mask, dilated_volume_mask = mask.masking_options(
+        str(mrc_path), None, (N, N, N), np.float32, 0, True, None
+    )
+
+    foreground = float(np.mean(np.asarray(dilated_volume_mask) > 0.5))
+    assert foreground < 0.5, (
+        f"dilated mask covers {foreground:.0%} of the box -- the un-thresholded "
+        "binary_dilation bug (all-ones dilated mask) has regressed"
+    )
+    # keep_input_mask keeps the raw input as the (soft) volume mask.
+    np.testing.assert_allclose(np.asarray(volume_mask), soft, rtol=0, atol=1e-6)


### PR DESCRIPTION
## Summary

Fixes a bug where `masking_options(..., keep_input_mask=True)` produces an
**all-ones dilated mask**, which silently corrupts the variance/covariance
estimate and flattens the latent embedding on any run that passes
`--keep-input-mask`.

## Root cause

`masking_options` builds the dilated solvent mask with
`binary_dilation(input_mask, ...)`. In the `keep_input_mask=True` branch the
input was assigned straight to `volume_mask` and **never thresholded to
boolean** (the `input_mask > 0.5` step lived only in the `else` branch).

A mask loaded from an `.mrc` carries tiny (~1e-8) nonzero roundoff in nearly
every voxel (observed `min = -2.8e-8`, 100% of voxels nonzero on the
EMPIAR-10073 solvent mask). `scipy.ndimage.binary_dilation` treats **any
nonzero** value as foreground, so dilating the raw float mask expands it to the
entire box.

```
dilate(raw float mask)   -> 100.0% foreground   (the bug)
dilate(mask > 0.5)       ->   6.1% foreground   (correct)
```

## Impact

`compute_variance` (and the covariance estimation) use this `dilated_volume_mask`.
With it stuck at all-ones, the variance/covariance is computed over the **whole
unmasked box** (pure-noise solvent included). On EMPIAR-10073 this inflated the
Fourier variance ~84x and high-frequency-heavy, drove the
`high_snr_from_var_est` covariance-column picker toward noise frequencies
(~6% column overlap vs the correct run), flattened the PCA spectrum
(eig-ratio 1.86 vs 2.36), and turned a clear conformational "horseshoe"
embedding/density into a near-isotropic blob. With the fix the embedding
statistics match the known-good result to ~1% and the horseshoe is restored.

## Fix

Use a separate boolean `dilation_base` so the soft input mask is preserved for
masking while the dilation runs on a thresholded mask. One-function change in
`recovar/core/mask.py`; other mask paths (default `.mrc`, `from_halfmaps`,
`sphere`, `none`) are unchanged.

## Scope

Only affects the `keep_input_mask=True` path (i.e. `--keep-input-mask`). Default
runs and `from_halfmaps` are unaffected.

## Tests

- New regression test `tests/unit/test_core_mask.py::test_keep_input_mask_dilated_not_all_ones`
  (builds a soft `.mrc` mask with ~1e-8 roundoff, asserts the dilated mask is not
  all-ones). It fails on the un-patched code and passes with the fix.
- Full `tests/unit/test_core_mask.py` passes (51 tests).

## Testing note

The full long-test/regression suite was **not** run for this PR: the change is
provably inert for every existing baseline. No regression test or baseline uses
`keep_input_mask=True` (e.g. `test_pipeline_with_outliers` passes
`keep_input_mask=False`), and the bug only manifests on that path — so the
long-test would reproduce identical baselines. Happy to run it before merge if
preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
