### PR TITLE
Switch project license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,26 +1,21 @@
-Copyright 2025 The Trustees of Princeton University. All rights reserved.
+MIT License
 
-Permission is hereby granted, free of charge, to non-profit academic and research institutions ("Academic Users") to use, reproduce, and modify this software for internal, non-commercial academic and research purposes only, subject to the following conditions:
+Copyright (c) 2025 The Trustees of Princeton University
 
-This license applies solely to internal use for academic research or educational purposes. Any other use, including but not limited to:
-   - use by or on behalf of a for-profit organization,
-   - incorporation into a commercial product or service,
- - or use in connection with commercial research or fee-for-service activities, requires a separate commercial license. To inquire about a commercial license, please contact: Cortney Cavanaugh at ccavanaugh@princeton.edu or otl@princeton.edu
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
-* Redistributions of source code must retain the above copyright notice, this list of conditions, and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-* Neither The Trustees of Princeton University nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE TRUSTEES OF PRINCETON UNIVERSITY AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE TRUSTEES OF PRINCETON UNIVERSITY OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-=====================================================================================
-NOTIFICATION OF COMMERCIAL USE
-=====================================================================================
-This software is intended for research and instructional purposes only.
-
-To use this software for commercial purposes, please contact: 
-Cortney Cavanaugh 
-New Ventures and Licensing Associate
-Technology Licensing & New Ventures, Princeton University
-ccavanaugh@princeton.edu or otl@princeton.edu
-=====================================================================================
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RECOVAR analyzes conformational heterogeneity in cryo-EM and cryo-ET datasets. I
 
 > **Looking for the older release?** Active development happens on the `dev` branch. If you want the previous stable release (`0.4.5`, possibly more stable but missing recent features like `.cs`/`.star` auto-extraction), install with `pip install recovar==0.4.5` or check out the [`legacy-0.4.5`](https://github.com/ma-gilles/recovar/tree/legacy-0.4.5) branch.
 
-**License**: the code has been modified and is now under the PU-RL v2.0 license, and the code imports libraries that are under non-PU-RL v2.0 (including GPL) licenses. See [LICENSE](LICENSE).
+**License**: RECOVAR is licensed under the MIT License. See [LICENSE](LICENSE).
 
 ## Key features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ authors = [
 ]
 description = "RECOVAR cryo-EM heterogeneity analysis"
 readme = "README.md"
-license = { text = "Princeton University Academic/Non-Commercial License (see LICENSE file)" }
+license = { text = "MIT" }
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: Other/Proprietary License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux"
 ]


### PR DESCRIPTION
## Summary

- replace the existing academic/non-commercial license with the standard MIT License
- update the README license notice
- update Python package metadata and classifier to MIT

## Why

RECOVAR should be distributed under a standard permissive MIT license rather than the current restricted academic/non-commercial license.

## Impact

This removes the project-level non-commercial restriction and advertises the MIT license consistently in the repository and package metadata. Bundled third-party license notices are unchanged.

## Validation

- `git diff --check`
- TOML parsing and setuptools metadata validation passed
- confirmed no stale project-level PU-RL, academic/non-commercial, or proprietary-license references remain

Per maintainer direction, the full long-test gate was not required for this license-only PR. An attempted long-test run was stopped after the unit group exposed an unrelated pre-existing assertion mismatch in `test_all_extra_prefers_gpu_alias` (Slurm job `11804280`); the PR does not change the optional-dependency value involved in that failure.