### PR TITLE
Don't mark finished jobs failed on GUI restart; honour --port

### DIFF
--- a/recovar/commands/gui.py
+++ b/recovar/commands/gui.py
@@ -39,6 +39,8 @@ import sys
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_PORT = 8080
+
 
 # (import name, pip/dist name) for every package the GUI backend needs at
 # runtime. Several are imported lazily by the server — most notably the
@@ -62,17 +64,53 @@ def _missing_gui_deps() -> list[str]:
     return [pip for mod, pip in _REQUIRED_GUI_DEPS if importlib.util.find_spec(mod) is None]
 
 
+def _port_is_free(host: str, port: int) -> bool:
+    """Return True if *port* can be bound on *host*.
+
+    The probe sets SO_REUSEADDR because uvicorn does. Without it, a socket
+    left in TIME_WAIT by a server that was just stopped reads as busy, so a
+    restart drifts to another port even though uvicorn would have bound the
+    requested one fine.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            probe.bind((host, port))
+            return True
+        except OSError:
+            return False
+
+
 def _pick_port(host: str, requested: int, span: int = 20) -> int:
     """Return *requested* if free, otherwise the next free port in range — so a
     busy default port doesn't crash the launch with 'address already in use'."""
     for candidate in range(requested, requested + span):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-            try:
-                probe.bind((host, candidate))
-                return candidate
-            except OSError:
-                continue
+        if _port_is_free(host, candidate):
+            return candidate
     return requested  # nothing free in range; let uvicorn surface the error
+
+
+class PortUnavailableError(RuntimeError):
+    """Raised when a port the user asked for by name is already taken."""
+
+
+def _resolve_port(host: str, requested: int, explicit: bool) -> int:
+    """Decide which port to bind.
+
+    The default port may drift to the next free one, so a launch is not
+    blocked by a leftover server. A port named with ``--port`` never drifts:
+    it is normally the port being forwarded over SSH, and binding a different
+    one just shows "connection refused" in the browser with nothing to
+    explain why.
+    """
+    if not explicit:
+        return _pick_port(host, requested)
+    if _port_is_free(host, requested):
+        return requested
+    raise PortUnavailableError(
+        f"Port {requested} is already in use on {host}. Stop whatever is "
+        f"listening (often an older 'recovar gui') or pass a different --port."
+    )
 
 
 def _maybe_open_browser(url: str, host: str, no_browser: bool) -> None:
@@ -174,8 +212,12 @@ def main():
     parser.add_argument(
         "--port",
         type=int,
-        default=8080,
-        help="Port to bind to (default: 8080; the next free port is used if it is busy)",
+        default=None,
+        help=(
+            "Port to bind to (default: 8080, falling back to the next free port "
+            "if it is busy). A port given explicitly is used as-is: if it is "
+            "busy the launch fails rather than moving to another port."
+        ),
     )
     parser.add_argument(
         "--reload",
@@ -200,8 +242,10 @@ def main():
         format="%(asctime)s %(levelname)s %(name)s — %(message)s",
     )
 
+    requested_port = _DEFAULT_PORT if args.port is None else args.port
+
     if args.check:
-        sys.exit(_run_doctor(args.host, args.port))
+        sys.exit(_run_doctor(args.host, requested_port))
 
     # Preflight: verify the whole GUI runtime set up front so a missing
     # package is reported immediately, with the exact install command,
@@ -222,9 +266,16 @@ def main():
 
     from recovar.gui_v2.backend.main import create_app
 
-    # Use the next free port if the requested one is taken, so the launch
-    # "just works" instead of dying with 'address already in use'.
-    port = _pick_port(args.host, args.port)
+    # Only the *default* port drifts when busy, so the launch "just works"
+    # instead of dying with 'address already in use'. An explicit --port is
+    # honoured exactly: it is normally the port the user forwards over SSH,
+    # and quietly binding a different one just makes the browser show
+    # "connection refused" with no clue why (see recovar#163 discussion).
+    try:
+        port = _resolve_port(args.host, requested_port, explicit=args.port is not None)
+    except PortUnavailableError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
     url = f"http://{args.host}:{port}"
 
     print()
@@ -241,8 +292,8 @@ def main():
             "  ║     untrusted networks.                              ║"
         )
     print("  ╚══════════════════════════════════════════════╝")
-    if port != args.port:
-        print(f"  (port {args.port} was busy — using {port})")
+    if port != requested_port:
+        print(f"  (port {requested_port} was busy — using {port})")
     print()
 
     _maybe_open_browser(url, args.host, args.no_browser)

