### PR TITLE
Find analyze jobs nested inside pipeline output directories

### DIFF
--- a/recovar/gui_v2/backend/api/files.py
+++ b/recovar/gui_v2/backend/api/files.py
@@ -36,12 +36,15 @@ _allowed_roots: list[str] = []
 def configure_allowed_roots(roots: list[str]) -> None:
     """Set the allowed root directories for the file browser."""
     global _allowed_roots
-    _allowed_roots = [os.path.abspath(r) for r in roots]
+    # Resolve symlinks so roots compare canonically with the resolved
+    # request paths in _check_path_allowed (e.g. HPC homes that symlink
+    # into project storage).
+    _allowed_roots = [str(Path(os.path.expanduser(r)).resolve()) for r in roots]
 
 
 def add_allowed_root(root: str) -> None:
     """Add an allowed root directory."""
-    _allowed_roots.append(os.path.abspath(root))
+    _allowed_roots.append(str(Path(os.path.expanduser(root)).resolve()))
 
 
 def _check_path_allowed(path: str) -> None:

--- a/recovar/gui_v2/backend/main.py
+++ b/recovar/gui_v2/backend/main.py
@@ -179,7 +179,7 @@ async def lifespan(app: FastAPI):
         "/tmp",
     ]
     # Add common HPC scratch paths if they exist
-    for candidate in ["/scratch", "/gpfs", "/projects", "/data"]:
+    for candidate in ["/scratch", "/gpfs", "/projects", "/data", "/hpc"]:
         if os.path.isdir(candidate):
             default_roots.append(candidate)
     configure_allowed_roots(default_roots)

--- a/recovar/gui_v2/backend/services/scanner.py
+++ b/recovar/gui_v2/backend/services/scanner.py
@@ -265,6 +265,57 @@ def _scan_job_dir(type_name: str, job_dir: str) -> ScannedJob:
     )
 
 
