### PR TITLE
Add shared-particle cryo-ET support to direct PPCA

### DIFF
--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -830,6 +830,11 @@ def _resolve_ppca_contrast_mode(args):
     return "marginalize" if getattr(args, "correct_contrast", False) else "none"
 
 
+def _contrast_option_for_repeat(shared_contrast_across_tilts):
+    """Keep the second contrast-correction pass at the first pass's granularity."""
+    return "contrast_shared" if shared_contrast_across_tilts else "contrast"
+
+
 def _resolve_ppca_contrast_grid(contrast_mode):
     """Return PPCA contrast quadrature nodes and weights.
 
@@ -1086,6 +1091,15 @@ def _run_ppca_refinement(
         update_noise=ppca_update_noise,
     )
 
+    posterior_count = int(np.asarray(expected_zs).shape[0])
+    expected_posterior_count = int(dataset.n_units)
+    if posterior_count != expected_posterior_count:
+        raise RuntimeError(
+            f"PPCA returned {posterior_count} posteriors for {expected_posterior_count} dataset units"
+        )
+    posterior_unit = "tilt-series particles" if getattr(dataset, "tilt_series_flag", False) else "images"
+    logger.info("PPCA posterior count: %d (%s)", posterior_count, posterior_unit)
+
     half_vol_size = int(np.prod(fourier_transform_utils.volume_shape_to_half_volume_shape(dataset.volume_shape)))
     U_full = U_ppca
     if U_full.shape[0] == half_vol_size:
@@ -1187,6 +1201,7 @@ def _run_ppca_refinement(
         "contrasts": contrasts,
         "contrasts_noreg": contrasts_noreg,
         "em_mean_c": posterior_info.get("mean_c") if posterior_info else None,
+        "posterior_count": posterior_count,
     }
 
 
@@ -1459,7 +1474,7 @@ def standard_recovar_pipeline(args):
             contrasts_for_second /= np.mean(contrasts_for_second)
             # Embedding returns contrasts in original dataset order (no halfset reordering needed).
             ds.set_contrasts(contrasts_for_second)
-            options.contrast = "contrast"
+            options.contrast = _contrast_option_for_repeat(args.shared_contrast_across_tilts)
 
         ##TODO: mean functions return a dict with volume sized arrays.
         ## I think none of them are on gpu which is good (nothing should be on gpu that absolutely has to be)
@@ -1676,6 +1691,7 @@ def standard_recovar_pipeline(args):
                 "ppca_refitb_kappa": float(getattr(args, "ppca_refitb_kappa", 0.0)),
                 "ppca_effective_zdim": int(getattr(args, "ppca_effective_zdim", 0)),
                 "embedding_source": ppca_result["embedding_source"],
+                "posterior_count": int(ppca_result["posterior_count"]),
             }
         else:
             for idx, focus_mask in enumerate(focus_masks):

--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -449,6 +449,23 @@ def add_args(parser: argparse.ArgumentParser):
         ),
     )
     adv.add_argument(
+        "--ppca-mean-fsc-bandlimit",
+        dest="ppca_mean_fsc_bandlimit",
+        action="store_true",
+        help=(
+            "After PPCA EM, hard-bandlimit the exported PCs and loadings to the "
+            "global half-map mean FSC resolution, then recompute embeddings in "
+            "that bandlimited basis. Off by default."
+        ),
+    )
+    adv.add_argument(
+        "--ppca-mean-fsc-threshold",
+        dest="ppca_mean_fsc_threshold",
+        type=float,
+        default=1 / 7,
+        help="FSC cutoff used by --ppca-mean-fsc-bandlimit (default: 1/7).",
+    )
+    adv.add_argument(
         "--ppca-update-noise",
         dest="ppca_update_noise",
         action="store_true",
@@ -953,6 +970,42 @@ def _as_pipeline_basis_dtype(arr):
     return arr.astype(np.complex64 if np.iscomplexobj(arr) else np.float32)
 
 
+def _mean_fsc_pc_bandlimit(dataset, means, threshold=1 / 7):
+    """Return the current mean-FSC radial masks used by heterogeneous EM.
+
+    This intentionally mirrors :mod:`recovar.em.iterations`: compute the
+    global FSC from the two unregularized half maps, interpolate its threshold
+    crossing with ``locres.find_fsc_resol``, and use the dataset's hard radial
+    support mask at that radius.
+    """
+    threshold = float(threshold)
+    if not 0.0 < threshold < 1.0:
+        raise ValueError(f"--ppca-mean-fsc-threshold must be between 0 and 1, got {threshold}")
+
+    from recovar.heterogeneity import locres
+    from recovar.reconstruction import regularization
+
+    fsc = np.asarray(
+        regularization.get_fsc(
+            means.corrected0,
+            means.corrected1,
+            dataset.volume_shape,
+            substract_shell_mean=False,
+            frequency_shift=0,
+        )
+    )
+    radius = float(locres.find_fsc_resol(fsc, threshold=threshold))
+    full_mask = np.asarray(dataset.get_valid_frequency_indices(radius), dtype=np.float32).reshape(-1)
+    half_mask = np.asarray(
+        fourier_transform_utils.full_volume_to_half_volume(
+            full_mask.reshape(dataset.volume_shape),
+            dataset.volume_shape,
+        )
+    ).reshape(-1)
+    half_mask = np.asarray(half_mask.real, dtype=np.float32)
+    return full_mask, half_mask, radius, fsc
+
+
 def _run_ppca_refinement(
     dataset,
     means,
@@ -1105,6 +1158,22 @@ def _run_ppca_refinement(
     if U_full.shape[0] == half_vol_size:
         U_full = fourier_transform_utils.half_volume_to_full_volume(np.asarray(U_full).T, dataset.volume_shape).T
     U_full = _as_pipeline_basis_dtype(U_full)
+    mean_fsc_bandlimit = bool(getattr(args, "ppca_mean_fsc_bandlimit", False))
+    mean_fsc_radius = None
+    mean_fsc_threshold = float(getattr(args, "ppca_mean_fsc_threshold", 1 / 7))
+    if mean_fsc_bandlimit:
+        full_mask, half_mask, mean_fsc_radius, _ = _mean_fsc_pc_bandlimit(
+            dataset,
+            means,
+            threshold=mean_fsc_threshold,
+        )
+        U_full = U_full * full_mask[:, None]
+        W_ppca = np.asarray(W_ppca) * half_mask[:, None]
+        logger.info(
+            "PPCA: bandlimited PCs/loadings to mean FSC %.6g crossing at Fourier radius %.3f pixels",
+            mean_fsc_threshold,
+            mean_fsc_radius,
+        )
     u_rescaled = U_full
 
     use_em_contrasts = (
@@ -1112,7 +1181,13 @@ def _run_ppca_refinement(
         and contrast_mode == "marginalize"
         and posterior_info is not None
         and posterior_info.get("mean_c") is not None
+        and not mean_fsc_bandlimit
     )
+    if mean_fsc_bandlimit and bool(getattr(args, "ppca_embed_use_em_contrasts", False)):
+        logger.warning(
+            "PPCA: --ppca-mean-fsc-bandlimit changes the basis; recomputing embeddings and contrasts "
+            "instead of using the pre-bandlimit EM posteriors"
+        )
 
     if use_em_contrasts:
         # Use EM's marginalized posterior contrasts directly, bypassing the
@@ -1175,6 +1250,8 @@ def _run_ppca_refinement(
             embedding_source = "refitb"
         else:
             embedding_source = "compute_embeddings"
+        if mean_fsc_bandlimit:
+            embedding_source += "+mean_fsc_bandlimit"
 
     logger.info(
         "PPCA solve complete: q=%d iters=%d projcov_every=%d refitb_every=%d contrast_mode=%s",
@@ -1202,6 +1279,9 @@ def _run_ppca_refinement(
         "contrasts_noreg": contrasts_noreg,
         "em_mean_c": posterior_info.get("mean_c") if posterior_info else None,
         "posterior_count": posterior_count,
+        "mean_fsc_bandlimit": mean_fsc_bandlimit,
+        "mean_fsc_threshold": mean_fsc_threshold if mean_fsc_bandlimit else None,
+        "mean_fsc_radius": mean_fsc_radius,
     }
 
 
@@ -1692,6 +1772,9 @@ def standard_recovar_pipeline(args):
                 "ppca_effective_zdim": int(getattr(args, "ppca_effective_zdim", 0)),
                 "embedding_source": ppca_result["embedding_source"],
                 "posterior_count": int(ppca_result["posterior_count"]),
+                "mean_fsc_bandlimit": bool(ppca_result["mean_fsc_bandlimit"]),
+                "mean_fsc_threshold": ppca_result["mean_fsc_threshold"],
+                "mean_fsc_radius": ppca_result["mean_fsc_radius"],
             }
         else:
             for idx, focus_mask in enumerate(focus_masks):

--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -978,9 +978,6 @@ def _run_ppca_refinement(
     if basis_size <= 0:
         raise ValueError(f"PPCA basis size must be positive, got {basis_size}")
 
-    if getattr(args, "tilt_series", False):
-        raise ValueError("PPCA pipeline mode does not support --tilt-series yet")
-
     # Multi-mask support: build masks array and PC assignment
     ppca_masks = None
     ppca_pc_mask_assignment = None
@@ -1004,6 +1001,17 @@ def _run_ppca_refinement(
     logger.warning("PPCA pipeline mode currently uses the provisional hybrid-shell prior. This should be tightened up.")
 
     contrast_mode = _resolve_ppca_contrast_mode(args)
+    if (
+        getattr(args, "tilt_series", False)
+        and contrast_mode != "none"
+        and not getattr(args, "shared_contrast_across_tilts", False)
+    ):
+        raise ValueError(
+            "Cryo-ET PPCA contrast refinement requires --shared_contrast_across_tilts; "
+            "without --correct-contrast, PPCA uses fixed contrast and supports either setting."
+        )
+    if getattr(args, "tilt_series", False):
+        logger.info("PPCA cryo-ET mode: sharing one latent conformation across all tilts of each particle")
     contrast_grid, contrast_weights = _resolve_ppca_contrast_grid(contrast_mode)
     W_init = _make_ppca_initial_loading(dataset.volume_size, basis_size, volume_shape=dataset.volume_shape)
     prior_info = ppca_prior_estimation.estimate_hybrid_shell_prior_from_data(

--- a/recovar/ppca/ppca.py
+++ b/recovar/ppca/ppca.py
@@ -127,6 +127,81 @@ def _tri_size(q):
     return (q * (q + 1)) // 2
 
 
+def _particle_groups_for_batch(particle_indices, n_images):
+    """Return sorted particle ids and a consecutive group id per image."""
+    particle_ids = np.asarray(particle_indices, dtype=np.int32).reshape(-1)
+    if particle_ids.size == 1:
+        particle_ids = np.full(n_images, particle_ids[0], dtype=np.int32)
+    if particle_ids.size != n_images:
+        raise ValueError(f"Expected one particle id per image (or one shared id), got {particle_ids.size} ids for {n_images} images")
+    if np.any(particle_ids < 0):
+        raise ValueError("PPCA tilt-series batches must not contain padded particle ids")
+    unique_particles, group_ids = np.unique(particle_ids, return_inverse=True)
+    return unique_particles.astype(np.int32, copy=False), group_ids.astype(np.int32, copy=False)
+
+
+def _group_ppca_sufficient_statistics(H, g, h, t, nu, y_norm_sq, centered_norm_sq, particle_indices=None):
+    """Group per-image PPCA statistics by particle when labels are provided.
+
+    The returned ``image_to_group`` array broadcasts particle-level posterior
+    moments back to the per-tilt arrays used by the image-wise M-step.
+    """
+    n_images = int(H.shape[0])
+    if particle_indices is None:
+        image_to_group = jnp.arange(n_images, dtype=jnp.int32)
+        counts = jnp.ones(n_images, dtype=H.dtype)
+        return H, g, h, t, nu, y_norm_sq, centered_norm_sq, image_to_group, counts
+
+    _unique_particles, group_ids_np = _particle_groups_for_batch(particle_indices, n_images)
+    n_groups = int(np.max(group_ids_np)) + 1
+    image_to_group = jnp.asarray(group_ids_np, dtype=jnp.int32)
+
+    def group_sum(x):
+        return jax.ops.segment_sum(x, image_to_group, num_segments=n_groups)
+
+    counts = group_sum(jnp.ones(n_images, dtype=H.dtype))
+    return (
+        group_sum(H),
+        group_sum(g),
+        group_sum(h),
+        group_sum(t),
+        group_sum(nu),
+        group_sum(y_norm_sq),
+        group_sum(centered_norm_sq),
+        image_to_group,
+        counts,
+    )
+
+
+def _solve_grouped_no_contrast_posterior(
+    H,
+    g,
+    h,
+    centered_norm_sq,
+    z_prior_precision_diag,
+    image_shape,
+    observation_counts,
+    compute_ll,
+):
+    """Solve the c=1 posterior from image- or particle-level statistics."""
+    M_n = H + jnp.diag(z_prior_precision_diag)
+    b_n = (g - h)[..., None]
+    M_n_inv = jnp.linalg.pinv(M_n, hermitian=True)
+    expected_zs = (M_n_inv @ b_n).squeeze(-1)
+    second_moment_zs = M_n_inv + linalg.broadcast_outer(expected_zs, jnp.conj(expected_zs))
+
+    ll_sum = jnp.array(0.0, dtype=H.dtype)
+    if compute_ll:
+        u = b_n.squeeze(-1)
+        quad = jnp.real(jnp.sum(jnp.conj(u) * (M_n_inv @ u[..., None]).squeeze(-1), axis=-1))
+        L = jnp.linalg.cholesky(M_n)
+        logdetM = 2.0 * jnp.sum(jnp.log(jnp.real(jnp.diagonal(L, axis1=1, axis2=2))), axis=-1)
+        dimensions = observation_counts * np.prod(image_shape)
+        ll_per_unit = -0.5 * (dimensions * jnp.log(2.0 * jnp.pi) + centered_norm_sq - quad + logdetM)
+        ll_sum = jnp.sum(ll_per_unit)
+    return expected_zs, second_moment_zs, ll_sum
+
+
 _half_slice_volume = functools.partial(core.slice_volume, half_volume=True, half_image=True)
 batch_over_vol_slice_volume_half = jax.vmap(_half_slice_volume, in_axes=(1, None, None, None, None), out_axes=1)
 
@@ -153,11 +228,11 @@ def _e_step_half_inner(
     disc_type,
     z_prior_precision_diag,  # (q,) array of 1/var per dim. Use jnp.ones(q) for identity prior.
 ):
-    """JIT'd E-step core: computes sufficient stats and c=1 posterior.
+    """Compute per-image sufficient statistics for the PPCA E-step.
 
-    Returns sufficient statistics (H, g, h, t, nu, y_norm_sq) plus
-    noise-whitened images/mean/CTF for backprojection, and the standard
-    (c=1) posterior moments.
+    Returns sufficient statistics ``(H, g, h, t, nu, y_norm_sq)`` plus
+    noise-whitened images/mean/CTF/basis projections for the posterior solve
+    and backprojection.
 
     Contrast dispatch happens OUTSIDE JIT in E_M_step_batch_half.
     """
