### PR TITLE
Update solvar (fixed pose) 

### DIFF
--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -500,7 +500,7 @@ def add_args(parser: argparse.ArgumentParser):
         "--solvar-init",
         dest="solvar_init",
         choices=["covariance", "random"],
-        default="covariance",
+        default="random",
         help="SOLVAR loading initialization. 'covariance' warm-starts from RECOVAR covariance PCA; 'random' uses random real-space loadings.",
     )
     adv.add_argument(
@@ -517,7 +517,7 @@ def add_args(parser: argparse.ArgumentParser):
         "--solvar-batch-size",
         dest="solvar_batch_size",
         type=int,
-        default=200,
+        default=1024,
         help="Image batch size for SOLVAR optimization.",
     )
     adv.add_argument(

--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -542,6 +542,13 @@ def add_args(parser: argparse.ArgumentParser):
         help="Disable real-space mask projection after each SOLVAR update.",
     )
     adv.add_argument(
+        "--solvar-gt-data",
+        dest="solvar_gt_data",
+        type=os.path.abspath,
+        default=None,
+        help="Path to pickle file containing simulation info for SOLVAR evaluation (synthetic dataset only).",
+    )    
+    adv.add_argument(
         "--test-covar-options",
         dest="test_covar_options",
         action="store_true",
@@ -1276,6 +1283,7 @@ def _run_solvar_refinement(
     W_initial=None,
     init_mode="random",
     warm_start_n_pcs=None,
+    gt_data_info=None,
 ):
     """Run fixed-pose no-contrast SOLVAR and return pipeline-compatible arrays."""
     basis_size = int(np.max(options.zs_dim_to_test))
@@ -1310,6 +1318,11 @@ def _run_solvar_refinement(
     solvar_batch_size = int(getattr(args, "solvar_batch_size", 200))
     if solvar_batch_size <= 0:
         solvar_batch_size = int(batch_size)
+
+    if gt_data_info is not None:
+        from recovar.simulation.synthetic_dataset import load_heterogeneous_reconstruction
+        gt_data = load_heterogeneous_reconstruction(gt_data_info)
+    
     result = solvar_module.fit(
         dataset,
         means.combined,
@@ -1324,6 +1337,7 @@ def _run_solvar_refinement(
         project_mask=bool(getattr(args, "solvar_mask_projection", True)),
         disc_type_mean="cubic",
         disc_type="linear_interp",
+        gt_data=gt_data if gt_data_info is not None else None,
         return_iteration_data=True,
     )
 
@@ -1933,6 +1947,7 @@ def standard_recovar_pipeline(args):
                 W_initial=solvar_W_initial,
                 init_mode=solvar_init_mode,
                 warm_start_n_pcs=warm_start_n_pcs,
+                gt_data_info=args.solvar_gt_data
             )
             u = {"rescaled": solvar_result["u_rescaled"], "real": None}
             s = {"rescaled": solvar_result["s_rescaled"], "real": None}

--- a/recovar/simulation/simulator.py
+++ b/recovar/simulation/simulator.py
@@ -838,9 +838,9 @@ def generate_synthetic_dataset(
 def load_volumes_from_folder(volumes_path_root, grid_size, trailing_zero_format_in_vol_name=False, normalize=True):
 
     if trailing_zero_format_in_vol_name:
-
+        num_trailing_zeros = trailing_zero_format_in_vol_name if isinstance(trailing_zero_format_in_vol_name, int) else 4
         def make_file(k):
-            return volumes_path_root + format(k, "04d") + ".mrc"
+            return volumes_path_root + format(k, f"0{num_trailing_zeros}d") + ".mrc"
     else:
 
         def make_file(k):

--- a/recovar/solvar/gt_metrics.py
+++ b/recovar/solvar/gt_metrics.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+import recovar.core.fourier_transform_utils as ftu
+from recovar.output import metrics as output_metrics
+from recovar.ppca import ppca
+
+__all__ = ["compute_eigenvector_metrics", "compute_mean_relative_error"]
+
+
+def compute_eigenvector_metrics(W_half, gt_data, volume_shape, use_est_rank = True) -> dict:
+
+    U_est,s_est, _ = ppca._orthonormalize_W_to_basis(jnp.asarray(W_half), volume_shape)
+    U_est = ftu.get_dft3(U_est).reshape(U_est.shape[0], -1).T
+
+    U_gt = jnp.asarray(gt_data.get_u())
+    s_gt = jnp.asarray(gt_data.get_s())
+
+    if use_est_rank:
+        U_gt = U_gt[:, :U_est.shape[1]]
+        s_gt = s_gt[:U_est.shape[1]]
+
+    _, rel_var, _ = output_metrics.get_all_variance_scores(U_est, U_gt, s_gt)
+    sine_angles = output_metrics.subspace_angles(U_est, U_gt, max_rank=min(U_est.shape[1], U_gt.shape[1]))
+    cosine_similarity = np.sqrt(np.maximum(1.0 - sine_angles**2, 0.0))
+
+    fro_diff = output_metrics.fro_norm_diff_low_rank(
+        jnp.asarray(U_est), jnp.asarray(s_est), jnp.asarray(U_gt), jnp.asarray(s_gt)
+    ).real
+    fro_gt = jnp.sqrt(jnp.sum(jnp.asarray(s_gt) ** 2))
+
+    return {
+        "gt_relative_variance": float(rel_var[-1]),
+        "gt_relative_variance_curve": np.asarray(rel_var, dtype=np.float32).tolist(),
+        "gt_cosine_similarity": float(np.mean(cosine_similarity)),
+        "gt_fro_relative_error": float(fro_diff / fro_gt),
+    }
+
+

--- a/recovar/solvar/solvar.py
+++ b/recovar/solvar/solvar.py
@@ -50,12 +50,12 @@ def _half_image_weights(image_shape, dtype):
 
 def _weighted_gram(projected_basis, weights):
     weighted_conj = jnp.conj(projected_basis) * weights[None, None, :]
-    return jnp.einsum("bkp,bjp->bkj", weighted_conj, projected_basis).real
+    return jnp.einsum("bkp,bjp->bkj", weighted_conj, projected_basis)
 
 
 def _weighted_basis_image_inner(projected_basis, centered_images, weights):
     weighted_conj = jnp.conj(projected_basis) * weights[None, None, :]
-    return jnp.einsum("bkp,bp->bk", weighted_conj, centered_images).real
+    return jnp.einsum("bkp,bp->bk", weighted_conj, centered_images)
 
 
 def _weighted_norm_sq(images, weights):
@@ -100,16 +100,16 @@ def solvar_image_losses(centered_images, projected_basis, image_shape, *, object
     image_norm_sq = _weighted_norm_sq(centered_images, weights)
 
     if objective == "ls":
-        gram_sq = jnp.sum(gram * gram, axis=(1, 2))
-        image_basis_sq = jnp.sum(basis_image * basis_image, axis=1)
-        trace_gram = jnp.trace(gram, axis1=1, axis2=2)
+        gram_sq = jnp.sum(gram * jnp.conj(gram), axis=(1, 2)).real
+        image_basis_sq = jnp.sum(basis_image * jnp.conj(basis_image), axis=1).real
+        trace_gram = jnp.trace(gram, axis1=1, axis2=2).real
         return image_norm_sq**2 - 2.0 * (image_basis_sq + image_norm_sq) + gram_sq + 2.0 * trace_gram
 
     rank = projected_basis.shape[1]
     eye = jnp.eye(rank, dtype=gram.dtype)
     M = gram + eye[None, :, :]
     solved = jnp.linalg.solve(M, basis_image[..., None])[..., 0]
-    quad = jnp.sum(basis_image * solved, axis=1)
+    quad = jnp.sum(jnp.conj(basis_image) * solved, axis=1).real
     sign, logabsdet = jnp.linalg.slogdet(M)
     return image_norm_sq - quad + logabsdet
 

--- a/recovar/solvar/solvar.py
+++ b/recovar/solvar/solvar.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 import logging
 from typing import NamedTuple
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -67,6 +68,84 @@ def _state_from_loadings(W_half, volume_shape) -> WHalfParametrization:
     U_half = ftu.get_dft3_real(jnp.asarray(U_real)).reshape(rank, -1).T.astype(W_half.dtype)
     log_sqrt_eigenvalues = 0.5 * jnp.log(jnp.asarray(eigenvalues, dtype=U_half.real.dtype))
     return WHalfParametrization(U=U_half, log_sqrt_eigenvalues=log_sqrt_eigenvalues)
+
+
+class TrainConfig(eqx.Module):
+    """Structural configuration for one :func:`fit` run — fixed for its whole duration.
+
+    All fields are static (compile-time constants): changing any of them
+    triggers a JIT recompilation.
+    """
+
+    image_shape: tuple = eqx.field(static=True)
+    volume_shape: tuple = eqx.field(static=True)
+    ctf_evaluator: core.CTFEvaluator = eqx.field(static=True)
+    disc_type_mean: str = eqx.field(static=True)
+    disc_type: str = eqx.field(static=True)
+    objective: str = eqx.field(static=True)
+    project_mask: bool = eqx.field(static=True)
+    optimizer: optax.GradientTransformation = eqx.field(static=True)
+
+
+class TrainArrs(NamedTuple):
+    """Arrays fixed for the whole ``fit()`` run but too large to bake in as JIT constants."""
+
+    W_prior_half: jax.Array
+    mean_for_slicing: jax.Array
+    volume_mask: jax.Array | None
+
+
+class BatchStruct(NamedTuple):
+    """One mini-batch of images and per-image pose/CTF/noise data."""
+
+    images_half: jax.Array
+    ctf_params: jax.Array
+    rotation_matrices: jax.Array
+    translations: jax.Array
+    noise_variance_half: jax.Array
+    voxel_size: jax.Array
+    data_scale: jax.Array
+
+
+
+@jax.jit
+def _train_step(params: WHalfParametrization, opt_state: optax.OptState, batch: BatchStruct, tensor_data: TrainArrs, config: TrainConfig):
+    """
+    Batched SOLVAR SGD step.
+    """
+
+    def loss_for_params(params):
+        return _batch_total_loss(
+            loadings_from_state(params),
+            tensor_data.W_prior_half,
+            batch.images_half,
+            tensor_data.mean_for_slicing,
+            batch.ctf_params,
+            batch.rotation_matrices,
+            batch.translations,
+            batch.noise_variance_half,
+            config.image_shape,
+            config.volume_shape,
+            batch.voxel_size,
+            config.ctf_evaluator,
+            config.disc_type_mean,
+            config.disc_type,
+            config.objective,
+            batch.data_scale,
+        )
+
+    loss, grad = jax.value_and_grad(loss_for_params)(params)
+    # JAX's grad of a real-valued function w.r.t. a complex input is the
+    # non-conjugated Wirtinger derivative, not the descent direction — conjugate
+    # once here so `params + updates` is steepest descent (no-op on the real
+    # log_sqrt_eigenvalues leaf).
+    grad = jax.tree.map(jnp.conj, grad)
+    updates, opt_state = config.optimizer.update(grad, opt_state, params)
+    params = optax.apply_updates(params, updates)
+    if config.project_mask:
+        params = params.apply_masking(config.volume_shape, tensor_data.volume_mask)
+    grad_norm = jnp.sqrt(sum(jnp.sum(jnp.abs(g) ** 2) for g in jax.tree.leaves(grad)))
+    return params, opt_state, loss, grad_norm
 
 
 def _validate_objective(objective: str) -> str:
@@ -351,11 +430,6 @@ def fit(
     )
     mean_for_slicing = jnp.asarray(mean_for_slicing)
 
-    params = _state_from_loadings(W, volume_shape)
-
-    n_total = int(experiment_dataset.n_images)
-    iteration_data: list[dict] = []
-
     optimizer = optax.multi_transform(
         {
             "U": _branch_optimizer(learning_rate, gradient_clip_norm),
@@ -363,7 +437,24 @@ def fit(
         },
         param_labels=WHalfParametrization("U", "log_sqrt_eigenvalues"),
     )
-    optimizer_state = optimizer.init(params)
+    params = _state_from_loadings(W, volume_shape)
+    opt_state = optimizer.init(params)
+    tensor_data = TrainArrs(W_prior_half=W_prior_half, mean_for_slicing=mean_for_slicing, volume_mask=volume_mask)
+    # image_shape/volume_shape/ctf_evaluator are assumed identical across halfsets (only the
+    # image subset differs), so one config covers every batch of both.
+    config = TrainConfig(
+        image_shape=halfset_datasets[0].image_shape,
+        volume_shape=halfset_datasets[0].volume_shape,
+        ctf_evaluator=halfset_datasets[0].ctf_evaluator,
+        disc_type_mean=disc_type_mean,
+        disc_type=disc_type,
+        objective=objective,
+        project_mask=project_mask,
+        optimizer=optimizer,
+    )
+
+    n_total = int(experiment_dataset.n_images)
+    iteration_data: list[dict] = []
 
     logger.info(
         "SOLVAR fit: objective=%s epochs=%d rank=%d batch_size=%d learning_rate=%.3e log_eigenvalue_lr_factor=%.1f",
@@ -384,40 +475,20 @@ def fit(
                 ds, int(batch_size)
             ):
                 batch_n = int(batch_half.shape[0])
-                data_scale = float(n_total) / float(batch_n)
-                noise_variance_half = ds.noise.get_half(batch_image_ind)
+                batch = BatchStruct(
+                    images_half=batch_half,
+                    ctf_params=ctf_params,
+                    rotation_matrices=rotation_matrices,
+                    translations=translations,
+                    noise_variance_half=ds.noise.get_half(batch_image_ind),
+                    voxel_size=ds.voxel_size,
+                    data_scale=float(n_total) / float(batch_n),
+                )
 
-                def loss_for_state(params_candidate):
-                    return _batch_total_loss(
-                        loadings_from_state(params_candidate),
-                        W_prior_half,
-                        batch_half,
-                        mean_for_slicing,
-                        ctf_params,
-                        rotation_matrices,
-                        translations,
-                        noise_variance_half,
-                        ds.image_shape,
-                        ds.volume_shape,
-                        ds.voxel_size,
-                        ds.ctf_evaluator,
-                        disc_type_mean,
-                        disc_type,
-                        objective,
-                        data_scale,
-                    )
-
-                loss, grad = jax.value_and_grad(loss_for_state)(params)
-                # Apply conjugate on Wirtinger derivative to get steepest descent in real/imag coordinates.
-                grad = jax.tree.map(jnp.conj, grad)
-                updates, optimizer_state = optimizer.update(grad, optimizer_state, params)
-                params = optax.apply_updates(params, updates)
-
-                if project_mask:
-                    params = params.apply_masking(volume_shape, volume_mask)
+                params, opt_state, loss, grad_norm = _train_step(params, opt_state, batch, tensor_data, config)
 
                 epoch_loss += float(loss)
-                epoch_grad_norm += float(jnp.sqrt(sum(jnp.sum(jnp.abs(g) ** 2) for g in jax.tree.leaves(grad))))
+                epoch_grad_norm += float(grad_norm)
                 epoch_batches += 1
 
         W_current = loadings_from_state(params)

--- a/recovar/solvar/solvar.py
+++ b/recovar/solvar/solvar.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -33,7 +34,34 @@ class SolvarFitResult:
     U: jax.Array
     S: jax.Array
     W: jax.Array
-    iteration_data: list[dict[str, float]]
+    iteration_data: list[dict]
+
+
+class WHalfParametrization(NamedTuple):
+    """
+    Parameterizes the half-Fourier loading matrix ``W`` for gradient-based optimization by:
+    ``W = U * exp(log_sqrt_eigenvalues)``.
+    """
+
+    U: jax.Array
+    log_sqrt_eigenvalues: jax.Array
+
+
+def loadings_from_state(state: WHalfParametrization) -> jax.Array:
+    """Reconstruct the half-Fourier loading matrix ``W = U * exp(log_sqrt_eigenvalues)``.
+    """
+    scale = jnp.exp(state.log_sqrt_eigenvalues)
+    return state.U * scale[None, :]
+
+
+def _state_from_loadings(W_half, volume_shape) -> WHalfParametrization:
+    """Rebase ``W_half`` onto its exact SVD basis: orthonormal ``U`` + log singular values.
+    """
+    U_real, eigenvalues, _ = ppca._orthonormalize_W_to_basis(W_half, volume_shape)
+    rank = U_real.shape[0]
+    U_half = ftu.get_dft3_real(jnp.asarray(U_real)).reshape(rank, -1).T.astype(W_half.dtype)
+    log_sqrt_eigenvalues = 0.5 * jnp.log(jnp.asarray(eigenvalues, dtype=U_half.real.dtype))
+    return WHalfParametrization(U=U_half, log_sqrt_eigenvalues=log_sqrt_eigenvalues)
 
 
 def _validate_objective(objective: str) -> str:
@@ -274,6 +302,15 @@ def _adam_step(W, grad, m, v, t, *, learning_rate, beta1, beta2, eps):
     return W, m, v
 
 
+def _clip_grad_norm(grad, clip_norm):
+    """Clip ``grad`` to ``clip_norm`` by L2 norm. Returns ``(grad, norm_used)``."""
+    grad_norm = float(jnp.linalg.norm(grad))
+    if clip_norm and clip_norm > 0.0 and grad_norm > clip_norm:
+        grad = grad * (float(clip_norm) / (grad_norm + 1e-12))
+        grad_norm = float(clip_norm)
+    return grad, grad_norm
+
+
 def fit(
     experiment_dataset,
     mean_estimate,
@@ -288,6 +325,7 @@ def fit(
     beta2: float = 0.999,
     adam_eps: float = 1e-8,
     gradient_clip_norm: float = 0.0,
+    log_eigenvalue_lr_factor: float = 100.0,
     volume_mask=None,
     project_mask: bool = True,
     disc_type_mean: str = "cubic",
@@ -327,19 +365,28 @@ def fit(
     )
     mean_for_slicing = jnp.asarray(mean_for_slicing)
 
-    m = jnp.zeros_like(W)
-    v = jnp.zeros(W.shape, dtype=W.real.dtype)
+    state = _state_from_loadings(W, volume_shape)
+
+    def _zero_moments(state):
+        m_U = jnp.zeros_like(state.U)
+        v_U = jnp.zeros(state.U.shape, dtype=state.U.real.dtype)
+        m_s = jnp.zeros_like(state.log_sqrt_eigenvalues)
+        v_s = jnp.zeros_like(state.log_sqrt_eigenvalues)
+        return m_U, v_U, m_s, v_s
+
+    m_U, v_U, m_s, v_s = _zero_moments(state)
     n_total = int(experiment_dataset.n_images)
-    iteration_data: list[dict[str, float]] = []
+    iteration_data: list[dict] = []
     step = 0
 
     logger.info(
-        "SOLVAR fit: objective=%s epochs=%d rank=%d batch_size=%d learning_rate=%.3e",
+        "SOLVAR fit: objective=%s epochs=%d rank=%d batch_size=%d learning_rate=%.3e log_eigenvalue_lr_factor=%.1f",
         objective,
         int(n_epochs),
-        int(W.shape[1]),
+        int(state.U.shape[1]),
         int(batch_size),
         float(learning_rate),
+        float(log_eigenvalue_lr_factor),
     )
 
     for epoch in range(int(n_epochs)):
@@ -354,9 +401,9 @@ def fit(
                 data_scale = float(n_total) / float(batch_n)
                 noise_variance_half = ds.noise.get_half(batch_image_ind)
 
-                def loss_for_W(W_candidate):
+                def loss_for_state(state_candidate):
                     return _batch_total_loss(
-                        W_candidate,
+                        loadings_from_state(state_candidate),
                         W_prior_half,
                         batch_half,
                         mean_for_slicing,
@@ -374,36 +421,50 @@ def fit(
                         data_scale,
                     )
 
-                loss, grad = jax.value_and_grad(loss_for_W)(W)
-                grad_norm = float(jnp.linalg.norm(grad))
-                if gradient_clip_norm and gradient_clip_norm > 0.0 and grad_norm > gradient_clip_norm:
-                    grad = grad * (float(gradient_clip_norm) / (grad_norm + 1e-12))
-                    grad_norm = float(gradient_clip_norm)
+                loss, grad = jax.value_and_grad(loss_for_state)(state)
+                grad_U, grad_norm_U = _clip_grad_norm(grad.U, gradient_clip_norm)
+                grad_s, grad_norm_s = _clip_grad_norm(grad.log_sqrt_eigenvalues, gradient_clip_norm)
+                grad_norm = float(jnp.sqrt(grad_norm_U**2 + grad_norm_s**2))
+
                 step += 1
-                W, m, v = _adam_step(
-                    W,
-                    grad,
-                    m,
-                    v,
+                new_U, m_U, v_U = _adam_step(
+                    state.U,
+                    grad_U,
+                    m_U,
+                    v_U,
                     step,
                     learning_rate=float(learning_rate),
                     beta1=float(beta1),
                     beta2=float(beta2),
                     eps=float(adam_eps),
                 )
+                new_log_sqrt_eigenvalues, m_s, v_s = _adam_step(
+                    state.log_sqrt_eigenvalues,
+                    grad_s,
+                    m_s,
+                    v_s,
+                    step,
+                    learning_rate=float(learning_rate) * float(log_eigenvalue_lr_factor),
+                    beta1=float(beta1),
+                    beta2=float(beta2),
+                    eps=float(adam_eps),
+                )
                 if project_mask:
-                    W = project_loading_to_mask(W, volume_shape, volume_mask)
+                    new_U = project_loading_to_mask(new_U, volume_shape, volume_mask)
+                state = WHalfParametrization(new_U, new_log_sqrt_eigenvalues)
+
                 epoch_loss += float(loss)
                 epoch_grad_norm += grad_norm
                 epoch_batches += 1
 
-        prior_loss = float(w_prior_quadratic(W, W_prior_half))
+        W_current = loadings_from_state(state)
+        prior_loss = float(w_prior_quadratic(W_current, W_prior_half))
         row = {
             "epoch": float(epoch),
             "loss_mean_batch_estimate": epoch_loss / max(epoch_batches, 1),
             "prior_loss": prior_loss,
             "grad_norm_mean": epoch_grad_norm / max(epoch_batches, 1),
-            "W_norm": float(jnp.linalg.norm(W)),
+            "W_norm": float(jnp.linalg.norm(W_current)),
         }
         iteration_data.append(row)
         logger.info(
@@ -415,6 +476,7 @@ def fit(
             row["grad_norm_mean"],
         )
 
+    W = loadings_from_state(state)
     U_real, eigenvalues, _ = ppca._orthonormalize_W_to_basis(W, volume_shape)
     rank = U_real.shape[0]
     U_half = ftu.get_dft3_real(jnp.asarray(U_real)).reshape(rank, -1).T

--- a/recovar/solvar/solvar.py
+++ b/recovar/solvar/solvar.py
@@ -23,6 +23,8 @@ from recovar import core
 from recovar.core import linalg
 from recovar.ppca import ppca
 from recovar.ppca.w_regularization import w_prior_quadratic
+from recovar.simulation.synthetic_dataset import HeterogeneousVolumeDistribution
+from recovar.solvar import gt_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -397,6 +399,7 @@ def fit(
     disc_type_mean: str = "cubic",
     disc_type: str = "linear_interp",
     seed: int | None = None,
+    gt_data: HeterogeneousVolumeDistribution | None = None,
     return_iteration_data: bool = False,
 ):
     """Fit SOLVAR fixed-pose loadings with the LS or MLE objective.
@@ -501,6 +504,8 @@ def fit(
             "grad_norm_mean": epoch_grad_norm / max(epoch_batches, 1),
             "W_norm": float(jnp.linalg.norm(W_current)),
         }
+        if gt_data is not None:
+            row.update(gt_metrics.compute_eigenvector_metrics(W_current, gt_data, volume_shape))
         iteration_data.append(row)
         logger.info(
             "SOLVAR epoch %d/%d loss=%.6e prior=%.6e grad_norm=%.6e",
@@ -510,6 +515,15 @@ def fit(
             row["prior_loss"],
             row["grad_norm_mean"],
         )
+        if gt_data is not None:
+            logger.info(
+                "SOLVAR epoch %d/%d gt_relative_variance=%.4f gt_cosine_similarity=%.4f gt_fro_relative_error=%.4f",
+                epoch + 1,
+                int(n_epochs),
+                row["gt_relative_variance"],
+                row["gt_cosine_similarity"],
+                row["gt_fro_relative_error"],
+            )
 
     params = params.apply_masking(config.volume_shape, tensor_data.volume_mask) if config.project_mask else params
     W = loadings_from_state(params)

--- a/recovar/solvar/solvar.py
+++ b/recovar/solvar/solvar.py
@@ -143,7 +143,7 @@ def _train_step(params: WHalfParametrization, opt_state: optax.OptState, batch: 
     # once here so `params + updates` is steepest descent (no-op on the real
     # log_sqrt_eigenvalues leaf).
     grad = jax.tree.map(jnp.conj, grad)
-    updates, opt_state = config.optimizer.update(grad, opt_state, params)
+    updates, opt_state = config.optimizer.update(grad, opt_state, params, value=loss)
     params = optax.apply_updates(params, updates)
     if config.project_mask:
         params = params.apply_masking(config.volume_shape, tensor_data.volume_mask)
@@ -376,10 +376,24 @@ def _as_half_volume_prior(W_prior, W_shape, volume_shape):
     return ftu.full_volume_to_half_volume(W_prior.T, volume_shape).T
 
 
-def _branch_optimizer(branch_learning_rate, gradient_clip_norm: float = 0.0):
+def _branch_optimizer(branch_learning_rate, gradient_clip_norm: float = 0.0, scheduler_patience: int = 1, scheduler_factor: float = 0.1):
+    transformations = [
+        optax.adam(branch_learning_rate),
+        optax.contrib.reduce_on_plateau(
+            factor=scheduler_factor,
+            patience = scheduler_patience,
+            rtol = 1e-4,
+            cooldown = 3,
+            #TODO: Scheduler should be fed the per epoch loss
+            # which requires seperating it from the optimizer update step.
+            # For now a large accumulation size approximates the per epoch loss.
+            accumulation_size=100,
+        )
+    ]
     if gradient_clip_norm and gradient_clip_norm > 0.0:
-        return optax.chain(optax.clip_by_global_norm(gradient_clip_norm), optax.adam(branch_learning_rate))
-    return optax.adam(branch_learning_rate)
+        transformations.insert(0, optax.clip_by_global_norm(gradient_clip_norm))
+
+    return optax.chain(*transformations)
 
 
 def fit(
@@ -503,17 +517,19 @@ def fit(
             "prior_loss": prior_loss,
             "grad_norm_mean": epoch_grad_norm / max(epoch_batches, 1),
             "W_norm": float(jnp.linalg.norm(W_current)),
+            "step_scaling": float(opt_state[-1]['U'].inner_state[-1].scale.real),
         }
         if gt_data is not None:
             row.update(gt_metrics.compute_eigenvector_metrics(W_current, gt_data, volume_shape))
         iteration_data.append(row)
         logger.info(
-            "SOLVAR epoch %d/%d loss=%.6e prior=%.6e grad_norm=%.6e",
+            "SOLVAR epoch %d/%d loss=%.6e prior=%.6e grad_norm=%.6e step scaling=%.2e",
             epoch + 1,
             int(n_epochs),
             row["loss_mean_batch_estimate"],
             row["prior_loss"],
             row["grad_norm_mean"],
+            row["step_scaling"],
         )
         if gt_data is not None:
             logger.info(
@@ -524,6 +540,11 @@ def fit(
                 row["gt_cosine_similarity"],
                 row["gt_fro_relative_error"],
             )
+
+
+        if row["step_scaling"] < 1e-4:
+            logger.info("SOLVAR epoch %d/%d step scaling below threshold, stopping early", epoch + 1, int(n_epochs))
+            break
 
     params = params.apply_masking(config.volume_shape, tensor_data.volume_mask) if config.project_mask else params
     W = loadings_from_state(params)

--- a/recovar/solvar/solvar.py
+++ b/recovar/solvar/solvar.py
@@ -15,6 +15,7 @@ from typing import NamedTuple
 import jax
 import jax.numpy as jnp
 import numpy as np
+import optax
 
 import recovar.core.fourier_transform_utils as ftu
 from recovar import core
@@ -45,6 +46,10 @@ class WHalfParametrization(NamedTuple):
 
     U: jax.Array
     log_sqrt_eigenvalues: jax.Array
+
+    def apply_masking(self, volume_shape, volume_mask) -> "WHalfParametrization":
+        """Apply a real-space volume mask."""
+        return self._replace(U=project_loading_to_mask(self.U, volume_shape, volume_mask))
 
 
 def loadings_from_state(state: WHalfParametrization) -> jax.Array:
@@ -289,26 +294,10 @@ def _as_half_volume_prior(W_prior, W_shape, volume_shape):
     return ftu.full_volume_to_half_volume(W_prior.T, volume_shape).T
 
 
-def _adam_step(W, grad, m, v, t, *, learning_rate, beta1, beta2, eps):
-    # JAX returns conjugated Wirtinger gradients for real-valued functions of
-    # complex inputs. Conjugate once here so ``W -= step`` is steepest descent
-    # in the real/imaginary coordinates.
-    descent_grad = jnp.conj(grad)
-    m = beta1 * m + (1.0 - beta1) * descent_grad
-    v = beta2 * v + (1.0 - beta2) * (jnp.abs(descent_grad) ** 2)
-    m_hat = m / (1.0 - beta1**t)
-    v_hat = v / (1.0 - beta2**t)
-    W = W - learning_rate * m_hat / (jnp.sqrt(v_hat) + eps)
-    return W, m, v
-
-
-def _clip_grad_norm(grad, clip_norm):
-    """Clip ``grad`` to ``clip_norm`` by L2 norm. Returns ``(grad, norm_used)``."""
-    grad_norm = float(jnp.linalg.norm(grad))
-    if clip_norm and clip_norm > 0.0 and grad_norm > clip_norm:
-        grad = grad * (float(clip_norm) / (grad_norm + 1e-12))
-        grad_norm = float(clip_norm)
-    return grad, grad_norm
+def _branch_optimizer(branch_learning_rate, gradient_clip_norm: float = 0.0):
+    if gradient_clip_norm and gradient_clip_norm > 0.0:
+        return optax.chain(optax.clip_by_global_norm(gradient_clip_norm), optax.adam(branch_learning_rate))
+    return optax.adam(branch_learning_rate)
 
 
 def fit(
@@ -321,9 +310,6 @@ def fit(
     n_epochs: int = 40,
     batch_size: int = 200,
     learning_rate: float = 1e-6,
-    beta1: float = 0.9,
-    beta2: float = 0.999,
-    adam_eps: float = 1e-8,
     gradient_clip_norm: float = 0.0,
     log_eigenvalue_lr_factor: float = 100.0,
     volume_mask=None,
@@ -365,25 +351,25 @@ def fit(
     )
     mean_for_slicing = jnp.asarray(mean_for_slicing)
 
-    state = _state_from_loadings(W, volume_shape)
+    params = _state_from_loadings(W, volume_shape)
 
-    def _zero_moments(state):
-        m_U = jnp.zeros_like(state.U)
-        v_U = jnp.zeros(state.U.shape, dtype=state.U.real.dtype)
-        m_s = jnp.zeros_like(state.log_sqrt_eigenvalues)
-        v_s = jnp.zeros_like(state.log_sqrt_eigenvalues)
-        return m_U, v_U, m_s, v_s
-
-    m_U, v_U, m_s, v_s = _zero_moments(state)
     n_total = int(experiment_dataset.n_images)
     iteration_data: list[dict] = []
-    step = 0
+
+    optimizer = optax.multi_transform(
+        {
+            "U": _branch_optimizer(learning_rate, gradient_clip_norm),
+            "log_sqrt_eigenvalues": _branch_optimizer(learning_rate * log_eigenvalue_lr_factor, gradient_clip_norm),
+        },
+        param_labels=WHalfParametrization("U", "log_sqrt_eigenvalues"),
+    )
+    optimizer_state = optimizer.init(params)
 
     logger.info(
         "SOLVAR fit: objective=%s epochs=%d rank=%d batch_size=%d learning_rate=%.3e log_eigenvalue_lr_factor=%.1f",
         objective,
         int(n_epochs),
-        int(state.U.shape[1]),
+        int(params.U.shape[1]),
         int(batch_size),
         float(learning_rate),
         float(log_eigenvalue_lr_factor),
@@ -401,9 +387,9 @@ def fit(
                 data_scale = float(n_total) / float(batch_n)
                 noise_variance_half = ds.noise.get_half(batch_image_ind)
 
-                def loss_for_state(state_candidate):
+                def loss_for_state(params_candidate):
                     return _batch_total_loss(
-                        loadings_from_state(state_candidate),
+                        loadings_from_state(params_candidate),
                         W_prior_half,
                         batch_half,
                         mean_for_slicing,
@@ -421,43 +407,20 @@ def fit(
                         data_scale,
                     )
 
-                loss, grad = jax.value_and_grad(loss_for_state)(state)
-                grad_U, grad_norm_U = _clip_grad_norm(grad.U, gradient_clip_norm)
-                grad_s, grad_norm_s = _clip_grad_norm(grad.log_sqrt_eigenvalues, gradient_clip_norm)
-                grad_norm = float(jnp.sqrt(grad_norm_U**2 + grad_norm_s**2))
+                loss, grad = jax.value_and_grad(loss_for_state)(params)
+                # Apply conjugate on Wirtinger derivative to get steepest descent in real/imag coordinates.
+                grad = jax.tree.map(jnp.conj, grad)
+                updates, optimizer_state = optimizer.update(grad, optimizer_state, params)
+                params = optax.apply_updates(params, updates)
 
-                step += 1
-                new_U, m_U, v_U = _adam_step(
-                    state.U,
-                    grad_U,
-                    m_U,
-                    v_U,
-                    step,
-                    learning_rate=float(learning_rate),
-                    beta1=float(beta1),
-                    beta2=float(beta2),
-                    eps=float(adam_eps),
-                )
-                new_log_sqrt_eigenvalues, m_s, v_s = _adam_step(
-                    state.log_sqrt_eigenvalues,
-                    grad_s,
-                    m_s,
-                    v_s,
-                    step,
-                    learning_rate=float(learning_rate) * float(log_eigenvalue_lr_factor),
-                    beta1=float(beta1),
-                    beta2=float(beta2),
-                    eps=float(adam_eps),
-                )
                 if project_mask:
-                    new_U = project_loading_to_mask(new_U, volume_shape, volume_mask)
-                state = WHalfParametrization(new_U, new_log_sqrt_eigenvalues)
+                    params = params.apply_masking(volume_shape, volume_mask)
 
                 epoch_loss += float(loss)
-                epoch_grad_norm += grad_norm
+                epoch_grad_norm += float(jnp.sqrt(sum(jnp.sum(jnp.abs(g) ** 2) for g in jax.tree.leaves(grad))))
                 epoch_batches += 1
 
-        W_current = loadings_from_state(state)
+        W_current = loadings_from_state(params)
         prior_loss = float(w_prior_quadratic(W_current, W_prior_half))
         row = {
             "epoch": float(epoch),
@@ -476,7 +439,7 @@ def fit(
             row["grad_norm_mean"],
         )
 
-    W = loadings_from_state(state)
+    W = loadings_from_state(params)
     U_real, eigenvalues, _ = ppca._orthonormalize_W_to_basis(W, volume_shape)
     rank = U_real.shape[0]
     U_half = ftu.get_dft3_real(jnp.asarray(U_real)).reshape(rank, -1).T

--- a/recovar/solvar/solvar.py
+++ b/recovar/solvar/solvar.py
@@ -177,7 +177,7 @@ def _weighted_norm_sq(images, weights):
     return jnp.sum(weights[None, :] * jnp.real(jnp.conj(images) * images), axis=-1)
 
 
-def solvar_image_losses(centered_images, projected_basis, image_shape, *, objective: str):
+def solvar_image_losses(centered_images, projected_basis, image_shape, *, objective: str, apply_mean_terms: bool = False):
     """Evaluate per-image SOLVAR LS or MLE losses in whitened image space.
 
     Parameters
@@ -194,6 +194,8 @@ def solvar_image_losses(centered_images, projected_basis, image_shape, *, object
     objective
         ``"ls"`` for the low-rank least-squares covariance objective or
         ``"mle"`` for the Woodbury maximum-likelihood objective.
+    apply_mean_terms
+        Whether to apply mean terms to the objective function.
     """
 
     objective = _validate_objective(objective)
@@ -218,7 +220,10 @@ def solvar_image_losses(centered_images, projected_basis, image_shape, *, object
         gram_sq = jnp.sum(gram * jnp.conj(gram), axis=(1, 2)).real
         image_basis_sq = jnp.sum(basis_image * jnp.conj(basis_image), axis=1).real
         trace_gram = jnp.trace(gram, axis1=1, axis2=2).real
-        return image_norm_sq**2 - 2.0 * (image_basis_sq + image_norm_sq) + gram_sq + 2.0 * trace_gram
+        loss = - 2.0 * image_basis_sq + gram_sq + 2.0 * trace_gram
+        if apply_mean_terms:
+            loss += image_norm_sq**2 - 2.0 * image_norm_sq
+        return loss
 
     rank = projected_basis.shape[1]
     eye = jnp.eye(rank, dtype=gram.dtype)
@@ -226,7 +231,10 @@ def solvar_image_losses(centered_images, projected_basis, image_shape, *, object
     solved = jnp.linalg.solve(M, basis_image[..., None])[..., 0]
     quad = jnp.sum(jnp.conj(basis_image) * solved, axis=1).real
     sign, logabsdet = jnp.linalg.slogdet(M)
-    return image_norm_sq - quad + logabsdet
+    loss = - quad + logabsdet
+    if apply_mean_terms:
+        loss += image_norm_sq
+    return loss
 
 
 def _prepare_batch(

--- a/recovar/solvar/solvar.py
+++ b/recovar/solvar/solvar.py
@@ -50,7 +50,7 @@ class WHalfParametrization(NamedTuple):
 
     def apply_masking(self, volume_shape, volume_mask) -> "WHalfParametrization":
         """Apply a real-space volume mask."""
-        return self._replace(U=project_loading_to_mask(self.U, volume_shape, volume_mask))
+        return WHalfParametrization(U=project_loading_to_mask(self.U, volume_shape, volume_mask), log_sqrt_eigenvalues=self.log_sqrt_eigenvalues)
 
 
 def loadings_from_state(state: WHalfParametrization) -> jax.Array:
@@ -115,6 +115,7 @@ def _train_step(params: WHalfParametrization, opt_state: optax.OptState, batch: 
     """
 
     def loss_for_params(params):
+        masked_params = params.apply_masking(config.volume_shape, tensor_data.volume_mask) if config.project_mask else params
         return _batch_total_loss(
             loadings_from_state(params),
             tensor_data.W_prior_half,
@@ -510,6 +511,7 @@ def fit(
             row["grad_norm_mean"],
         )
 
+    params = params.apply_masking(config.volume_shape, tensor_data.volume_mask) if config.project_mask else params
     W = loadings_from_state(params)
     U_real, eigenvalues, _ = ppca._orthonormalize_W_to_basis(W, volume_shape)
     rank = U_real.shape[0]

--- a/tests/unit/test_solvar.py
+++ b/tests/unit/test_solvar.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import jax
 import jax.numpy as jnp
 import numpy as np
+import optax
 import pytest
 
 from recovar.commands import pipeline
@@ -11,7 +12,6 @@ import recovar.core.fourier_transform_utils as ftu
 from recovar.core import linalg
 from recovar.ppca.w_regularization import w_prior_precision, w_prior_quadratic
 from recovar.solvar.solvar import (
-    _adam_step,
     _state_from_loadings,
     loadings_from_state,
     make_loading_from_basis,
@@ -35,7 +35,7 @@ def test_solvar_ls_loss_matches_direct_low_rank_covariance_terms():
     y = rng.normal(size=(3, image_shape[0] * (image_shape[1] // 2 + 1))).astype(np.float32)
     Z = rng.normal(size=(3, 2, y.shape[1])).astype(np.float32)
 
-    got = np.asarray(solvar_image_losses(jnp.asarray(y), jnp.asarray(Z), image_shape, objective="ls"))
+    got = np.asarray(solvar_image_losses(jnp.asarray(y), jnp.asarray(Z), image_shape, objective="ls", apply_mean_terms=True))
     w_sqrt = np.sqrt(_weights(image_shape)).astype(np.float32)
     expected = []
     for i in range(y.shape[0]):
@@ -53,7 +53,7 @@ def test_solvar_mle_loss_matches_direct_woodbury_covariance():
     y = rng.normal(size=(2, image_shape[0] * (image_shape[1] // 2 + 1))).astype(np.float32)
     Z = rng.normal(size=(2, 3, y.shape[1])).astype(np.float32)
 
-    got = np.asarray(solvar_image_losses(jnp.asarray(y), jnp.asarray(Z), image_shape, objective="mle"))
+    got = np.asarray(solvar_image_losses(jnp.asarray(y), jnp.asarray(Z), image_shape, objective="mle", apply_mean_terms=True))
     w_sqrt = np.sqrt(_weights(image_shape)).astype(np.float32)
     expected = []
     for i in range(y.shape[0]):
@@ -80,18 +80,12 @@ def test_complex_adam_step_descends_real_quadratic():
     W = jnp.array([1.0 + 2.0j], dtype=jnp.complex64)
     objective = lambda z: jnp.sum(jnp.real(jnp.conj(z) * z))
     grad = jax.grad(objective)(W)
+    grad = jax.tree.map(jnp.conj, grad)
 
-    next_W, _, _ = _adam_step(
-        W,
-        grad,
-        jnp.zeros_like(W),
-        jnp.zeros(W.shape, dtype=W.real.dtype),
-        1,
-        learning_rate=0.1,
-        beta1=0.0,
-        beta2=0.0,
-        eps=1e-8,
-    )
+    optimizer = optax.adam(learning_rate=1e-4)
+    opt_state = optimizer.init(W)
+    updates, _ = optimizer.update(grad, opt_state, W)
+    next_W = optax.apply_updates(W, updates)
 
     assert objective(next_W) < objective(W)
 

--- a/tests/unit/test_solvar.py
+++ b/tests/unit/test_solvar.py
@@ -10,7 +10,14 @@ from recovar.commands import pipeline
 import recovar.core.fourier_transform_utils as ftu
 from recovar.core import linalg
 from recovar.ppca.w_regularization import w_prior_precision, w_prior_quadratic
-from recovar.solvar.solvar import _adam_step, make_loading_from_basis, solvar_image_losses
+from recovar.solvar.solvar import (
+    _adam_step,
+    _state_from_loadings,
+    loadings_from_state,
+    make_loading_from_basis,
+    make_random_loading,
+    solvar_image_losses,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -134,6 +141,8 @@ def test_pipeline_solvar_cli_plumbing():
             "4",
             "--solvar-iters",
             "2",
+            "--solvar-init",
+            "covariance",
         ]
     )
     assert args.use_solvar is True
@@ -148,3 +157,31 @@ def test_pipeline_solvar_cli_plumbing():
     assert pipeline._resolve_solvar_warm_start_n_pcs(SimpleNamespace(solvar_warm_start_n_pcs=64), 20) == 64
     with pytest.raises(ValueError):
         pipeline._resolve_solvar_warm_start_n_pcs(SimpleNamespace(solvar_warm_start_n_pcs=8), 20)
+
+
+def test_state_from_loadings_reconstructs_same_covariance():
+    volume_shape = (6, 6, 6)
+    rank = 2
+    W_half = jnp.asarray(make_random_loading(volume_shape, rank, seed=3, init_scale=1.0))
+
+    state = _state_from_loadings(W_half, volume_shape)
+    W_recon = loadings_from_state(state)
+
+    cov_orig = np.asarray(W_half) @ np.asarray(W_half).conj().T
+    cov_recon = np.asarray(W_recon) @ np.asarray(W_recon).conj().T
+    np.testing.assert_allclose(cov_recon, cov_orig, rtol=1e-4, atol=1e-3)
+
+
+def test_state_from_loadings_u_is_orthonormal_in_real_space():
+    volume_shape = (6, 6, 6)
+    rank = 3
+    W_half = jnp.asarray(make_random_loading(volume_shape, rank, seed=4, init_scale=1.0))
+    vol_size = int(np.prod(volume_shape))
+    half_shape = ftu.volume_shape_to_half_volume_shape(volume_shape)
+
+    state = _state_from_loadings(W_half, volume_shape)
+    U_real = np.asarray(ftu.get_idft3_real(np.asarray(state.U).T.reshape(rank, *half_shape), volume_shape))
+    gram = U_real.reshape(rank, -1) @ U_real.reshape(rank, -1).T
+    np.testing.assert_allclose(gram, np.eye(rank) / vol_size, rtol=1e-4, atol=1e-6)
+
+


### PR DESCRIPTION
## Summary

- Fixed a conjugate bug in the inner-product terms of the objective.
- Re-parametrized the half-Fourier loading matrix as `W = U * exp(log_sqrt_eigenvalues)`.
- Swapped optimizer use to `optax`.
- Used jittable train step.
- Updated real-space mask projection.
- Added an LR scheduler and early-stopping.
- Added optional mean terms to the objective function.
- Updated/extended `tests/unit/test_solvar.py` to cover the re-parametrization and new objective terms.

## Checklist

- [X] Tests pass  `tests/unit/test_solvar.py`