+# Subdirectories of a pipeline output that hold its own artifacts rather than
+# nested jobs.  Skipping them keeps the nested walk cheap and stops artifact
+# directories (``data/`` + ``plots/``) from tripping the structural fingerprint.
+_PIPELINE_ARTIFACT_DIRS = frozenset(
+    {
+        "model",
+        "output",
+        "downsampled",
+        "_diagnostics",
+        "volumes",
+        "plots",
+        "data",
+        "kmeans",
+    }
+)
+
+
+def _scan_nested_job_dirs(pipeline_dir: str) -> list[ScannedJob]:
+    """Find downstream jobs written *inside* a pipeline output directory.
+
+    ``analyze`` and the other downstream commands default to writing into
+    the pipeline directory they consume (``<pipeline>/Analyze/``,
+    ``<pipeline>/analysis_N/``), which is one level below where the
+    project walk looks.
+    """
+    pipeline_dir = os.path.abspath(pipeline_dir)
+    nested: list[ScannedJob] = []
+    try:
+        entries = sorted(os.listdir(pipeline_dir))
+    except OSError as exc:
+        logger.warning("Cannot list %s: %s", pipeline_dir, exc)
+        return nested
+
+    for name in entries:
+        if name in _PIPELINE_ARTIFACT_DIRS:
+            continue
+        sub_dir = os.path.join(pipeline_dir, name)
+        if not os.path.isdir(sub_dir):
+            continue
+        job_type = _detect_job_type_from_dir(name, sub_dir)
+        # A nested "Pipeline" would be a pipeline inside a pipeline: out of
+        # scope, and descending into it risks unbounded recursion.
+        if job_type is None or job_type == "Pipeline":
+            continue
+        scanned = _scan_job_dir(job_type, sub_dir)
+        if pipeline_dir not in scanned.parent_job_dirs:
+            scanned.parent_job_dirs.append(pipeline_dir)
+        nested.append(scanned)
+    return nested
+
+
 def scan_project_directory(project_dir: str) -> list[ScannedJob]:
     """Scan a project directory for existing job outputs.
 
@@ -301,6 +352,7 @@ def scan_project_directory(project_dir: str) -> list[ScannedJob]:
     # Pipeline/job_NNNN/).
     if _is_pipeline_output(project_dir):
         results.append(_scan_job_dir("Pipeline", project_dir))
+        results.extend(_scan_nested_job_dirs(project_dir))
 
     for type_dir_name in top_entries:
         type_dir = os.path.join(project_dir, type_dir_name)
@@ -328,6 +380,8 @@ def scan_project_directory(project_dir: str) -> list[ScannedJob]:
 
             scanned = _scan_job_dir(job_type, job_dir)
             results.append(scanned)
+            if job_type == "Pipeline":
+                results.extend(_scan_nested_job_dirs(job_dir))
             found_job_dir = True
 
         # If no job_NNNN subdirectories found, check if the type
@@ -339,6 +393,19 @@ def scan_project_directory(project_dir: str) -> list[ScannedJob]:
                 or _is_analyze_output(type_dir)
             ):
                 results.append(_scan_job_dir(job_type, type_dir))
+                if job_type == "Pipeline":
+                    results.extend(_scan_nested_job_dirs(type_dir))
+
+    # A job can be reachable twice (nested walk plus the top-level walk
+    # of a flat project whose root is itself a pipeline output).
+    seen: set[str] = set()
+    deduped: list[ScannedJob] = []
+    for job in results:
+        if job.output_dir in seen:
+            continue
+        seen.add(job.output_dir)
+        deduped.append(job)
+    results = deduped
 
     # Sort by creation time (oldest first)
     results.sort(key=lambda s: s.created_at or datetime.datetime.min)
@@ -367,7 +434,10 @@ def scan_arbitrary_directory(scan_path: str) -> list[ScannedJob]:
 
     # First check if this IS a pipeline output directly
     if _is_pipeline_output(scan_path):
-        return [_scan_job_dir("Pipeline", scan_path)]
+        return [
+            _scan_job_dir("Pipeline", scan_path),
+            *_scan_nested_job_dirs(scan_path),
+        ]
 
     # Check if it's an analyze output directly
     if _is_analyze_output(scan_path):

--- a/recovar/gui_v2/tests/backend/test_scanner_nested_jobs.py
+++ b/recovar/gui_v2/tests/backend/test_scanner_nested_jobs.py
@@ -1,0 +1,134 @@
+"""Tests for discovering jobs nested inside pipeline output directories.
+
+``analyze`` and the other downstream commands write into the pipeline
+directory they consume, so the scanner has to descend one level below the
+project walk to find them.
+
+Covers:
+    - nested Analyze in a flat project layout (``round_1/Analyze/``)
+    - nested Analyze in the canonical ``Pipeline/job_0001/`` layout
+    - pipeline artifact directories are not mistaken for jobs
+    - no duplicates when the project root is itself a pipeline output
+    - ``scan_arbitrary_directory`` on a pipeline directory
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from recovar.gui_v2.backend.services.scanner import (
+    scan_arbitrary_directory,
+    scan_project_directory,
+)
+
+
+def _make_pipeline(pipeline_dir: Path) -> Path:
+    """Write the minimum markers that identify a pipeline output."""
+    (pipeline_dir / "model").mkdir(parents=True)
+    (pipeline_dir / "model" / "metadata.json").write_text(json.dumps({"zdim": 10}))
+    (pipeline_dir / "output" / "volumes").mkdir(parents=True)
+    return pipeline_dir
+
+
+def _make_analyze(analyze_dir: Path, status: str = "completed") -> Path:
+    """Write the minimum markers that identify an analyze output."""
+    analyze_dir.mkdir(parents=True)
+    (analyze_dir / "kmeans").mkdir()
+    (analyze_dir / "job.json").write_text(
+        json.dumps({"command": "analyze", "status": status, "parameters": {"zdim": 10}})
+    )
+    return analyze_dir
+
+
+def _by_type(jobs: list) -> dict[str, list]:
+    out: dict[str, list] = {}
+    for job in jobs:
+        out.setdefault(job.type, []).append(job)
+    return out
+
+
+def test_finds_analyze_nested_in_flat_pipeline_dir(tmp_path: Path) -> None:
+    """A flat project (``round_1/``, ``round_2/``) exposes its Analyze jobs."""
+    project = tmp_path / "project"
+    for round_name in ("round_1", "round_2"):
+        pipeline = _make_pipeline(project / round_name)
+        _make_analyze(pipeline / "Analyze")
+
+    jobs = _by_type(scan_project_directory(str(project)))
+
+    assert len(jobs["Pipeline"]) == 2
+    assert len(jobs["Analyze"]) == 2
+    analyze_dirs = sorted(job.output_dir for job in jobs["Analyze"])
+    assert analyze_dirs == [
+        str(project / "round_1" / "Analyze"),
+        str(project / "round_2" / "Analyze"),
+    ]
+
+
+def test_nested_analyze_records_its_parent_pipeline(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    pipeline = _make_pipeline(project / "round_1")
+    _make_analyze(pipeline / "Analyze")
+
+    analyze = _by_type(scan_project_directory(str(project)))["Analyze"][0]
+
+    assert analyze.parent_job_dirs == [str(pipeline)]
+
+
+def test_finds_analyze_nested_in_canonical_job_dir(tmp_path: Path) -> None:
+    """The ``Pipeline/job_0001/`` layout also gets its nested jobs."""
+    project = tmp_path / "project"
+    pipeline = _make_pipeline(project / "Pipeline" / "job_0001")
+    _make_analyze(pipeline / "analysis_0")
+
+    jobs = _by_type(scan_project_directory(str(project)))
+
+    assert len(jobs["Pipeline"]) == 1
+    assert [job.output_dir for job in jobs["Analyze"]] == [str(pipeline / "analysis_0")]
+
+
+def test_pipeline_artifact_dirs_are_not_jobs(tmp_path: Path) -> None:
+    """``data/`` + ``plots/`` under a pipeline are artifacts, not an Analyze job."""
+    project = tmp_path / "project"
+    pipeline = _make_pipeline(project / "round_1")
+    (pipeline / "data").mkdir()
+    (pipeline / "plots").mkdir()
+
+    jobs = scan_project_directory(str(project))
+
+    assert [job.type for job in jobs] == ["Pipeline"]
+
+
+def test_no_duplicates_when_project_root_is_the_pipeline(tmp_path: Path) -> None:
+    """The root-is-a-pipeline path and the top-level walk must not double-count."""
+    project = _make_pipeline(tmp_path / "project")
+    _make_analyze(project / "Analyze")
+
+    jobs = scan_project_directory(str(project))
+
+    output_dirs = [job.output_dir for job in jobs]
+    assert len(output_dirs) == len(set(output_dirs))
+    assert sorted(job.type for job in jobs) == ["Analyze", "Pipeline"]
+
+
+def test_scan_arbitrary_directory_includes_nested_jobs(tmp_path: Path) -> None:
+    """Pointing the scanner straight at a pipeline dir still finds its Analyze."""
+    pipeline = _make_pipeline(tmp_path / "some_pipeline_output")
+    _make_analyze(pipeline / "Analyze")
+
+    jobs = _by_type(scan_arbitrary_directory(str(pipeline)))
+
+    assert len(jobs["Pipeline"]) == 1
+    assert [job.output_dir for job in jobs["Analyze"]] == [str(pipeline / "Analyze")]
+
+
+def test_nested_analyze_keeps_its_reported_status(tmp_path: Path) -> None:
+    """A still-running analyze is imported as running, not silently completed."""
+    project = tmp_path / "project"
+    pipeline = _make_pipeline(project / "round_2")
+    _make_analyze(pipeline / "Analyze", status="running")
+
+    analyze = _by_type(scan_project_directory(str(project)))["Analyze"][0]
+
+    assert analyze.status == "running"


### PR DESCRIPTION
## Problem

Opening a project with completed `analyze` runs showed **`ANALYZE (0)`** in the sidebar, with no way to reach them from the GUI.

`scan_project_directory` walks one level below the project root. But `analyze` and the other downstream commands write *into* the pipeline directory they consume — `<pipeline>/Analyze/`, `<pipeline>/analysis_N/` — which is one level deeper than the walk reaches. The function's docstring already promised this ("Also detects `analysis_N/` directories inside pipeline jobs"), but no code implemented it.

Reproduced on a real project: 2 pipeline rounds each with a completed `Analyze/` on disk, all of it invisible to the GUI.

## Fix

Descend into each directory identified as a pipeline output and classify its subdirectories with the existing detection logic:

- **Artifact directories are skipped** (`model/`, `output/`, `data/`, `plots/`, `kmeans/`, …) so a pipeline's own `data/` + `plots/` can't trip the structural fingerprint and register as a phantom Analyze job.
- **Nested pipelines are skipped**, so the walk cannot recurse without bound.
- Nested jobs **record their parent pipeline** in `parent_job_dirs`.
- Results are **deduplicated by `output_dir`** — a flat project whose root is itself a pipeline output can now reach the same job from two paths.
- Applied to all four discovery paths: flat project root, canonical `Pipeline/job_NNNN/`, flat type directory, and `scan_arbitrary_directory`.

### Also included: file-browser 403s

`configure_allowed_roots()` stored roots with `os.path.abspath()` (keeps symlinks) while `_check_path_allowed()` resolves request paths with `Path.resolve()` (follows them). Any path reached through a symlink therefore could never match a root and returned `403 Access denied: path is outside allowed directories`. Roots are now resolved the same way, and `/hpc` joins the default candidates so HPC sites whose storage lives there get a usable browser out of the box.

## Verification

On the project that surfaced this, the scan goes from **2 jobs to 8** (2 pipeline, 2 analyze, 4 outlier-detection that were also invisible). Driven through the browser end to end: the analyze job detail page loads, plots and parameters populate, the latent explorer renders PCA + UMAP for 71k particles, and the 3D volume viewer renders a k-means center. A still-running analyze correctly shows as running.

Adds `test_scanner_nested_jobs.py` — 7 tests covering both layouts, parent linkage, artifact directories, the dedupe path, `scan_arbitrary_directory`, and status preservation. Confirmed they fail against the pre-fix scanner (0 analyze jobs found on the same fixture) and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)