### PR TITLE
Fix RELION 5 tilt metadata conversion

### DIFF
--- a/recovar/commands/parse_relion5_tomo.py
+++ b/recovar/commands/parse_relion5_tomo.py
@@ -130,7 +130,15 @@ class Tomogram:
         # --- Tilt-level metadata (same for all particles sharing this Tomogram) ---
         mic_names = tilt_df["_rlnMicrographName"].values
         pre_exposure = tilt_df["_rlnMicrographPreExposure"].values.astype(float)
-        ctf_scale = tilt_df["_rlnCtfScalefactor"].values.astype(float)
+        # RELION-like tilt-series STAR files produced by external alignment
+        # pipelines may omit the per-tilt ice-thickness scale. RELION 5's
+        # tomography reconstruction initializes a missing scale to cos(Y tilt),
+        # and cryoDRGN follows the same convention. RECOVAR's downstream tilt
+        # loader expects the output column to be present.
+        if "_rlnCtfScalefactor" in tilt_df.columns:
+            ctf_scale = tilt_df["_rlnCtfScalefactor"].values.astype(float)
+        else:
+            ctf_scale = np.cos(np.deg2rad(tilt_df["_rlnTomoYTilt"].values.astype(float)))
         stage_tilt = tilt_df["_rlnTomoNominalStageTiltAngle"].values.astype(float)
 
         # --- Build flat arrays for the output DataFrame ---
@@ -157,6 +165,10 @@ class Tomogram:
                 "_rlnDefocusAngle": dfa_all.ravel(),
                 "_rlnImageName": img_name_flat,
                 "_rlnMicrographName": mic_flat,
+                # Every RELION 5 micrograph row represents one physical tilt.
+                # Also expose that identity under RECOVAR's canonical name so
+                # micrograph-level outlier detection can group its particles.
+                "_rlnTiltName": mic_flat,
                 "_rlnCtfScalefactor": ctf_scale_flat,
                 "_rlnGroupName": group_flat,
                 "_rlnAngleRot": euler_all[:, :, 0].ravel(),

--- a/recovar/data_io/image_backends.py
+++ b/recovar/data_io/image_backends.py
@@ -14,19 +14,17 @@ import logging
 import queue
 import threading
 import time
-from collections import OrderedDict, Counter
+from collections import Counter, OrderedDict
 from typing import Dict, List, Optional
 
-import numpy as np
-import jax.numpy as jnp
-
 import grain.python as grain
+import jax.numpy as jnp
+import numpy as np
 
+from recovar.core import mask
+from recovar.data_io import starfile
 from recovar.data_io._index_utils import normalize_indices
 from recovar.data_io.image_loader import ImageLoader
-from recovar.data_io import starfile
-from recovar.core import mask
-
 from recovar.utils.nvtx_shim import nvtx
 
 logger = logging.getLogger(__name__)
@@ -387,13 +385,14 @@ class TiltSeriesDataset(ParticleImageDataset):
         star = starfile.StarFile.load(starfile_path)
         df = star.df
 
-        tilt_col = None
-        for col in ["_rlnTiltName", "rlnTiltName"]:
-            if col in df.columns:
-                tilt_col = col
-                break
-
-        if tilt_col is None:
+        # STAR labels are represented canonically with their leading underscore.
+        # RECOVAR-native files use _rlnTiltName; RELION 5 uses
+        # _rlnMicrographName for the same physical tilt identity.
+        if "_rlnTiltName" in df.columns:
+            tilt_col = "_rlnTiltName"
+        elif "_rlnMicrographName" in df.columns:
+            tilt_col = "_rlnMicrographName"
+        else:
             raise ValueError(f"No tilt name column found. Available: {list(df.columns)}")
 
         grouped = df.groupby(tilt_col).groups

--- a/tests/unit/test_image_backends.py
+++ b/tests/unit/test_image_backends.py
@@ -3,10 +3,10 @@ from types import SimpleNamespace
 import numpy as np
 import pandas as pd
 import pytest
-
-from recovar.data_io import image_backends
-from recovar.core import fourier_transform_utils
 from helpers import tiny_synthetic
+
+from recovar.core import fourier_transform_utils
+from recovar.data_io import image_backends
 
 pytestmark = pytest.mark.unit
 
@@ -184,16 +184,16 @@ def test_tiltseries_parse_micrograph_tilt_mapping(monkeypatch):
     assert sorted(reverse.keys()) == [0, 1, 2, 3]
 
 
-def test_tiltseries_parse_micrograph_tilt_mapping_alt_column_name(monkeypatch):
+def test_tiltseries_parse_micrograph_tilt_mapping_relion5_micrograph_fallback(monkeypatch):
     df = pd.DataFrame(
         {
-            "rlnTiltName": ["tA", "tA", "tB"],
+            "_rlnMicrographName": ["mic_a.mrc", "mic_a.mrc", "mic_b.mrc"],
         }
     )
     monkeypatch.setattr(image_backends.starfile.StarFile, "load", lambda _p: SimpleNamespace(df=df))
     groups, reverse = image_backends.TiltSeriesDataset.parse_micrograph_tilt_mapping("dummy.star")
-    assert len(groups) == 2
-    assert set(reverse.keys()) == {0, 1, 2}
+    assert [group.tolist() for group in groups] == [[0, 1], [2]]
+    assert reverse == {0: 0, 1: 0, 2: 1}
 
 
 def test_tiltseries_parse_micrograph_tilt_mapping_missing_column(monkeypatch):