@@ -194,51 +269,22 @@ def _e_step_half_inner(
     t = jnp.sum(rfft_w * jnp.real(jnp.conj(images_half) * projected_mean_half), axis=-1)
     nu = jnp.sum(rfft_w * jnp.real(jnp.conj(projected_mean_half) * projected_mean_half), axis=-1)
     y_norm_sq = jnp.sum(rfft_w * jnp.real(jnp.conj(images_half) * images_half), axis=-1)
-
-    # Standard c=1 posterior (always computed — used for LL and as fallback).
-    # Caller always supplies z_prior_precision_diag (a (q,) array). For the
-    # default identity prior z ~ N(0, I), pass jnp.ones(q). For a calibrated
-    # prior z ~ N(0, diag(eig)), pass 1/eig.
-    M_n = H + jnp.diag(z_prior_precision_diag)
-    b_n = (g - h)[..., None]
-    M_n_inv = jax.numpy.linalg.pinv(M_n, hermitian=True)
-    expected_zs = (M_n_inv @ b_n).squeeze(-1)
-    second_moment_zs = M_n_inv + linalg.broadcast_outer(expected_zs, jnp.conj(expected_zs))
-
-    ll_sum = jnp.array(0.0, dtype=images_half.dtype)
-    if compute_ll:
-        u = b_n.squeeze(-1)
-        quad = jnp.real(jnp.sum(jnp.conj(u) * (M_n_inv @ u[..., None]).squeeze(-1), axis=-1))
-        r2 = jnp.sum(rfft_w * jnp.real(jnp.conj(images_half) * images_half), axis=-1)
-        centered_half = images_half - projected_mean_half
-        r2 = jnp.sum(rfft_w * jnp.real(jnp.conj(centered_half) * centered_half), axis=-1)
-        L = jnp.linalg.cholesky(M_n)
-        logdetM = 2.0 * jnp.sum(jnp.log(jnp.real(jnp.diagonal(L, axis1=1, axis2=2))), axis=-1)
-        d_n = np.prod(image_shape)
-        ll_per_image = -0.5 * (d_n * jnp.log(2.0 * jnp.pi) + r2 - quad + logdetM)
-        ll_sum = jnp.sum(ll_per_image)
-
-    # Whitened residual power per half-pixel, summed over batch (c=1 approximation).
-    # Used by the noise update: new_σ²(k) ≈ σ²_old(k) * <|r_w|²>_shell.
-    Wz = jnp.einsum("bqp,bq->bp", PW_half, expected_zs)
-    residual_w = images_half - projected_mean_half - Wz
-    residual_power_half = jnp.sum(jnp.real(jnp.conj(residual_w) * residual_w), axis=0)
+    centered_half = images_half - projected_mean_half
+    centered_norm_sq = jnp.sum(rfft_w * jnp.real(jnp.conj(centered_half) * centered_half), axis=-1)
 
     return (
-        expected_zs,
-        second_moment_zs,
         ctf_squared_half,
         images_half,
         projected_mean_half,
         CTF_half,
-        ll_sum,
         H,
         g,
         h,
         t,
         nu,
         y_norm_sq,
-        residual_power_half,
+        centered_norm_sq,
+        PW_half,
     )
 
 
@@ -267,6 +313,7 @@ def E_M_step_batch_half(
     eigenvalues=None,
     contrast_mean=1.0,
     contrast_variance=np.inf,
+    particle_indices=None,
 ):
     """Half-spectrum, upper-triangular-LHS variant of :func:`E_M_step_batch`.
 
@@ -289,20 +336,18 @@ def E_M_step_batch_half(
     else:
         z_prior_precision_diag = jnp.ones(basis_size, dtype=W_half.real.dtype)
     (
-        expected_zs,
-        second_moment_zs,
         ctf_squared_half,
         images_half_w,
         projected_mean_half_w,
         CTF_half,
-        ll_sum,
         H,
         g,
         h,
         t,
         nu,
         y_norm_sq,
-        residual_power_half,
+        centered_norm_sq,
+        PW_half,
     ) = _e_step_half_inner(
         images_half,
         mean,
@@ -319,6 +364,31 @@ def E_M_step_batch_half(
         disc_type_mean,
         disc_type,
         z_prior_precision_diag,
+    )
+
+    # SPA has one latent variable per image. Cryo-ET has one latent variable
+    # per particle, shared by all of that particle's tilts. Segment-summing
+    # these sufficient statistics is the same shared-label construction used
+    # by RECOVAR's covariance and embedding paths.
+    H, g, h, t, nu, y_norm_sq, centered_norm_sq, image_to_group, observation_counts = _group_ppca_sufficient_statistics(
+        H,
+        g,
+        h,
+        t,
+        nu,
+        y_norm_sq,
+        centered_norm_sq,
+        particle_indices=particle_indices,
+    )
+    expected_zs, second_moment_zs, ll_sum = _solve_grouped_no_contrast_posterior(
+        H,
+        g,
+        h,
+        centered_norm_sq,
+        z_prior_precision_diag,
+        image_shape,
+        observation_counts,
+        compute_ll,
     )
     ## TODO: WHY IS THIS OUTSIDE OF JIT?
     # --- Contrast dispatch (outside JIT) ---
@@ -346,17 +416,31 @@ def E_M_step_batch_half(
             contrast_variance=contrast_variance,
         )
         expected_zs = result.mean_z
+        second_moment_zs = result.second_moment_z
         mean_cz = result.mean_cz
         mean_c2z = result.mean_c2z
         second_moment_czz = result.second_moment_czz
         mean_c = result.mean_c
         marginal_ll_batch = result.marginal_ll
 
+    # Backprojection remains image-wise, so repeat the shared particle
+    # posterior moments over that particle's tilts only at this boundary.
+    expected_zs_images = expected_zs[image_to_group]
+    mean_cz_images = mean_cz[image_to_group]
+    mean_c2z_images = mean_c2z[image_to_group]
+    second_moment_czz_images = second_moment_czz[image_to_group]
+
+    # Whitened residual power per half-pixel, summed over images (c=1
+    # approximation). This is used only by the optional noise update.
+    Wz = jnp.einsum("bqp,bq->bp", PW_half, expected_zs_images)
+    residual_w = images_half_w - projected_mean_half_w - Wz
+    residual_power_half = jnp.sum(jnp.real(jnp.conj(residual_w) * residual_w), axis=0)
+
     # --- backprojection ---
     if compute_stats:
         half_volume_size = lhs_summed.shape[0]
         # LHS uses E[c²zz^T] (= E[zz^T] when c=1)
-        second_moment_tri = second_moment_czz[:, tri_i, tri_j]
+        second_moment_tri = second_moment_czz_images[:, tri_i, tri_j]
         ctf_squared_full = ftu.half_image_to_full_image(ctf_squared_half, image_shape)
         _max_r = image_shape[0] // 2 - 1
 
@@ -400,8 +484,8 @@ def E_M_step_batch_half(
         # must backproject through the basis interpolation disc_type. For c=1
         # this collapses to the original centered residual CTF · (y - Aμ) · E[z]^T.
         rhs_residual = (
-            images_half_w[..., None] * jnp.conj(mean_cz)[:, None, :]
-            - projected_mean_half_w[..., None] * jnp.conj(mean_c2z)[:, None, :]
+            images_half_w[..., None] * jnp.conj(mean_cz_images)[:, None, :]
+            - projected_mean_half_w[..., None] * jnp.conj(mean_c2z_images)[:, None, :]
         )
         before_rhs = (CTF_half[..., None] * rhs_residual).transpose(2, 0, 1)
         bp_rhs = core.batch_adjoint_slice_volume(
@@ -422,7 +506,7 @@ def E_M_step_batch_half(
         lhs_summed,
         rhs_summed,
         expected_zs,
-        second_moment_czz,
+        second_moment_zs,
         ll_sum,
         ll_per_image,
         mean_c,
@@ -736,17 +820,19 @@ def _iter_processed_batches_half(experiment_dataset, batch_size):
         translations,
         ctf_params,
         _noise_variance,
-        _particle_indices,
+        particle_indices,
         image_indices,
     ) in experiment_dataset.iter_batches(
         batch_size,
         by_image=not getattr(experiment_dataset, "tilt_series_flag", False),
+        pack_groups=getattr(experiment_dataset, "tilt_series_flag", False),
     ):
         yield (
             experiment_dataset.process_images_half(batch, apply_image_mask=False),
             ctf_params,
             rotation_matrices,
             translations,
+            particle_indices,
             image_indices,
         )
 
@@ -829,9 +915,14 @@ def EM_step_half(
     n_images_total = 0
 
     for ds in halfset_datasets:
-        for batch_half, ctf_params, rotation_matrices, translations, batch_image_ind in _iter_processed_batches_half(
-            ds, batch_size
-        ):
+        for (
+            batch_half,
+            ctf_params,
+            rotation_matrices,
+            translations,
+            particle_indices,
+            batch_image_ind,
+        ) in _iter_processed_batches_half(ds, batch_size):
             noise_variance_half = ds.noise.get_half(batch_image_ind)
             (
                 lhs_summed,
@@ -869,6 +960,7 @@ def EM_step_half(
                 eigenvalues=eigenvalues,
                 contrast_mean=contrast_mean,
                 contrast_variance=contrast_variance,
+                particle_indices=particle_indices if ds.tilt_series_flag else None,
             )
             expected_zs.append(np.array(ez_batch))
             second_moment_zs.append(np.array(smz_batch))
@@ -1568,7 +1660,7 @@ def EM(
                 disc_type_mean,
             )
             for _ds in halfset_datasets:
-                for _bh, _cp, _rm, _tr, _bi in _iter_processed_batches_half(_ds, batch_size):
+                for _bh, _cp, _rm, _tr, _pi, _bi in _iter_processed_batches_half(_ds, batch_size):
                     _nvh = _ds.noise.get_half(_bi)
                     _, _, _, _, _llb, _, _, _, _, _ = E_M_step_batch_half(
                         _bh,
@@ -1589,6 +1681,7 @@ def EM(
                         disc_type_mean=disc_type_mean,
                         disc_type=disc_type,
                         compute_stats=False,
+                        particle_indices=_pi if _ds.tilt_series_flag else None,
                     )
                     ll_sum_r += _llb
             _Wph = ftu.full_volume_to_half_volume(W_prior.T, vs).T if W_prior.shape[0] != W.shape[0] else W_prior

--- a/tests/unit/test_commands_pipeline.py
+++ b/tests/unit/test_commands_pipeline.py
@@ -392,6 +392,14 @@ def test_resolve_ppca_contrast_mode_auto():
     )
 
 
+@pytest.mark.parametrize(
+    ("shared_contrast_across_tilts", "expected"),
+    [(False, "contrast"), (True, "contrast_shared")],
+)
+def test_contrast_option_for_repeat_preserves_tilt_sharing(shared_contrast_across_tilts, expected):
+    assert pipeline_cmd._contrast_option_for_repeat(shared_contrast_across_tilts) == expected
+
+
 def test_configure_ppca_single_zdim_overrides_options():
     args = SimpleNamespace(ppca_zdim=7, zdim=[1, 2, 4])
     options = SimpleNamespace(zs_dim_to_test=[1, 2, 4, 10])
@@ -440,7 +448,12 @@ def test_run_ppca_refinement_uses_hybrid_shell_prior(
     shared_contrast,
     expected_contrast_mode,
 ):
-    fake_dataset = SimpleNamespace(volume_shape=(2, 2, 2), volume_size=8)
+    fake_dataset = SimpleNamespace(
+        volume_shape=(2, 2, 2),
+        volume_size=8,
+        n_units=1,
+        tilt_series_flag=tilt_series,
+    )
     means = SimpleNamespace(combined=np.zeros(8, dtype=np.complex64))
     options = SimpleNamespace(zs_dim_to_test=[4])
     args = SimpleNamespace(
@@ -540,6 +553,7 @@ def test_run_ppca_refinement_uses_hybrid_shell_prior(
     assert out["u_rescaled"].dtype == np.complex64
     assert out["s_rescaled"].dtype == np.float32
     assert out["W"].dtype == np.complex64
+    assert out["posterior_count"] == 1
     np.testing.assert_allclose(out["latent_coords"][4], np.array([[1.0, 2.0, 0.0, 0.0]], dtype=np.float32) * np.sqrt(np.arange(1, 5, dtype=np.float32))[None, :])
     np.testing.assert_allclose(out["contrasts"][4], np.array([1.25], dtype=np.float32))
 def test_run_ppca_refinement_rejects_unshared_cryoet_contrast():

--- a/tests/unit/test_commands_pipeline.py
+++ b/tests/unit/test_commands_pipeline.py
@@ -425,19 +425,34 @@ def test_rescale_ppca_posteriors_matches_covariance_space_formula():
     np.testing.assert_allclose(covariances, expected_cov)
 
 
-def test_run_ppca_refinement_uses_hybrid_shell_prior(monkeypatch):
+@pytest.mark.parametrize(
+    ("tilt_series", "correct_contrast", "shared_contrast", "expected_contrast_mode"),
+    [
+        (False, True, False, "marginalize"),
+        (True, True, True, "marginalize"),
+        (True, False, False, "none"),
+    ],
+)
+def test_run_ppca_refinement_uses_hybrid_shell_prior(
+    monkeypatch,
+    tilt_series,
+    correct_contrast,
+    shared_contrast,
+    expected_contrast_mode,
+):
     fake_dataset = SimpleNamespace(volume_shape=(2, 2, 2), volume_size=8)
     means = SimpleNamespace(combined=np.zeros(8, dtype=np.complex64))
     options = SimpleNamespace(zs_dim_to_test=[4])
     args = SimpleNamespace(
         ppca_zdim=4,
         ppca_contrast_mode="auto",
-        correct_contrast=True,
+        correct_contrast=correct_contrast,
         ppca_em_iters=7,
         use_complement_mask=False,
         ppca_use_gridding_correction=True,
         ppca_projected_covariance=False,
-        tilt_series=False,
+        tilt_series=tilt_series,
+        shared_contrast_across_tilts=shared_contrast,
     )
 
     prior_calls = {}
@@ -516,14 +531,35 @@ def test_run_ppca_refinement_uses_hybrid_shell_prior(monkeypatch):
     assert prior_calls["args"][4] == 32
     assert em_calls["W_init"].shape == (8, 4)
     np.testing.assert_allclose(em_calls["W_prior"], np.full((8, 4), 3.0, dtype=np.float32))
-    assert em_calls["kwargs"]["contrast_mode"] == "marginalize"
+    assert em_calls["kwargs"]["contrast_mode"] == expected_contrast_mode
     assert em_calls["kwargs"]["EM_iter"] == 7
     assert em_calls["kwargs"]["return_posterior_info"] is True
     assert out["basis_size"] == 4
-    assert out["contrast_mode"] == "marginalize"
+    assert out["contrast_mode"] == expected_contrast_mode
     assert out["prior_mode"] == "hybrid_shell"
     assert out["u_rescaled"].dtype == np.complex64
     assert out["s_rescaled"].dtype == np.float32
     assert out["W"].dtype == np.complex64
     np.testing.assert_allclose(out["latent_coords"][4], np.array([[1.0, 2.0, 0.0, 0.0]], dtype=np.float32) * np.sqrt(np.arange(1, 5, dtype=np.float32))[None, :])
     np.testing.assert_allclose(out["contrasts"][4], np.array([1.25], dtype=np.float32))
+def test_run_ppca_refinement_rejects_unshared_cryoet_contrast():
+    args = SimpleNamespace(
+        ppca_contrast_mode="auto",
+        correct_contrast=True,
+        tilt_series=True,
+        shared_contrast_across_tilts=False,
+    )
+    with pytest.raises(ValueError, match="requires --shared_contrast_across_tilts"):
+        pipeline_cmd._run_ppca_refinement(
+            SimpleNamespace(volume_shape=(2, 2, 2), volume_size=8),
+            SimpleNamespace(combined=np.zeros(8, dtype=np.complex64)),
+            np.ones((2, 2, 2), dtype=np.float32),
+            np.ones((2, 2, 2), dtype=np.float32),
+            SimpleNamespace(zs_dim_to_test=[2]),
+            args,
+            batch_size=8,
+            gpu_memory=8,
+            covariance_options={"disc_type_u": "linear_interp"},
+            focus_masks=[np.ones((2, 2, 2), dtype=np.float32)],
+            zdim_for_rest=20,
+        )

--- a/tests/unit/test_commands_pipeline.py
+++ b/tests/unit/test_commands_pipeline.py
@@ -62,6 +62,9 @@ def test_pipeline_registers_use_ppca():
     assert "--ppca-use-gridding-correction" in actions
     assert "--ppca-contrast-mode" in actions
     assert "--ppca-projected-covariance" in actions
+    assert "--ppca-mean-fsc-bandlimit" in actions
+    assert "--ppca-mean-fsc-threshold" in actions
+    assert actions["--ppca-mean-fsc-threshold"].default == pytest.approx(1 / 7)
 
 
 def test_pipeline_zdim_default_is_list():
@@ -433,12 +436,60 @@ def test_rescale_ppca_posteriors_matches_covariance_space_formula():
     np.testing.assert_allclose(covariances, expected_cov)
 
 
+def test_mean_fsc_pc_bandlimit_uses_current_heterogeneous_em_rule(monkeypatch):
+    volume_shape = (8, 8, 8)
+    dataset = SimpleNamespace(
+        volume_shape=volume_shape,
+        grid_size=8,
+        get_valid_frequency_indices=lambda radius: np.full(np.prod(volume_shape), radius, dtype=np.float32),
+    )
+    means = SimpleNamespace(
+        corrected0=np.ones(np.prod(volume_shape), dtype=np.complex64),
+        corrected1=np.ones(np.prod(volume_shape), dtype=np.complex64),
+    )
+    expected_fsc = np.array([1.0, 0.9, 0.5, 0.1, 0.0], dtype=np.float32)
+    observed = {}
+
+    from recovar.heterogeneity import locres
+    from recovar.reconstruction import regularization
+
+    monkeypatch.setattr(regularization, "get_fsc", lambda *args, **kwargs: expected_fsc)
+
+    def _fake_find_fsc_resol(fsc, threshold):
+        np.testing.assert_array_equal(fsc, expected_fsc)
+        observed["threshold"] = threshold
+        return 2.75
+
+    monkeypatch.setattr(locres, "find_fsc_resol", _fake_find_fsc_resol)
+
+    full_mask, half_mask, radius, fsc = pipeline_cmd._mean_fsc_pc_bandlimit(dataset, means, threshold=1 / 7)
+
+    assert observed["threshold"] == pytest.approx(1 / 7)
+    assert radius == 2.75
+    np.testing.assert_array_equal(fsc, expected_fsc)
+    np.testing.assert_array_equal(full_mask, np.full(np.prod(volume_shape), 2.75, dtype=np.float32))
+    assert half_mask.shape == (8 * 8 * 5,)
+    np.testing.assert_array_equal(half_mask, np.full(8 * 8 * 5, 2.75, dtype=np.float32))
+
+
+@pytest.mark.parametrize("threshold", [0.0, 1.0, -0.1, 1.1])
+def test_mean_fsc_pc_bandlimit_rejects_invalid_threshold(threshold):
+    with pytest.raises(ValueError, match="must be between 0 and 1"):
+        pipeline_cmd._mean_fsc_pc_bandlimit(SimpleNamespace(), SimpleNamespace(), threshold=threshold)
+
+
 @pytest.mark.parametrize(
-    ("tilt_series", "correct_contrast", "shared_contrast", "expected_contrast_mode"),
+    (
+        "tilt_series",
+        "correct_contrast",
+        "shared_contrast",
+        "expected_contrast_mode",
+        "mean_fsc_bandlimit",
+    ),
     [
-        (False, True, False, "marginalize"),
-        (True, True, True, "marginalize"),
-        (True, False, False, "none"),
+        (False, True, False, "marginalize", False),
+        (True, True, True, "marginalize", True),
+        (True, False, False, "none", False),
     ],
 )
 def test_run_ppca_refinement_uses_hybrid_shell_prior(
@@ -447,6 +498,7 @@ def test_run_ppca_refinement_uses_hybrid_shell_prior(
     correct_contrast,
     shared_contrast,
     expected_contrast_mode,
+    mean_fsc_bandlimit,
 ):
     fake_dataset = SimpleNamespace(
         volume_shape=(2, 2, 2),
@@ -466,10 +518,14 @@ def test_run_ppca_refinement_uses_hybrid_shell_prior(
         ppca_projected_covariance=False,
         tilt_series=tilt_series,
         shared_contrast_across_tilts=shared_contrast,
+        ppca_mean_fsc_bandlimit=mean_fsc_bandlimit,
     )
 
     prior_calls = {}
     em_calls = {}
+    embedding_calls = {}
+    full_mask = np.array([1, 1, 1, 1, 0, 0, 0, 0], dtype=np.float32)
+    half_mask = np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=np.float32)
 
     def _fake_prior(dataset, mean_estimate, npc, volume_shape, batch_size):
         prior_calls["args"] = (dataset, mean_estimate, npc, volume_shape, batch_size)
@@ -503,6 +559,7 @@ def test_run_ppca_refinement_uses_hybrid_shell_prior(
         )
 
     def _fake_compute_embeddings(*args_, **kwargs_):
+        embedding_calls["u_rescaled"] = np.asarray(args_[1]["rescaled"])
         return (
             {4: np.array([[1.0, 2.0, 0.0, 0.0]], dtype=np.float32) * np.sqrt(np.arange(1, 5, dtype=np.float32))[None, :]},
             {4: np.array([[1.0, 2.0, 0.0, 0.0]], dtype=np.float32)},
@@ -519,6 +576,11 @@ def test_run_ppca_refinement_uses_hybrid_shell_prior(
     )
     monkeypatch.setattr(pipeline_cmd.ppca_module, "EM", _fake_em)
     monkeypatch.setattr(pipeline_cmd, "_compute_embeddings", _fake_compute_embeddings)
+    monkeypatch.setattr(
+        pipeline_cmd,
+        "_mean_fsc_pc_bandlimit",
+        lambda *args_, **kwargs_: (full_mask, half_mask, 2.5, np.ones(2, dtype=np.float32)),
+    )
 
     out = pipeline_cmd._run_ppca_refinement(
         fake_dataset,
@@ -554,6 +616,19 @@ def test_run_ppca_refinement_uses_hybrid_shell_prior(
     assert out["s_rescaled"].dtype == np.float32
     assert out["W"].dtype == np.complex64
     assert out["posterior_count"] == 1
+    assert out["mean_fsc_bandlimit"] is mean_fsc_bandlimit
+    if mean_fsc_bandlimit:
+        np.testing.assert_array_equal(out["u_rescaled"], full_mask[:, None] * np.ones((8, 4)))
+        np.testing.assert_array_equal(out["W"], half_mask[:, None] * np.full((8, 4), 5.0))
+        np.testing.assert_array_equal(embedding_calls["u_rescaled"], out["u_rescaled"])
+        assert out["mean_fsc_threshold"] == pytest.approx(1 / 7)
+        assert out["mean_fsc_radius"] == 2.5
+        assert out["embedding_source"].endswith("+mean_fsc_bandlimit")
+    else:
+        np.testing.assert_array_equal(out["u_rescaled"], np.ones((8, 4)))
+        np.testing.assert_array_equal(out["W"], np.full((8, 4), 5.0))
+        assert out["mean_fsc_threshold"] is None
+        assert out["mean_fsc_radius"] is None
     np.testing.assert_allclose(out["latent_coords"][4], np.array([[1.0, 2.0, 0.0, 0.0]], dtype=np.float32) * np.sqrt(np.arange(1, 5, dtype=np.float32))[None, :])
     np.testing.assert_allclose(out["contrasts"][4], np.array([1.25], dtype=np.float32))
 def test_run_ppca_refinement_rejects_unshared_cryoet_contrast():

--- a/tests/unit/test_ppca.py
+++ b/tests/unit/test_ppca.py
@@ -202,6 +202,47 @@ def test_unpack_tri_to_full_roundtrip():
     np.testing.assert_allclose(recovered, A, atol=1e-6)
 
 
+def test_group_ppca_sufficient_statistics_and_posterior_match_manual_particle_sums():
+    """Cryo-ET E-step sums tilts before solving one posterior per particle."""
+    from recovar.ppca import ppca as ppca_mod
+
+    H = jnp.asarray([[[1.0]], [[2.0]], [[3.0]], [[4.0]], [[5.0]]], dtype=jnp.float32)
+    g = jnp.asarray([[2.0], [4.0], [3.0], [6.0], [9.0]], dtype=jnp.float32)
+    h = jnp.asarray([[0.5], [1.0], [0.25], [0.5], [0.75]], dtype=jnp.float32)
+    t = jnp.arange(5, dtype=jnp.float32)
+    nu = jnp.arange(5, dtype=jnp.float32) + 1.0
+    y_norm_sq = jnp.arange(5, dtype=jnp.float32) + 10.0
+    particle_ids = np.asarray([9, 9, 3, 3, 3], dtype=np.int32)
+
+    centered_norm_sq = y_norm_sq - 2.0 * t + nu
+    H_g, g_g, h_g, _t_g, _nu_g, _yn_g, centered_g, image_to_group, counts = ppca_mod._group_ppca_sufficient_statistics(
+        H, g, h, t, nu, y_norm_sq, centered_norm_sq, particle_ids
+    )
+
+    # np.unique orders particle 3 before particle 9.
+    np.testing.assert_array_equal(np.asarray(image_to_group), [1, 1, 0, 0, 0])
+    np.testing.assert_array_equal(np.asarray(counts), [3.0, 2.0])
+    np.testing.assert_allclose(np.asarray(H_g[:, 0, 0]), [12.0, 3.0])
+    np.testing.assert_allclose(np.asarray(g_g[:, 0]), [18.0, 6.0])
+    np.testing.assert_allclose(np.asarray(h_g[:, 0]), [1.5, 1.5])
+
+    ez, smz, ll = ppca_mod._solve_grouped_no_contrast_posterior(
+        H_g,
+        g_g,
+        h_g,
+        centered_g,
+        jnp.ones(1, dtype=jnp.float32),
+        (2, 2),
+        counts,
+        compute_ll=True,
+    )
+    expected_ez = np.asarray([(18.0 - 1.5) / 13.0, (6.0 - 1.5) / 4.0], dtype=np.float32)
+    expected_var = np.asarray([1.0 / 13.0, 1.0 / 4.0], dtype=np.float32)
+    np.testing.assert_allclose(np.asarray(ez[:, 0]), expected_ez, rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(smz[:, 0, 0]), expected_var + expected_ez**2, rtol=1e-6)
+    assert np.isfinite(float(ll))
+
+
 def test_E_M_step_batch_half_shapes():
     """Verify E_M_step_batch_half returns correct shapes."""
     from recovar.ppca.ppca import E_M_step_batch_half, _tri_size
@@ -392,6 +433,40 @@ def test_E_M_step_batch_half_no_stats():
     # But E-step should still produce non-trivial results
     assert np.any(np.asarray(ez) != 0)
     assert np.isfinite(float(ll.real))
+
+
+def test_E_M_step_batch_half_returns_one_posterior_per_cryoet_particle():
+    from recovar.ppca.ppca import E_M_step_batch_half, _tri_size
+
+    rng = np.random.default_rng(56)
+    d = _make_em_step_test_data(rng, grid_size=8, n_images=4, basis_size=2)
+    tri_sz = _tri_size(d["basis_size"])
+
+    _, _, ez, smz, ll, _, mean_c, _, _, n_images = E_M_step_batch_half(
+        d["images_half"],
+        jnp.zeros((d["half_volume_size"], tri_sz), dtype=np.float32),
+        jnp.zeros((d["half_volume_size"], d["basis_size"]), dtype=np.complex64),
+        d["mean_full"],
+        d["W_half"],
+        d["CTF_params"],
+        d["rotation_matrices"],
+        d["translations"],
+        d["image_shape"],
+        d["volume_shape"],
+        d["grid_size"],
+        d["voxel_size"],
+        d["noise_variance_half"],
+        d["ctf_evaluator"],
+        compute_ll=True,
+        compute_stats=False,
+        particle_indices=np.asarray([11, 11, 29, 29], dtype=np.int32),
+    )
+
+    assert ez.shape == (2, d["basis_size"])
+    assert smz.shape == (2, d["basis_size"], d["basis_size"])
+    assert mean_c.shape == (2,)
+    assert n_images == 4
+    assert np.isfinite(float(ll))
 
 
 def test_em_return_posterior_info_exposes_mean_c(monkeypatch):


### PR DESCRIPTION
## Summary

Adds the smallest fixed-pose cryo-ET extension of the existing direct PPCA pipeline:

- permits `--use-ppca --tilt-series`
- requires `--shared_contrast_across_tilts` when cryo-ET PPCA contrast correction is enabled
- segment-sums image-level sufficient statistics by tilt-series particle
- solves one latent and one contrast posterior per particle
- broadcasts posterior moments only for image-wise M-step backprojection
- keeps saved embeddings and contrasts particle-level
- preserves SPA behavior

Also fixes the contrast do-over pass so shared cryo-ET contrasts remain `contrast_shared`, records/checks the PPCA posterior count, and adds optional post-EM mean-FSC bandlimiting of exported PCs/loadings followed by re-embedding in the bandlimited basis.

This is a stacked draft PR. Its base branch, `codex/dev2-main-rebased`, is the full dev2 stack rebased with merge topology onto current `main` `4990ffd9e29b50f0219bc9f92911c522f058774e`. Immutable base: `e7cbe935d21307b8e7a47deaa9fd818600e702ad`; immutable head: `d44b18e4f84f72fbd143ba534d4d55bdedae3b2b`. The review diff is intentionally limited to four files.

## Mean-FSC behavior

New options:

- `--ppca-mean-fsc-bandlimit`
- `--ppca-mean-fsc-threshold` (default `1/7`)

The implementation follows the current/top heterogeneous-EM rule: compute FSC from unregularized corrected halfmaps, locate the threshold crossing with `locres.find_fsc_resol`, build the current dataset's canonical valid-frequency masks, hard-mask exported full PCs and saved half-loadings, then recompute embeddings/contrasts in that basis. It does not repeatedly mask the EM iterate.

## Scope exclusions

No RefitB, projected-covariance refinement, PPCA noise update, or unrelated PPCA feature is added.

## Focused validation

- CPU-safe pipeline/PPCA suite: **45 passed, 2 deselected**
- Local A100 custom-CUDA PPCA suite: **14 passed**
- RELION-binding backprojection check after native build: **13 passed**
- Full custom-CUDA scientific jobs used one allocated GPU and did not use `RECOVAR_DISABLE_CUDA`
- No Slurm script uses `--exclusive`; every inspected running job had matching `ReqTRES`/`AllocTRES` with exactly one GPU

## Serious matched cryo-ET validation

Dataset: grid 128, 50,000 tilt images, 7,143 particles, nominally 7 tilts/particle (one 6-tilt tail), noise 0.1, seed 42, contrast std 0.1, no outliers, `radial_per_tilt` noise. Covariance and PPCA used identical input, poses, CTF, particle halfsets, mask, contrast flags, seed, GPU budget, and GPU.

All means, eigenvectors, eigenvalues, embeddings, precisions, and contrasts are finite. Both pipelines save `(7143, 4)` latent coordinates and `(7143,)` shared contrasts. PPCA reports exactly 7,143 particle posteriors from 50,000 tilt images, and packed-batch audit confirms no particle split across batches.

| Metric | Covariance | PPCA | PPCA + mean-FSC |
|---|---:|---:|---:|
| contrast MAE | 0.01585 | 0.04771 | 0.04663 |
| contrast Pearson r | 0.98127 | 0.85493 | 0.86068 |
| within-state variance ratio | 0.22114 | 0.30304 | 0.29476 |
| captured GT covariance fraction | 0.81881 | 0.89219 | 0.86324 |
| mean principal cosine | 0.42735 | 0.65363 | 0.66062 |
| min principal cosine | 0.01294 | 0.13400 | 0.13194 |
| mean FSC 0.5 resolution | 4.283 Å | 4.283 Å | 4.283 Å |
| spatial-variance FSC 0.5 resolution | 4.283 Å | 4.283 Å | 4.283 Å |
| runtime | 1050.3 s | 621.9 s | 644.6 s |
| sampled peak GPU memory | 35.04 GiB | 11.05 GiB | 11.05 GiB |

Mean-FSC threshold `1/7` crossed at Fourier radius 62 pixels. Saved W is exactly zero outside the mask; U has only MRC/FFT round-trip leakage (maximum `8.79e-9`, relative norm `1.38e-7`).

Artifacts:

- `/scratch/gpfs/CRYOEM/gilleslab/em_work/codex_ppca_cryoet_fullscale_g128_n50000_t7_radial_per_tilt_20260812/metrics.json`
- `/scratch/gpfs/CRYOEM/gilleslab/em_work/codex_ppca_cryoet_fsc_bandlimit_g128_n50000_t7_rpt_20260812/metrics.json`
- `/scratch/gpfs/CRYOEM/gilleslab/em_work/codex_ppca_cryoet_fsc_bandlimit_g128_n50000_t7_rpt_20260812/bandlimit_audit.json`

## Cross-cutting long test

Command: `./scripts/run_tests_parallel.sh long-test`

Corrected-stack jobs: `12312402`–`12312411`; summary `12312412`.

Passing groups:

- smoke-tiny: 15/15
- downstream: 14/14
- metrics-SPA: 1/1
- metrics-cryo-ET: 1/1
- outliers-long: 4/4
- PDB trajectory: 1/1
- user indices: 2/2
- GPU stress: 2/2
- isolated-functions: 8 skipped because its optional dataset path was unset

Broad unit group: **4,081 passed, 61 skipped, 11 failed**. Across the workflow: **4,121 passed, 69 skipped, 11 failed**. None of the 11 failures is in PPCA or cryo-ET PPCA:

- 4 direct-script subprocess tests cannot import `recovar` because the shared pixi environment was not editable-installed to this worktree
- 4 inherited custom-CUDA staleness/build mock expectation failures
- 1 packaging metadata expectation (`plot` now included in the `all` extra)
- 1 RELION5 converter column-set expectation (current output intentionally adds `_rlnTiltName`; all numerical/string/order tests pass)
- 1 pandas scalar-broadcast starfile test

The SPA and cryo-ET quality regression tables contain no regressions. The extractor flags compute-state GPU memory at 0.2→0.3 GB (+10.6%) in both performance tables; pipeline wall time improves 16.3% for SPA and 56.8% for cryo-ET.

Regression tables:

`/scratch/gpfs/CRYOEM/gilleslab/em_work/codex_ppca_cryoet_fsc_bandlimit_20260812/regression_tables_corrected_stack.md`

The PR remains draft because the repository's aggregate long-test summary is not completely green, despite all PPCA and scientific validation passing.