### PR TITLE
Reject density outliers in PCA density dimension

### DIFF
--- a/recovar/heterogeneity/deconvolve_density.py
+++ b/recovar/heterogeneity/deconvolve_density.py
@@ -47,14 +47,19 @@ def get_raw_density(
     coords_entry = "latent_coords_noreg" if noreg else "latent_coords"
     precision_entry = "latent_precision_noreg" if noreg else "latent_precision"
 
-    zs = pipeline_output.get(coords_entry)[zdim]
-    cov_zs = pipeline_output.get(precision_entry)[zdim]
+    if hasattr(pipeline_output, "get_embedding_component"):
+        zs = pipeline_output.get_embedding_component(coords_entry, zdim)
+        cov_zs = pipeline_output.get_embedding_component(precision_entry, zdim)
+    else:
+        zs = pipeline_output.get(coords_entry)[zdim]
+        cov_zs = pipeline_output.get(precision_entry)[zdim]
 
+    zs = zs[:, :pca_dim_max]
+    cov_zs = cov_zs[:, :pca_dim_max, :pca_dim_max]
     cov_zs_norm = np.linalg.norm(cov_zs, axis=(-1, -2), ord=2)
     good_zs = cov_zs_norm > np.percentile(cov_zs_norm, percentile_reject)
-    zdim = pca_dim_max
-    zs = zs[good_zs][:, :zdim]
-    cov_zs = cov_zs[good_zs][:, :zdim, :zdim]
+    zs = zs[good_zs]
+    cov_zs = cov_zs[good_zs]
     gauss_kde = jax.scipy.stats.gaussian_kde(zs.T, "silverman")
     covar_data = np.mean(jnp.linalg.inv(cov_zs), axis=0)
     total_covar = covar_data + gauss_kde.covariance

--- a/tests/unit/test_deconvolve_density.py
+++ b/tests/unit/test_deconvolve_density.py
@@ -1,7 +1,8 @@
-import numpy as np
-import pytest
 import sys
 import types
+
+import numpy as np
+import pytest
 
 pytest.importorskip("jax")
 pytest.importorskip("jaxopt")
@@ -138,6 +139,94 @@ def _legacy_compute_deconvolved_density(
         lbfgsb_sols.append(np.array(lbfgsb_sol))
 
     return lbfgsb_sols, cost, reg_cost, alphas
+
+
+def test_get_raw_density_rejects_outliers_in_requested_pca_dim(monkeypatch):
+    zdim = 4
+    pca_dim = 2
+    num_points = 3
+    zs = np.arange(16, dtype=np.float32).reshape(4, 4)
+    cov_zs = np.zeros((4, 4, 4), dtype=np.float32)
+    diag_values = np.array(
+        [
+            [10.0, 10.0, 1.0, 1.0],
+            [1.0, 1.0, 100.0, 100.0],
+            [8.0, 8.0, 1.0, 1.0],
+            [0.5, 0.5, 90.0, 90.0],
+        ],
+        dtype=np.float32,
+    )
+    for idx, diag in enumerate(diag_values):
+        cov_zs[idx] = np.diag(diag)
+
+    class FakePipelineOutput:
+        def get_embedding_component(self, entry, key):
+            assert key == zdim
+            if entry == "latent_coords_noreg":
+                return zs
+            if entry == "latent_precision_noreg":
+                return cov_zs
+            raise KeyError(entry)
+
+        def get(self, key):
+            raise AssertionError(f"unexpected fallback get({key!r})")
+
+    captured = {}
+
+    class FakeGaussianKDE:
+        def __init__(self, dataset, bandwidth):
+            captured["kde_dataset"] = np.asarray(dataset)
+            captured["bandwidth"] = bandwidth
+            self.covariance = np.eye(pca_dim, dtype=np.float32) * 0.25
+
+    def fake_compute_latent_space_density_kde(zs_arg, pca_dim_max, num_points, percentile):
+        captured["density_zs"] = np.asarray(zs_arg)
+        captured["density_args"] = (pca_dim_max, num_points, percentile)
+        return np.ones((num_points, num_points), dtype=np.float32), np.array([[-1.0, 1.0], [-2.0, 2.0]])
+
+    def fake_make_latent_space_grid_from_bounds(bounds, num_points):
+        axes = [np.linspace(lo, hi, num_points, dtype=np.float32) for lo, hi in bounds]
+        mesh = np.meshgrid(*axes, indexing="ij")
+        return np.stack([axis.reshape(-1) for axis in mesh], axis=-1)
+
+    def fake_estimate_kernel_by_sampling(grids, cov_arg, gauss_covariance, num_samples):
+        captured["kernel_cov_zs"] = np.asarray(cov_arg)
+        captured["kernel_gauss_covariance"] = np.asarray(gauss_covariance)
+        captured["kernel_num_samples"] = num_samples
+        return np.ones(grids.shape[:-1], dtype=np.float32)
+
+    monkeypatch.setattr(dd.jax.scipy.stats, "gaussian_kde", FakeGaussianKDE)
+    monkeypatch.setattr(dd.latent_density, "compute_latent_space_density_kde", fake_compute_latent_space_density_kde)
+    monkeypatch.setattr(
+        dd.latent_density, "make_latent_space_grid_from_bounds", fake_make_latent_space_grid_from_bounds
+    )
+    monkeypatch.setattr(dd, "estimate_kernel_by_sampling", fake_estimate_kernel_by_sampling)
+
+    density, kernel, total_covar, grids, bounds = dd.get_raw_density(
+        FakePipelineOutput(),
+        zdim=zdim,
+        noreg=True,
+        pca_dim_max=pca_dim,
+        percentile_reject=50,
+        num_points=num_points,
+        percentile_bound=7,
+    )
+
+    expected_good = [0, 2]
+    expected_zs = zs[expected_good, :pca_dim]
+    expected_cov_zs = cov_zs[expected_good, :pca_dim, :pca_dim]
+    np.testing.assert_array_equal(captured["density_zs"], expected_zs)
+    np.testing.assert_array_equal(captured["kde_dataset"], expected_zs.T)
+    np.testing.assert_array_equal(captured["kernel_cov_zs"], expected_cov_zs)
+    assert captured["density_args"] == (pca_dim, num_points, 7)
+    assert captured["bandwidth"] == "silverman"
+    assert captured["kernel_num_samples"] == 5000
+    assert density.shape == (num_points, num_points)
+    assert kernel.shape == (num_points, num_points)
+    assert grids.shape == (num_points, num_points, pca_dim)
+    np.testing.assert_array_equal(bounds, np.array([[-1.0, 1.0], [-2.0, 2.0]]))
+    expected_total_covar = np.mean(np.linalg.inv(expected_cov_zs), axis=0) + np.eye(pca_dim) * 0.25
+    np.testing.assert_allclose(total_covar, expected_total_covar)
 
 
 def test_estimate_kernel_by_sampling_shape_and_normalization(cpu_device):


### PR DESCRIPTION
## Summary

- Slice latent coordinates and precision matrices to `pca_dim_max` before density outlier rejection in `get_raw_density`.
- Preserve the existing `get(...)` fallback while using `get_embedding_component(...)` when available.
- Add a focused unit test where full saved z-dimension rejection and requested PCA-dimension rejection choose different particles.

## Root Cause

`estimate_conformational_density` computes KDE/deconvolution in `pca_dim_max`, but `get_raw_density` selected covariance outliers using the full saved embedding dimension first. That could reject particles based on covariance components that are not used by the downstream density estimate.

Fixes #155.

## Validation

Run from clean worktree `/scratch/gpfs/GILLES/mg6942/recovar_dev/recovar_density_outlier_pr`:

- `git diff --cached --check`
- `pixi run python -m ruff format --check recovar/heterogeneity/deconvolve_density.py tests/unit/test_deconvolve_density.py`
- `pixi run python -m ruff check tests/unit/test_deconvolve_density.py`
- `nvidia-smi`
- `pixi run python -c "import jax; print(jax.devices())"`
- `pixi run pytest tests/unit/test_deconvolve_density.py -v`
- `pixi run smoke-import-recovar`
- `PYTHON="$(pixi run which python)" NVCC=/usr/local/cuda-12.8/bin/nvcc make -C recovar/cuda clean all`
- `./scripts/run_tests_parallel.sh long-test`

Long-test Slurm jobs:

- unit: `10844789`, PASS, 2541 passed / 32 skipped
- smoke-tiny: `10844790`, PASS, 15 passed
- downstream: `10844791`, PASS, 14 passed
- metrics-spa: `10844792`, PASS, 1 passed
- metrics-et: `10844793`, PASS, 1 passed
- outliers-long: `10844794`, PASS, 4 passed
- pdb-traj: `10844795`, PASS, 1 passed
- indices: `10844796`, PASS, 2 passed
- stress: `10844797`, PASS, 2 passed
- isolated-funcs: `10844798`, summary PASS, but all 8 tests were skipped because `FUNCTION_TEST_DATASET_DIR`/`FUNCTION_BASELINE_DIR` were unset and no local `intermediates/` baseline directory was found
- summary: `10844799`, TOTAL PASS, 2621 tests, 0 failures

Summary log: `/scratch/gpfs/GILLES/mg6942/recovar_dev/recovar_density_outlier_pr/logs/recovar-summary-10844799.out`

## Regression Tables

### SPA Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.026187 | 0.026247 | +0.23% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025938 | -1.18% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026056 | +0.22% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.025990 | -0.43% (better) | OK |
| embedding_squared_error_10 | 1.978306 | 1.951845 | -1.34% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.380108 | +0.11% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980249 | +0.04% (better) | OK |
| noise_max_relative_error | 2.112245 | 2.114650 | +0.11% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049131 | -3.69% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005747 | -3.60% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.478817 | +3.99% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.475395 | +5.23% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.024244 | 0.024055 | -0.78% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024058 | -0.82% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023828 | -0.82% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023809 | -0.88% (better) | OK |
| embedding_squared_error_10 | 1.460294 | 1.410610 | -3.40% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.201381 | -5.94% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.06% (better) | OK |
| noise_max_relative_error | 2.152798 | 2.140589 | -0.57% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049609 | -4.26% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005677 | -0.36% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.640388 | +0.92% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.638408 | +0.92% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### SPA Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 139.9s | 133.1s | -4.9% (better) | OK |
| dataset_generation | GPU_memory | 4.9GB | 4.9GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.0GB | 5.2GB | +4.5% (worse) | OK |
| pipeline | wall_time | 824.2s | 751.2s | -8.9% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 39.1GB | 40.1GB | +2.5% (worse) | OK |
| compute_state | wall_time | 246.1s | 217.6s | -11.6% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 0.3GB | +7.2% (worse) | OK |
| compute_state | CPU_memory | 42.7GB | 43.9GB | +2.8% (worse) | OK |
| metrics | wall_time | 37.5s | 35.4s | -5.7% (better) | OK |
| metrics | GPU_memory | 0.1GB | 0.1GB | -6.0% (better) | OK |
| metrics | CPU_memory | 47.2GB | 48.7GB | +3.0% (worse) | OK |

### Cryo-ET Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 134.3s | 129.2s | -3.8% (better) | OK |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 4.8GB | 5.0GB | +4.8% (worse) | OK |
| pipeline | wall_time | 2615.8s | 1209.6s | -53.8% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 36.4GB | 40.4GB | +11.0% (worse) | **REGRESSED** |
| compute_state | wall_time | 267.9s | 208.3s | -22.2% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 0.3GB | +7.2% (worse) | OK |
| compute_state | CPU_memory | 36.4GB | 44.0GB | +20.8% (worse) | **REGRESSED** |
| metrics | wall_time | 29.1s | 35.4s | +21.6% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 0.1GB | +76.3% (worse) | OK |
| metrics | CPU_memory | 40.2GB | 48.7GB | +21.2% (worse) | **REGRESSED** |

## Noted Follow-Up

- The existing long-test runner does not set the external isolated-function dataset/intermediate paths required by `tests/integration/test_pipeline_functions_isolated.py`, so that group was skipped despite the summary reporting PASS.
- Cryo-ET performance baseline comparison flagged CPU/time regressions; quality metrics passed.