### PR TITLE
Rename --keep-input-mask to --dont-resmooth-mask (keep deprecated alias)

### DIFF
--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -144,10 +144,13 @@ def add_args(parser: argparse.ArgumentParser):
         help="Focus mask (.mrc)",
     )
     mk.add_argument(
+        "--dont-resmooth-mask",
         "--keep-input-mask",
         action="store_true",
-        dest="keep_input_mask",
-        help="Use input mask as-is (skip thresholding/softening)",
+        dest="dont_resmooth_mask",
+        help="Use the input mask verbatim, skipping recovar's threshold-at-0.5 and "
+        "cosine soft-edge. Only use this if your mask already has a soft edge; "
+        "otherwise recovar softens it for you. (--keep-input-mask is a deprecated alias.)",
     )
     mk.add_argument(
         "--use-complement-mask",
@@ -611,7 +614,7 @@ def _build_focus_masks(args, means, volume_mask, volume_shape, dataset):
     """Build focus masks and optional complement mask."""
     if args.focus_mask is not None:
         focus_mask, _ = mask.masking_options(
-            args.focus_mask, means, volume_shape, dataset.dtype_real, args.mask_dilate_iter, args.keep_input_mask
+            args.focus_mask, means, volume_shape, dataset.dtype_real, args.mask_dilate_iter, args.dont_resmooth_mask
         )
     else:
         focus_mask = volume_mask
@@ -978,7 +981,7 @@ def standard_recovar_pipeline(args):
             volume_shape,
             ds.dtype_real,
             args.mask_dilate_iter,
-            args.keep_input_mask,
+            args.dont_resmooth_mask,
             args.dilated_mask_dilation_iters,
         )
 


### PR DESCRIPTION
## Summary

Renames the `--keep-input-mask` pipeline flag to **`--dont-resmooth-mask`** for
clarity. `--keep-input-mask` is kept as a **deprecated alias** so existing
scripts keep working.

## Motivation

"keep input mask" reads like "use this mask file", but it actually means "use
the mask **verbatim**, skipping recovar's threshold-at-0.5 and cosine
soft-edge." That ambiguity is easy to misuse:
- on a hard/binary mask it yields a hard mask (no soft edge),
- on a solvent mask it bypasses the softening recovar would otherwise apply.

The new name states the actual behavior, and the help text spells out the
precondition (only use it if your mask is already soft).

## Change

- CLI flag `--keep-input-mask` → `--dont-resmooth-mask` (dest `dont_resmooth_mask`).
- `--keep-input-mask` retained as a hidden/deprecated alias mapping to the same dest.
- Help text clarified.

CLI-only change in `recovar/commands/pipeline.py`. The `masking_options()`
internals are unchanged, so this does not touch any computation or baseline.

## Tests

Verified both `--dont-resmooth-mask` and the `--keep-input-mask` alias parse to
`dont_resmooth_mask=True`, default is `False`, and the old dest is gone.

## Notes

- Independent of #153 (the `keep_input_mask` dilation bug fix), which touches
  only `recovar/core/mask.py`. These two PRs do not overlap.
- Long-test not run: CLI-only rename, cannot affect any baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