--- a/recovar/gui_v2/backend/api/jobs.py
+++ b/recovar/gui_v2/backend/api/jobs.py
@@ -47,6 +47,7 @@ from recovar.gui_v2.backend.services.executor import (
     Executor,
     LocalExecutor,
     SlurmExecutor,
+    disk_completion_time,
     slurm_available,
 )
 from recovar.gui_v2.backend.services.executor import (
@@ -1153,11 +1154,21 @@ async def reconcile_job(job_id: str) -> ReconcileResponse:
                 changed=False,
             )
 
-        # No executor handle — cannot query the executor
+        # No executor handle to query (the job was imported by a scan, or
+        # submitted outside the GUI) — judge it by its outputs instead.
         if not job.executor_handle:
-            job.status = JobStatus.FAILED.value
-            job.error = "No executor handle — cannot check status."
-            job.completed_at = datetime.datetime.utcnow()
+            finished = disk_completion_time(job.output_dir, job.created_at)
+            if finished is not None:
+                job.status = JobStatus.COMPLETED.value
+                job.error = None
+                job.completed_at = finished
+            else:
+                job.status = JobStatus.FAILED.value
+                job.error = (
+                    "No executor handle, and no completed output in the job "
+                    "directory — cannot check status."
+                )
+                job.completed_at = datetime.datetime.utcnow()
             await session.commit()
             return ReconcileResponse(
                 id=job_id,

--- a/recovar/gui_v2/backend/main.py
+++ b/recovar/gui_v2/backend/main.py
@@ -37,6 +37,7 @@ from recovar.gui_v2.backend.config import DEFAULT_HOST, DEFAULT_PORT
 from recovar.gui_v2.backend.db import close_all, init_db
 from recovar.gui_v2.backend.models.job import Job, JobStatus
 from recovar.gui_v2.backend.services.executor import (
+    disk_completion_time,
     reconcile_jobs,
 )
 
@@ -69,6 +70,7 @@ async def _reconcile_on_startup() -> None:
 
     total_reconciled = 0
     total_restarted = 0
+    total_repaired = 0
 
     for project_path in project_paths:
         db_path = get_db_path(project_path)
@@ -82,6 +84,32 @@ async def _reconcile_on_startup() -> None:
             continue
 
         async with session_factory() as session:
+            # Repair rows an earlier restart got wrong: before jobs were
+            # judged by their outputs, any handle-less job in flight was
+            # recorded as failed even when it had finished, and nothing in
+            # the UI could undo that (a rescan skips known directories).
+            repair_stmt = select(Job).where(
+                Job.status == JobStatus.FAILED.value,
+                Job.executor_handle.is_(None),
+                Job.error.like("No executor handle%"),
+            )
+            stale = (await session.execute(repair_stmt)).scalars().all()
+            for job in stale:
+                finished = disk_completion_time(job.output_dir, job.created_at)
+                if finished is None:
+                    continue  # genuinely has nothing to show for itself
+                job.status = JobStatus.COMPLETED.value
+                job.error = None
+                job.completed_at = finished
+                total_repaired += 1
+                logger.info(
+                    "Startup repair: %s completed on disk, was recorded failed (%s)",
+                    job.type,
+                    job.output_dir,
+                )
+            if total_repaired:
+                await session.commit()
+
             # Find all non-terminal jobs
             stmt = select(Job).where(Job.status.in_([JobStatus.RUNNING.value, JobStatus.QUEUED.value]))
             result = await session.execute(stmt)
@@ -103,6 +131,7 @@ async def _reconcile_on_startup() -> None:
                     "handle": j.executor_handle,
                     "db_status": j.status,
                     "working_dir": j.output_dir,
+                    "created_at": j.created_at,
                 }
                 for j in inflight
             ]
@@ -128,10 +157,15 @@ async def _reconcile_on_startup() -> None:
                 if not job:
                     continue
                 job.status = upd["new_status"]
-                if upd.get("error"):
-                    job.error = upd["error"]
+                # Assign unconditionally: a job reconciled to completed must
+                # not keep the error text from a previous failed reconcile.
+                job.error = upd.get("error")
                 if upd["new_status"] in ("completed", "failed", "cancelled"):
-                    job.completed_at = datetime.datetime.utcnow()
+                    # Prefer the finish time recovered from disk — stamping
+                    # "now" would date a job that ended hours ago to the restart.
+                    job.completed_at = (
+                        upd.get("completed_at") or datetime.datetime.utcnow()
+                    )
                 total_reconciled += 1
 
             await session.commit()