--- a/tests/unit/test_parse_relion5_tomo.py
+++ b/tests/unit/test_parse_relion5_tomo.py
@@ -13,7 +13,7 @@ from recovar.commands.parse_relion5_tomo import (
     _parse_visible_frames,
     convert,
 )
-from recovar.data_io.starfile import read_star, StarFile
+from recovar.data_io.starfile import StarFile, read_star
 
 pytestmark = pytest.mark.unit
 
@@ -370,6 +370,7 @@ class TestConvert:
             "_rlnDefocusV",
             "_rlnDefocusAngle",
             "_rlnImageName",
+            "_rlnTiltName",
             "_rlnGroupName",
             "_rlnAngleRot",
             "_rlnAngleTilt",
@@ -383,6 +384,8 @@ class TestConvert:
         ]
         for col in required:
             assert col in df.columns, f"Missing column: {col}"
+
+        np.testing.assert_array_equal(df["_rlnTiltName"], df["_rlnMicrographName"])
 
     def test_dose_sorted_within_groups(self, relion5_data, tmp_path):
         output = str(tmp_path / "output.star")
@@ -790,6 +793,44 @@ class TestTomogramEdgeCases:
         assert df["_rlnMicrographPreExposure"].dtype in [np.float64, np.float32]
         assert df["_rlnCtfScalefactor"].dtype in [np.float64, np.float32]
         np.testing.assert_allclose(df["_rlnDefocusU"].values, [20000.0, 21000.0, 22000.0], atol=1e-6)
+
+    def test_expand_particles_batch_infers_missing_ctf_scale_from_tilt(self):
+        """Infer the geometric scale when external RELION-like STARs omit it."""
+        n = 3
+        tomo = Tomogram(
+            pixel_size=1.54,
+            defocus_u=np.full(n, 20_000.0),
+            defocus_v=np.full(n, 20_100.0),
+            defocus_angle=np.zeros(n),
+            x_tilts=np.zeros(n),
+            y_tilts=np.linspace(-30.0, 30.0, n),
+            z_rots=np.zeros(n),
+            x_shifts=np.zeros(n),
+            y_shifts=np.zeros(n),
+            hand=1,
+        )
+        tilt_df = pd.DataFrame(
+            {
+                "_rlnMicrographName": [f"tilt_{i}.mrc" for i in range(n)],
+                "_rlnMicrographPreExposure": [0.0, 2.0, 4.0],
+                "_rlnTomoYTilt": [-30.0, 0.0, 30.0],
+                "_rlnTomoNominalStageTiltAngle": [-30.0, 0.0, 30.0],
+            }
+        )
+
+        df = tomo.expand_particles_batch(
+            np.zeros((1, 3)),
+            ["particle.mrcs"],
+            tilt_df,
+            ["particle_1"],
+            R.identity(),
+            np.array([1]),
+        )
+
+        np.testing.assert_allclose(
+            df["_rlnCtfScalefactor"].values,
+            np.cos(np.deg2rad([-30.0, 0.0, 30.0])),
+        )
 
     def test_expand_preserves_ctf_scalefactor(self):
         """CTF scale factors from the tilt series should appear unchanged."""


### PR DESCRIPTION
## Summary

- emit `_rlnTiltName` from RELION 5 `_rlnMicrographName` values during tomography conversion
- accept the canonical RELION 5 `_rlnMicrographName` label as a tilt-grouping fallback
- initialize a missing `_rlnCtfScalefactor` as `cos(deg2rad(_rlnTomoYTilt))`
- add regression coverage for the converter and image backend

## Root cause

RECOVAR's RELION 5 converter assumed that every per-tomogram tilt-series STAR file contained `_rlnCtfScalefactor`, and its outlier code expected the RECOVAR-specific `_rlnTiltName` field. Some external RELION-like export pipelines omit the scale factor and identify tilts only through `_rlnMicrographName`. This caused conversion failures on missing scale metadata and later outlier-detection failures on missing tilt identities.

RELION 5.0.1 initializes a missing scale to `cos(DEG2RAD(rlnTomoYTilt))` in its tomography reconstruction path. cryoDRGN's RELION 5 parser uses the same fallback. The converter now follows that convention.

RELION source:
https://github.com/3dem/relion/blob/d476e6f6a4f1f37627c06ace5227fc374c0c2b05/src/jaz/tomography/programs/reconstruct_tomogram.cpp#L249-L264

cryoDRGN source:
https://github.com/ml-struct-bio/cryodrgn/blob/6273c8f3b6c2b76f68a721e465e9f7ef1b69610e/cryodrgn/commands_utils/parse_relion.py

## Impact

RELION 5 cryo-ET datasets produced by external processing pipelines can be converted and passed through one-round outlier cleanup even when the input tilt STAR files omit `rlnCtfScalefactor` and do not define a RECOVAR-specific tilt-name column.

STAR labels are handled only in their canonical leading-underscore form. Existing STAR files with an explicit CTF scale remain unchanged.

## Validation

- `python -m pytest -q tests/unit/test_parse_relion5_tomo.py tests/unit/test_image_backends.py`
  - 103 passed
- `python -m ruff check recovar/commands/parse_relion5_tomo.py recovar/data_io/image_backends.py tests/unit/test_image_backends.py tests/unit/test_parse_relion5_tomo.py`
  - passed
- converted four real RELION-5 tomography particle sets; verified emitted tilt names and non-unit cosine scale values
- four replacement grid-128 pipelines are running from the corrected metadata

## Related

The independently observed GPU memory-planner underestimate is tracked in #161.