@@ -159,9 +193,11 @@ async def _reconcile_on_startup() -> None:
                         total_restarted += 1
 
     logger.info(
-        "Startup reconcile complete: %d jobs updated, %d pollers restarted",
+        "Startup reconcile complete: %d jobs updated, %d pollers restarted, "
+        "%d wrongly-failed jobs repaired",
         total_reconciled,
         total_restarted,
+        total_repaired,
     )
 
 
@@ -179,7 +215,7 @@ async def lifespan(app: FastAPI):
         "/tmp",
     ]
     # Add common HPC scratch paths if they exist
-    for candidate in ["/scratch", "/gpfs", "/projects", "/data"]:
+    for candidate in ["/scratch", "/gpfs", "/projects", "/data", "/hpc"]:
         if os.path.isdir(candidate):
             default_roots.append(candidate)
     configure_allowed_roots(default_roots)

--- a/recovar/gui_v2/backend/services/executor.py
+++ b/recovar/gui_v2/backend/services/executor.py
@@ -14,6 +14,8 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import datetime
+import json
 import logging
 import os
 import shlex
@@ -793,6 +795,56 @@ def _render_jinja_template(
 # ---------------------------------------------------------------------------
 
 
+def disk_completion_time(
+    working_dir: str | None,
+    started_at: datetime.datetime | None = None,
+) -> datetime.datetime | None:
+    """Return when the job in *working_dir* finished, or None if it did not.
+
+    recovar writes ``job.json`` as the last step of a run, so its presence is
+    the on-disk record that the job completed. This is the only evidence left
+    for a job with no executor handle — one imported by a scan, or submitted
+    outside the GUI — and without it such jobs are reported as failures even
+    though all of their outputs are there.
+
+    *started_at* guards against an older ``job.json`` from a previous run of
+    the same directory being read as this run's completion.
+    """
+    if not working_dir:
+        return None
+    job_json = os.path.join(working_dir, "job.json")
+    try:
+        mtime = os.stat(job_json).st_mtime
+    except OSError:
+        return None
+    finished = datetime.datetime.utcfromtimestamp(mtime)
+    if started_at is not None and finished < started_at - datetime.timedelta(minutes=1):
+        return None  # left over from an earlier run in the same directory
+
+    try:
+        with open(job_json) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return finished  # unreadable, but it was written: the run got that far
+
+    if isinstance(data, dict):
+        if str(data.get("status", "completed")).lower() in (
+            "failed",
+            "error",
+            "cancelled",
+            "canceled",
+        ):
+            return None
+        stamp = (data.get("timing") or {}).get("completed_at")
+        if stamp:
+            try:
+                parsed = datetime.datetime.fromisoformat(stamp)
+            except ValueError:
+                return finished
+            return parsed.replace(tzinfo=None) if parsed.tzinfo else parsed
+    return finished
+
+
 async def reconcile_jobs(
     executor: Executor,
     inflight_jobs: list[dict],
@@ -818,17 +870,34 @@ async def reconcile_jobs(
 
     for job_info in inflight_jobs:
         handle = job_info.get("handle")
+        working_dir = job_info.get("working_dir")
         if not handle:
-            updates.append(
-                {
-                    "id": job_info["id"],
-                    "new_status": JobStatus.FAILED.value,
-                    "error": "No executor handle — cannot reconcile after restart.",
-                }
-            )
+            # Nothing to poll, so the outputs are the only evidence of what
+            # happened. A finished run is reported as completed rather than
+            # failed, and keeps the time it actually finished.
+            finished = disk_completion_time(working_dir, job_info.get("created_at"))
+            if finished is not None:
+                updates.append(
+                    {
+                        "id": job_info["id"],
+                        "new_status": JobStatus.COMPLETED.value,
+                        "error": None,
+                        "completed_at": finished,
+                    }
+                )
+            else:
+                updates.append(
+                    {
+                        "id": job_info["id"],
+                        "new_status": JobStatus.FAILED.value,
+                        "error": (
+                            "No executor handle, and no completed output in "
+                            "the job directory — cannot reconcile after restart."
+                        ),
+                    }
+                )
             continue
 
-        working_dir = job_info.get("working_dir")
         if working_dir and hasattr(executor, "status_with_dir"):
             actual = await executor.status_with_dir(handle, working_dir)
         else:
@@ -840,10 +909,18 @@ async def reconcile_jobs(
             continue
 
         error = None
+        completed_at = None
         if actual == JobStatus.UNKNOWN:
-            actual = JobStatus.FAILED
-            log = await executor.log_path(handle)
-            error = f"Job status unknown after server restart. Check output: {log}"
+            # The executor lost the job (SLURM purges accounting records), so
+            # fall back to the outputs before calling it a failure.
+            finished = disk_completion_time(working_dir, job_info.get("created_at"))
+            if finished is not None:
+                actual = JobStatus.COMPLETED
+                completed_at = finished
+            else:
+                actual = JobStatus.FAILED
+                log = await executor.log_path(handle)
+                error = f"Job status unknown after server restart. Check output: {log}"
         elif actual == JobStatus.FAILED:
             error = "Job failed (detected on server restart)."
 
@@ -852,6 +929,7 @@ async def reconcile_jobs(
                 "id": job_info["id"],
                 "new_status": actual.value,
                 "error": error,
+                "completed_at": completed_at,
             }
         )
 

--- a/recovar/gui_v2/tests/backend/test_reconcile_disk_evidence.py
+++ b/recovar/gui_v2/tests/backend/test_reconcile_disk_evidence.py
@@ -1,0 +1,197 @@
+"""Tests for judging a handle-less job by the outputs it left on disk.
+
+A job the GUI imported with "Scan for Jobs", or that was submitted outside
+the GUI, has no executor handle. There is nothing to poll for such a job
+after a server restart, so its output directory is the only evidence of
+what happened — and recovar writes ``job.json`` as the last step of a run.
+
+Covers:
+    - disk_completion_time: present / absent / failed / stale job.json
+    - reconcile_jobs: handle-less job that finished → completed, not failed
+    - reconcile_jobs: handle-less job with nothing to show → still failed
+    - reconcile_jobs: executor lost the job (UNKNOWN) but disk says finished
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from recovar.gui_v2.backend.services.executor import (
+    Executor,
+    JobStatus,
+    disk_completion_time,
+    reconcile_jobs,
+)
+
+
+def _write_job_json(
+    job_dir: Path,
+    status: str = "completed",
+    completed_at: str | None = None,
+) -> Path:
+    job_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict = {"command": "analyze", "status": status}
+    if completed_at:
+        payload["timing"] = {"completed_at": completed_at}
+    path = job_dir / "job.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+# ---------------------------------------------------------------- disk probe
+
+
+class TestDiskCompletionTime:
+    def test_none_without_working_dir(self):
+        assert disk_completion_time(None) is None
+
+    def test_none_when_job_json_missing(self, tmp_path: Path):
+        (tmp_path / "kmeans").mkdir()
+        assert disk_completion_time(str(tmp_path)) is None
+
+    def test_prefers_recorded_completion_time(self, tmp_path: Path):
+        _write_job_json(tmp_path, completed_at="2026-08-12T09:37:11.500000")
+        assert disk_completion_time(str(tmp_path)) == datetime.datetime(
+            2026, 8, 12, 9, 37, 11, 500000
+        )
+
+    def test_falls_back_to_file_mtime(self, tmp_path: Path):
+        path = _write_job_json(tmp_path)  # no timing block
+        os.utime(path, (1_760_000_000, 1_760_000_000))
+        assert disk_completion_time(str(tmp_path)) == datetime.datetime.utcfromtimestamp(
+            1_760_000_000
+        )
+
+    def test_none_when_the_run_recorded_failure(self, tmp_path: Path):
+        _write_job_json(tmp_path, status="failed")
+        assert disk_completion_time(str(tmp_path)) is None
+
+    def test_none_when_job_json_predates_this_run(self, tmp_path: Path):
+        """A job.json left by an earlier run in the same directory is ignored."""
+        path = _write_job_json(tmp_path)
+        old = datetime.datetime(2026, 8, 1, 12, 0, 0)
+        stamp = old.replace(tzinfo=datetime.timezone.utc).timestamp()
+        os.utime(path, (stamp, stamp))
+        started_now = datetime.datetime(2026, 8, 12, 12, 0, 0)
+        assert disk_completion_time(str(tmp_path), started_now) is None
+
+    def test_unreadable_job_json_still_counts_as_finished(self, tmp_path: Path):
+        (tmp_path / "job.json").write_text("{ not json")
+        assert disk_completion_time(str(tmp_path)) is not None
+
+
+# ------------------------------------------------------------------ reconcile
+
+
+class TestReconcileWithoutHandle:
+    @pytest.mark.asyncio
+    async def test_finished_job_is_completed_not_failed(self, tmp_path: Path):
+        _write_job_json(tmp_path, completed_at="2026-08-12T09:37:11")
+        mock_executor = AsyncMock(spec=Executor)
+
+        updates = await reconcile_jobs(
+            mock_executor,
+            [
+                {
+                    "id": "j1",
+                    "handle": None,
+                    "db_status": "running",
+                    "working_dir": str(tmp_path),
+                }
+            ],
+        )
+
+        assert len(updates) == 1
+        assert updates[0]["new_status"] == JobStatus.COMPLETED.value
+        assert updates[0]["error"] is None
+        assert updates[0]["completed_at"] == datetime.datetime(2026, 8, 12, 9, 37, 11)
+
+    @pytest.mark.asyncio
+    async def test_job_with_no_outputs_is_still_failed(self, tmp_path: Path):
+        mock_executor = AsyncMock(spec=Executor)
+
+        updates = await reconcile_jobs(
+            mock_executor,
+            [
+                {
+                    "id": "j1",
+                    "handle": None,
+                    "db_status": "running",
+                    "working_dir": str(tmp_path),
+                }
+            ],
+        )
+
+        assert updates[0]["new_status"] == JobStatus.FAILED.value
+        assert "no completed output" in updates[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_that_recorded_failure_stays_failed(self, tmp_path: Path):
+        _write_job_json(tmp_path, status="failed")
+        mock_executor = AsyncMock(spec=Executor)
+
+        updates = await reconcile_jobs(
+            mock_executor,
+            [
+                {
+                    "id": "j1",
+                    "handle": None,
+                    "db_status": "running",
+                    "working_dir": str(tmp_path),
+                }
+            ],
+        )
+
+        assert updates[0]["new_status"] == JobStatus.FAILED.value
+
+
+class TestReconcileUnknownStatus:
+    @pytest.mark.asyncio
+    async def test_unknown_but_finished_on_disk_is_completed(self, tmp_path: Path):
+        """SLURM purging its accounting record must not turn a finished job red."""
+        _write_job_json(tmp_path, completed_at="2026-08-12T09:37:11")
+        mock_executor = AsyncMock(spec=Executor)
+        mock_executor.status.return_value = JobStatus.UNKNOWN
+        mock_executor.log_path.return_value = Path("/tmp/some.log")
+
+        updates = await reconcile_jobs(
+            mock_executor,
+            [
+                {
+                    "id": "j1",
+                    "handle": "12345",
+                    "db_status": "running",
+                    "working_dir": str(tmp_path),
+                }
+            ],
+        )
+
+        assert updates[0]["new_status"] == JobStatus.COMPLETED.value
+        assert updates[0]["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_with_no_outputs_still_fails(self, tmp_path: Path):
+        mock_executor = AsyncMock(spec=Executor)
+        mock_executor.status.return_value = JobStatus.UNKNOWN
+        mock_executor.log_path.return_value = Path("/tmp/some.log")
+
+        updates = await reconcile_jobs(
+            mock_executor,
+            [
+                {
+                    "id": "j1",
+                    "handle": "12345",
+                    "db_status": "running",
+                    "working_dir": str(tmp_path),
+                }
+            ],
+        )
+
+        assert updates[0]["new_status"] == JobStatus.FAILED.value
+        assert "unknown after server restart" in updates[0]["error"]

--- a/tests/unit/test_gui_launcher.py
+++ b/tests/unit/test_gui_launcher.py
@@ -8,6 +8,7 @@ so they run in ``test-fast``.
 
 from __future__ import annotations
 
+import pytest
 import socket
 
 from recovar.commands import gui
@@ -44,3 +45,56 @@ def test_browser_not_opened_when_disabled_or_remote(monkeypatch):
     gui._maybe_open_browser("http://x", "127.0.0.1", no_browser=True)
     gui._maybe_open_browser("http://x", "0.0.0.0", no_browser=False)
     assert opened == []
+
+
+def test_port_probe_sets_reuseaddr(monkeypatch):
+    """The probe must not read a TIME_WAIT socket as busy.
+
+    uvicorn binds with SO_REUSEADDR, so a probe without it is stricter than
+    the real bind: restarting the server would report the port busy and the
+    launch would drift to another one, silently breaking an SSH tunnel.
+    """
+    seen = {}
+
+    class Recording(socket.socket):
+        def setsockopt(self, level, optname, value):  # noqa: D102
+            if level == socket.SOL_SOCKET and optname == socket.SO_REUSEADDR:
+                seen["reuseaddr"] = value
+            return super().setsockopt(level, optname, value)
+
+    monkeypatch.setattr(gui.socket, "socket", Recording)
+    gui._port_is_free("127.0.0.1", _free_port())
+
+    assert seen.get("reuseaddr") == 1
+
+
+def test_port_is_free_reports_a_listening_port_as_busy():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as occupied:
+        occupied.bind(("127.0.0.1", 0))
+        occupied.listen(1)
+        busy = occupied.getsockname()[1]
+        assert gui._port_is_free("127.0.0.1", busy) is False
+    assert gui._port_is_free("127.0.0.1", busy) is True
+
+
+def test_default_port_drifts_when_busy():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as occupied:
+        occupied.bind(("127.0.0.1", 0))
+        occupied.listen(1)
+        busy = occupied.getsockname()[1]
+        assert gui._resolve_port("127.0.0.1", busy, explicit=False) != busy
+
+
+def test_explicit_port_is_refused_rather_than_moved():
+    """--port names the port being forwarded: moving it looks like a dead GUI."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as occupied:
+        occupied.bind(("127.0.0.1", 0))
+        occupied.listen(1)
+        busy = occupied.getsockname()[1]
+        with pytest.raises(gui.PortUnavailableError):
+            gui._resolve_port("127.0.0.1", busy, explicit=True)
+
+
+def test_explicit_free_port_is_used_as_is():
+    port = _free_port()
+    assert gui._resolve_port("127.0.0.1", port, explicit=True) == port


### PR DESCRIPTION
Two bugs that made the GUI look broken after a restart. Both were hit on a live project on an HPC cluster; the fixes are verified by driving the actual UI, not just the tests.

## Finished jobs recorded as failed

A job imported with **Scan for Jobs**, or submitted outside the GUI, has no executor handle. `reconcile_jobs` treated a missing handle as proof of failure, so any such job that was in flight got recorded as `failed` on the next server start — with `completed_at` stamped to the restart time — even when it had run to completion hours earlier.

Nothing in the UI could undo that: a rescan skips directories already known to the project, and `POST /api/jobs/{id}/reconcile` returns early for terminal jobs. The job stayed red permanently.

recovar writes `job.json` as the last step of a run, so these jobs are now judged by their outputs:

- `disk_completion_time()` reports when a run finished, preferring `timing.completed_at` over the file mtime.
- A `job.json` older than the job's start time is ignored, so a file left by an earlier run in the same directory can't be read as this run's completion.
- A run that recorded its own failure stays failed; a job with nothing on disk stays failed.
- The same evidence settles jobs whose executor reports `UNKNOWN` — what SLURM returns once it purges the accounting record.
- Startup repairs rows an earlier version already got wrong (`status=failed`, no handle, `error` starting with "No executor handle"), so existing databases heal on the next launch instead of needing manual SQL.

`completed_at` now keeps the real finish time rather than the moment of the restart, and a job reconciled to completed no longer carries the error text from a previous failed reconcile.

## `--port` silently drifting

`_pick_port` probed with a bare `bind()` while uvicorn binds with `SO_REUSEADDR`. The probe was therefore stricter than the real bind: the socket left in `TIME_WAIT` by a server you just stopped read as busy, and a restart moved the GUI to 8081 while the port being forwarded over SSH stayed 8080. The browser shows "connection refused" with nothing to explain why.

The probe now sets `SO_REUSEADDR`, and the two cases are separated: the default port may still drift so a launch isn't blocked, but a port named with `--port` is used as given or the launch fails with a message naming the conflict.

## Tests

20 tests, all passing:

- `test_reconcile_disk_evidence.py` (new) — the disk probe (missing / recorded time / mtime fallback / self-reported failure / stale file / unreadable), handle-less reconcile in both directions, and the `UNKNOWN` path.
- `test_gui_launcher.py` — the probe sets `SO_REUSEADDR`, a listening port reads busy and is free again after close, default drifts, explicit is refused, explicit-and-free is used as-is.

7 pre-existing failures in `test_executor.py` (`TestLocalExecutor`, `TestSbatchTemplate`) are unrelated — they fail identically on a pristine `HEAD` worktree.

## Verified in the browser

Driven with Playwright against a real project on the cluster: an analyze job that this bug had marked failed shows **Completed** with its 14 plots, 20 k-means volumes render in 3D, the latent explorer loads 71,058 particles, and the server stays on the port it was given across restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
