### PR TITLE
Use global RELION tilt ranks for ntilts

### DIFF
--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -239,7 +239,10 @@ def add_args(parser: argparse.ArgumentParser):
         "--ntilts",
         default=None,
         type=int,
-        help="Number of tilts per tilt series. Default = all",
+        help=(
+            "Use only acquisition ranks 0 through N-1. For RELION 5 these are global pre-exposure ranks, "
+            "so particles missing an early tilt contribute fewer than N images. Default = all"
+        ),
     )
     tilt.add_argument(
         "--shared_contrast_across_tilts",

--- a/recovar/data_io/image_backends.py
+++ b/recovar/data_io/image_backends.py
@@ -249,7 +249,7 @@ class TiltSeriesDataset(ParticleImageDataset):
                 raise TypeError("num_tilts must be an integer or None")
             num_tilts = int(num_tilts)
             if num_tilts < 0:
-                logger.warning("num_tilts=%d < 0; using all available tilts per particle", num_tilts)
+                logger.warning("num_tilts=%d < 0; using all available tilts", num_tilts)
                 num_tilts = None
 
         super().__init__(starfile_path, lazy=lazy, ind=ind, **kwargs)
@@ -259,9 +259,12 @@ class TiltSeriesDataset(ParticleImageDataset):
         logger.info("STAR file parsed in %.2fs", time.time() - start_time)
 
         canonical_groups = self._get_canonical_groups(star.df)
+        tilt_numbers = self._compute_tilt_numbers(star.df, canonical_groups, tilt_file_option)
 
         if ind is not None:
-            star.df = star.df.loc[ind]
+            normalized_ind = normalize_indices(ind, n_total=len(star.df), name="ind")
+            star.df = star.df.loc[normalized_ind]
+            tilt_numbers = tilt_numbers[normalized_ind]
 
         self.particle_groups = self._build_particle_groups(star.df, canonical_groups)
         self._particle_tilts = list(self.particle_groups.values())
@@ -280,7 +283,11 @@ class TiltSeriesDataset(ParticleImageDataset):
         if tilt_file_option == "relion5":
             self.dose = np.asarray(star.df["_rlnMicrographPreExposure"], dtype=np.float32)
 
-        self._compute_tilt_ordering(tilt_file_option)
+        self.tilt_numbers = tilt_numbers
+        # Compatibility alias. RELION 5 values are global acquisition ranks;
+        # Warp retains its historical per-particle B-factor ranks because its
+        # B-factor is not a reliable dataset-wide acquisition identifier.
+        self.tilt_order = self.tilt_numbers
 
         self.num_tilts = num_tilts
         self.random_tilts = random_tilts
@@ -297,7 +304,6 @@ class TiltSeriesDataset(ParticleImageDataset):
         self.Np = self.num_particles
         self.particles = list(self.particle_groups.values())
         self.counts = group_counts
-        self.tilt_numbers = self.tilt_order
         self.ntilts = num_tilts
 
     @staticmethod
@@ -318,25 +324,40 @@ class TiltSeriesDataset(ParticleImageDataset):
                 ordered[gn] = np.array(groups[gn], dtype=int)
         return ordered
 
-    def _compute_tilt_ordering(self, method: str):
+    @staticmethod
+    def _compute_tilt_numbers(df, canonical_groups, method: str):
+        """Return the acquisition rank used by ``num_tilts`` selection.
+
+        RELION 5 pre-exposure is a global acquisition value: missing views
+        must not renumber later views of one particle. Warp only provides a
+        particle-dependent B-factor ordering, so preserve its local ranks.
+        """
         if method == "relion5":
-            logger.info("Ordering tilts by dose (_rlnMicrographPreExposure) - RELION 5")
+            logger.info("Numbering tilts globally by dose (_rlnMicrographPreExposure) - RELION 5")
+            values = np.asarray(df["_rlnMicrographPreExposure"], dtype=np.float64)
+            ordered_values = np.unique(values)
+            if ordered_values.size == 1 and "_rlnCtfBfactor" in df.columns:
+                b_factors = np.asarray(df["_rlnCtfBfactor"], dtype=np.float64)
+                if np.unique(b_factors).size > 1:
+                    logger.warning(
+                        "_rlnMicrographPreExposure is constant; numbering RELION 5 tilts globally by "
+                        "descending _rlnCtfBfactor instead"
+                    )
+                    values = b_factors
+                    ordered_values = np.unique(values)[::-1]
+            rank_by_value = {value: rank for rank, value in enumerate(ordered_values)}
+            return np.asarray([rank_by_value[value] for value in values], dtype=np.int32)
         elif method == "warp":
-            logger.info("Ordering tilts by B-factor - Warp")
+            logger.info("Ordering tilts per particle by B-factor - Warp")
+            ranks = np.zeros(len(df), dtype=np.int32)
+            groups = TiltSeriesDataset._build_particle_groups(df, canonical_groups)
+            b_factors = np.asarray(df["_rlnCtfBfactor"], dtype=np.float64)
+            for particle_tilts in groups.values():
+                order = np.argsort(-b_factors[particle_tilts], kind="stable")
+                ranks[particle_tilts[order]] = np.arange(particle_tilts.size, dtype=np.int32)
+            return ranks
         else:
             raise ValueError(f"Invalid tilt ordering method: {method}")
-
-        self.tilt_order = np.zeros(self.N, dtype=int)
-
-        for particle_tilts in self.particle_groups.values():
-            if method == "relion5":
-                sort_indices = np.argsort(-self.dose[particle_tilts])
-            else:
-                sort_indices = np.argsort(self.ctfBfactor[particle_tilts])
-
-            ranks = np.empty_like(sort_indices)
-            ranks[sort_indices[::-1]] = np.arange(len(particle_tilts))
-            self.tilt_order[particle_tilts] = ranks
 
     def __len__(self) -> int:
         return self.num_particles
@@ -344,17 +365,17 @@ class TiltSeriesDataset(ParticleImageDataset):
     def __getitem__(self, particle_index: int):
         particle_tilts = self._particle_tilts[particle_index]
 
-        if self.random_tilts and self.num_tilts is not None:
-            n_select = min(int(self.num_tilts), len(particle_tilts))
-            if n_select <= 0:
-                selected = particle_tilts[:0]
-            else:
-                selected = np.random.choice(particle_tilts, n_select, replace=False)
+        tilt_numbers = self.tilt_numbers[particle_tilts]
+        if self.num_tilts is not None:
+            eligible = particle_tilts[tilt_numbers < self.num_tilts]
         else:
-            tilt_orders = self.tilt_order[particle_tilts]
-            sorted_idx = np.argsort(tilt_orders)
-            n_select = self.num_tilts if self.num_tilts is not None else len(particle_tilts)
-            selected = particle_tilts[sorted_idx[:n_select]]
+            eligible = particle_tilts
+
+        if self.random_tilts and self.num_tilts is not None:
+            n_select = min(self.num_tilts, eligible.size)
+            selected = np.random.choice(eligible, n_select, replace=False)
+        else:
+            selected = eligible[np.argsort(self.tilt_numbers[eligible], kind="stable")]
 
         images = self.source.images(selected)
         return images, particle_index, selected
@@ -625,6 +646,7 @@ def _resolve_particle_tilts(dataset, effective_num_tilts):
             return (
                 [cursor._particle_tilts[i] for i in mapped_indices],
                 effective_num_tilts,
+                getattr(cursor, "tilt_numbers", None),
             )
 
         # Walk up subset chain (works for both _SimpleSubset and torch Subset)
@@ -637,13 +659,21 @@ def _resolve_particle_tilts(dataset, effective_num_tilts):
         mapped_indices = parent_idx[mapped_indices]
         cursor = parent
 
-    return None, effective_num_tilts
+    return None, effective_num_tilts, None
+
+
+def _selected_tilt_count(particle_tilts, effective_num_tilts, tilt_numbers):
+    if effective_num_tilts is None:
+        return len(particle_tilts)
+    if tilt_numbers is None:
+        return min(effective_num_tilts, len(particle_tilts))
+    return int(np.count_nonzero(tilt_numbers[np.asarray(particle_tilts, dtype=np.int32)] < effective_num_tilts))
 
 
 def _max_tilts_per_dataset_view(dataset) -> int:
     """Return the largest per-particle tilt count visible through a dataset/subset view."""
     effective_num_tilts = getattr(dataset, "num_tilts", None)
-    particle_tilts_list, effective_num_tilts = _resolve_particle_tilts(
+    particle_tilts_list, effective_num_tilts, tilt_numbers = _resolve_particle_tilts(
         dataset,
         effective_num_tilts,
     )
@@ -659,8 +689,7 @@ def _max_tilts_per_dataset_view(dataset) -> int:
 
     max_tilts = 0
     for particle_tilts in particle_tilts_list:
-        n_available = len(particle_tilts)
-        n_actual = min(effective_num_tilts, n_available) if effective_num_tilts is not None else n_available
+        n_actual = _selected_tilt_count(particle_tilts, effective_num_tilts, tilt_numbers)
         max_tilts = max(max_tilts, n_actual)
     return max_tilts
 
@@ -683,7 +712,9 @@ class _ImageCountBatchLoader:
         self.pad_to_batch = pad_to_batch
 
         effective_num_tilts = getattr(dataset, "num_tilts", None)
-        particle_tilts_list, effective_num_tilts = _resolve_particle_tilts(dataset, effective_num_tilts)
+        particle_tilts_list, effective_num_tilts, tilt_numbers = _resolve_particle_tilts(
+            dataset, effective_num_tilts
+        )
 
         if particle_tilts_list is None:
             particle_groups = getattr(dataset, "particle_groups", None)
@@ -697,8 +728,7 @@ class _ImageCountBatchLoader:
 
         self.tilts_counts = []
         for particle_tilts in particle_tilts_list:
-            n_available = len(particle_tilts)
-            n_actual = min(effective_num_tilts, n_available) if effective_num_tilts is not None else n_available
+            n_actual = _selected_tilt_count(particle_tilts, effective_num_tilts, tilt_numbers)
             self.tilts_counts.append(n_actual)
 
         self.tilts_counts = np.asarray(self.tilts_counts, dtype=np.int32)

--- a/tests/integration/test_run_test_all_metrics_regression_long.py
+++ b/tests/integration/test_run_test_all_metrics_regression_long.py
@@ -118,7 +118,7 @@ def _assert_cryo_et_subsampling_consistency(particles_star: Path):
     assert set(half0.tolist()).issubset(allowed_image_values)
     assert half1.size == 0
 
-    # ntilts subsampling: at most one tilt kept per selected particle when ntilts=1.
+    # ntilts subsampling: only global acquisition rank zero is eligible.
     split_ntilts = halfsets.get_split_tilt_indices(
         particles_file=str(particles_star),
         tilt_ind_file=np.array([keep_a, keep_b], dtype=np.int32),
@@ -129,9 +129,8 @@ def _assert_cryo_et_subsampling_consistency(particles_star: Path):
         ],
     )
     kept = np.asarray(split_ntilts[0], dtype=np.int32)
-    for pidx in np.unique(np.array([keep_a, keep_b], dtype=np.int32)):
-        particle_tilts = np.asarray(particles_to_tilts[int(pidx)], dtype=np.int32)
-        assert np.intersect1d(kept, particle_tilts).size <= 1
+    tilt_ds = cryo_dataset.TiltSeriesDataset(str(particles_star), lazy=True, tilt_file_option="relion5")
+    assert np.all(tilt_ds.tilt_numbers[kept] < 1)
 
 
 def test_run_test_all_metrics_regression_against_baseline(tmp_path):

--- a/tests/unit/test_cryo_et_subset_io.py
+++ b/tests/unit/test_cryo_et_subset_io.py
@@ -342,28 +342,22 @@ def test_get_split_tilt_indices_combined_out_of_range_particle_ids_ignored(tilt_
 
 
 # ---------------------------------------------------------------------------
-# 8. get_split_tilt_indices – ntilts per-particle cap
+# 8. get_split_tilt_indices – global acquisition cutoff
 # ---------------------------------------------------------------------------
 
 
-def test_get_split_tilt_indices_ntilts_caps_per_particle(tilt_files):
-    """ntilts=1 keeps at most one tilt per particle in each halfset."""
+def test_get_split_tilt_indices_ntilts_uses_global_acquisition_cutoff(tilt_files):
+    """ntilts=1 keeps only images with global acquisition rank zero."""
     star = tilt_files["particles_star"]
-    p2t, _ = _parse_p2t(tilt_files)
 
     half0, half1 = halfsets.get_split_tilt_indices(
         particles_file=star,
         ntilts=1,
     )
-    half0 = np.asarray(half0, dtype=np.int32)
-    half1 = np.asarray(half1, dtype=np.int32)
-
-    for pidx, tilts in enumerate(p2t):
-        particle_tilts = set(np.asarray(tilts, dtype=np.int32).tolist())
-        in_half0 = particle_tilts & set(half0.tolist())
-        in_half1 = particle_tilts & set(half1.tolist())
-        assert len(in_half0) <= 1, f"particle {pidx} has {len(in_half0)} tilts in half0"
-        assert len(in_half1) <= 1, f"particle {pidx} has {len(in_half1)} tilts in half1"
+    tilt_ds = cryo_dataset.TiltSeriesDataset(star, lazy=True, tilt_file_option="relion5")
+    for half in (half0, half1):
+        half = np.asarray(half, dtype=np.int32)
+        assert np.all(tilt_ds.tilt_numbers[half] < 1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dataset_tiny_io.py
+++ b/tests/unit/test_dataset_tiny_io.py
@@ -672,18 +672,15 @@ def test_get_split_tilt_indices_simulator_generated_with_ntilts_cap(sim_tiny_til
     )
     assert len(split) == 2
 
-    # Build reverse map and ensure each particle contributes at most one tilt in each half.
-    tilt_to_particle = {}
-    for p_idx, tilt_inds in enumerate(particles_to_tilts):
-        for t in tilt_inds:
-            tilt_to_particle[int(t)] = p_idx
-
+    tilt_ds = tilt_dataset.TiltSeriesDataset(
+        files["particles_star"],
+        datadir=str(Path(files["particles_star"]).parent),
+        lazy=True,
+        tilt_file_option="relion5",
+    )
     for half_imgs in split:
-        counts = {}
-        for t in np.asarray(half_imgs).astype(int):
-            p = tilt_to_particle[t]
-            counts[p] = counts.get(p, 0) + 1
-        assert all(v <= 1 for v in counts.values())
+        half_imgs = np.asarray(half_imgs, dtype=np.int32)
+        assert np.all(tilt_ds.tilt_numbers[half_imgs] < 1)
 
 
 def test_get_split_tilt_indices_simulator_with_zero_tilts_returns_empty_halves(sim_tiny_tilt_files):
@@ -1216,9 +1213,10 @@ def test_tiny_tilt_split_indices_accepts_in_memory_halfsets_and_arrays(tmp_path)
         datadir=str(tmp_path),
         ntilts=1,
     )
-    # ntilts=1 keeps one image per particle according to deterministic tilt ordering.
+    # Only row 0 has global acquisition rank zero. Particle g3 has no eligible
+    # image; row 2 must not be backfilled as that particle's local rank zero.
     np.testing.assert_array_equal(split[0], np.array([0], dtype=np.int32))
-    np.testing.assert_array_equal(split[1], np.array([2], dtype=np.int32))
+    np.testing.assert_array_equal(split[1], np.array([], dtype=np.int32))
 
 
 def test_simulator_tiny_tilt_split_indices_accepts_boolean_masks(sim_tiny_tilt_files):

--- a/tests/unit/test_image_backends.py
+++ b/tests/unit/test_image_backends.py
@@ -555,8 +555,43 @@ def test_tiltseries_dataset_getitem_deterministic_selection(monkeypatch):
     assert pidx == 0
     assert imgs.shape == (2, 8, 8)
     assert selected.shape == (2,)
-    # Deterministic order induced by _compute_tilt_ordering implementation.
+    # The first two global dose ranks are 1.0 and 2.0.
     np.testing.assert_array_equal(selected, np.array([0, 2]))
+
+
+def test_tiltseries_dataset_num_tilts_does_not_backfill_missing_global_tilts(monkeypatch):
+    class _Source:
+        def __init__(self):
+            self.n = 6
+            self.D = 8
+            self._store = np.arange(self.n * self.D * self.D, dtype=np.float32).reshape(self.n, self.D, self.D)
+
+        def images(self, index, require_contiguous=False):
+            _ = require_contiguous
+            if isinstance(index, (int, np.integer)):
+                return self._store[int(index)]
+            return self._store[np.asarray(index)]
+
+    df = pd.DataFrame(
+        {
+            "_rlnGroupName": ["complete", "complete", "complete", "missing", "missing", "missing"],
+            "_rlnMicrographPreExposure": [1.0, 2.0, 3.0, 2.0, 3.0, 4.0],
+            "_rlnCtfScalefactor": np.ones(6),
+            "_rlnCtfBfactor": -np.arange(1, 7, dtype=np.float32),
+        }
+    )
+    monkeypatch.setattr(image_backends.ImageLoader, "from_file", lambda *args, **kwargs: _Source())
+    monkeypatch.setattr(image_backends.starfile.StarFile, "load", lambda _p: SimpleNamespace(df=df))
+
+    ds = image_backends.TiltSeriesDataset(
+        "dummy.star", num_tilts=2, random_tilts=False, tilt_file_option="relion5"
+    )
+
+    np.testing.assert_array_equal(ds.tilt_numbers, np.array([0, 1, 2, 1, 2, 3], dtype=np.int32))
+    np.testing.assert_array_equal(ds[0][2], np.array([0, 1], dtype=np.int32))
+    # Global rank 0 is absent, so this particle contributes only rank 1. Ranks
+    # 2 and 3 must not be pulled in as replacements.
+    np.testing.assert_array_equal(ds[1][2], np.array([3], dtype=np.int32))
 
 
 def test_tiltseries_dataset_random_selection_clamps_when_num_tilts_exceeds_available(monkeypatch):
@@ -1264,11 +1299,12 @@ def test_tiltseries_dataset_ind_subset_preserves_image_tilt_alignment(monkeypatc
     assert int(tidx0) == 0
     np.testing.assert_array_equal(img0[0], ds.source._store[0])
 
-    # For g3 in subset (locals 0 and 2), relion5 ordering picks lower dose first -> local 2.
+    # For g3, the subset contains only global acquisition ranks 4 and 5.
+    # num_tilts=1 must not renumber either one to rank 0.
     imgs, particle_idx, selected = ds[2]  # canonical order: g1, g2, g3
     assert int(particle_idx) == 2
-    np.testing.assert_array_equal(selected, np.array([2], dtype=np.int32))
-    np.testing.assert_array_equal(imgs[0], ds.source._store[2])
+    assert selected.size == 0
+    assert imgs.shape == (0, 8, 8)
 
 
 def test_parse_particle_tilt_real_tiny_star_preserves_original_indices_with_subset(tmp_path):

--- a/tests/unit/test_tilt_index_consistency.py
+++ b/tests/unit/test_tilt_index_consistency.py
@@ -274,9 +274,10 @@ def test_random_tilt_selection_respects_num_tilts_and_membership(tmp_path):
     )
     for pidx in range(len(ds)):
         _, _, selected = ds[pidx]
-        assert selected.size == 1
+        assert selected.size <= 1
         all_group_tilts = list(ds.particle_groups.values())[pidx]
-        assert int(selected[0]) in set(all_group_tilts.tolist())
+        assert set(selected.tolist()).issubset(set(all_group_tilts.tolist()))
+        assert np.all(ds.tilt_numbers[selected] < 1)
 
 
 def test_get_split_tilt_indices_random_split_has_disjoint_complete_coverage(tmp_path):
@@ -295,23 +296,17 @@ def test_get_split_tilt_indices_random_split_has_disjoint_complete_coverage(tmp_
     np.testing.assert_array_equal(np.sort(np.concatenate(split)), np.arange(8, dtype=np.int32))
 
 
-def test_get_split_tilt_indices_with_ntilts_filters_per_particle(tmp_path):
+def test_get_split_tilt_indices_with_ntilts_uses_global_acquisition_rank(tmp_path):
     star_path = _make_tilt_fixture(tmp_path)
-    # Canonical particles:
-    # gA -> [1,4], gB -> [0,3,6], gC -> [2,5,7]
-    # RELION5 ordering in fixture (higher dose first):
-    # gA keeps tilt-order ranks [4,1] => with ntilts=1 keep one per particle in get_split_tilt_indices by tilt_numbers < 1.
     split = halfsets.get_split_tilt_indices(
         particles_file=str(star_path),
         ntilts=1,
         datadir=str(tmp_path),
     )
-    # exactly one tilt per particle in whichever halfset each particle is assigned.
+    # The only global rank-0 exposure is row 1 (dose 1.0). Particles missing
+    # that acquisition contribute no replacement image from a later exposure.
     kept = np.sort(np.concatenate(split))
-    assert kept.size == 3
-    p2t, _ = cryo_dataset.TiltSeriesDataset.parse_particle_tilt(str(star_path))
-    for particle_tilts in p2t:
-        assert np.intersect1d(kept, particle_tilts).size == 1
+    np.testing.assert_array_equal(kept, np.array([1], dtype=np.int32))
 
 
 def test_particle_subset_max_tilts_matches_parent_counts(tmp_path):
@@ -324,5 +319,6 @@ def test_particle_subset_max_tilts_matches_parent_counts(tmp_path):
         tilt_file_option="relion5",
     )
     subset = cryo_dataset._SimpleSubset(ds, np.array([1, 2], dtype=np.int32))
-    # both chosen particles have >=2 tilts; max should be 2 due to num_tilts cap.
-    assert cryo_dataset._max_tilts_per_dataset_view(subset) == 2
+    # Of these particles, only gB has one image among global ranks 0 and 1;
+    # later available images are not used as replacements.
+    assert cryo_dataset._max_tilts_per_dataset_view(subset) == 1


### PR DESCRIPTION
## Summary

- define RELION 5 tilt numbers as global acquisition ranks from `_rlnMicrographPreExposure`
- make `--ntilts N` admit only ranks `0..N-1`, without replacing missing early views with later, higher-dose tilts
- preserve Warp's existing per-particle B-factor ordering and make batch-size accounting honor the actual selected image counts
- clarify the command-line help and cover missing-view, subset, loader, and integration behavior

## Validation

Tested from commit `6ed64d53be83a8f13e58811a8c34f57ff5a6798f`, rebased on `origin/dev` at `2ab65a72e5641e051222a7c0abcc1d0fd5726c4d`.

Parallel Slurm summary: job `35483068`, **2622 passed, 0 failed**.

| Group | Slurm job | Result |
|---|---:|---|
| unit | 35479874 | 2574 passed |
| smoke/tiny integration | 35479836 | 15 passed |
| downstream commands | 35479837 | 14 passed |
| SPA metrics regression | 35479838 | 1 passed |
| cryo-ET metrics regression | 35480703 | 1 passed |
| outlier regression | 35481152 | 4 passed |
| PDB trajectory | 35479841 | 1 passed |
| pipeline indices | 35479842 | 2 passed |
| 256-grid GPU stress | 35479843 | 2 passed |
| isolated functions | 35479844 | 8 expected skips; group completed cleanly |

The first ET metrics allocation exceeded an A100 48 GB device; the unchanged retry passed on an H100 80 GB. The outlier quality test had one stochastic threshold miss on its first run; an unchanged same-A100 retry passed all four cases. No baselines or tolerances were changed.

## Regression Tables

### SPA Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.026187 | 0.026221 | +0.13% (worse) | OK |
| contrast_abs_error_10_noreg | 0.026248 | 0.025921 | -1.25% (better) | OK |
| contrast_abs_error_4 | 0.025998 | 0.026105 | +0.41% (worse) | OK |
| contrast_abs_error_4_noreg | 0.026102 | 0.026105 | +0.01% (worse) | OK |
| embedding_squared_error_10 | 1.978306 | 1.937780 | -2.05% (better) | OK |
| embedding_squared_error_4 | 0.379676 | 0.380902 | +0.32% (worse) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979892 | 0.980249 | +0.04% (better) | OK |
| noise_max_relative_error | 2.112245 | 2.114650 | +0.11% (worse) | OK |
| noise_mean_relative_error | 0.051014 | 0.049130 | -3.69% (better) | OK |
| noise_median_relative_error | 0.005962 | 0.005747 | -3.60% (better) | OK |
| svd_relative_variance_10 | 0.460460 | 0.478964 | +4.02% (better) | OK |
| svd_relative_variance_4 | 0.451753 | 0.475755 | +5.31% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### Cryo-ET Quality
| Metric | Baseline | Current | Change | Status |
|--------|----------|---------|--------|--------|
| contrast_abs_error_10 | 0.024244 | 0.024059 | -0.76% (better) | OK |
| contrast_abs_error_10_noreg | 0.024257 | 0.024057 | -0.82% (better) | OK |
| contrast_abs_error_4 | 0.024025 | 0.023823 | -0.84% (better) | OK |
| contrast_abs_error_4_noreg | 0.024021 | 0.023803 | -0.91% (better) | OK |
| embedding_squared_error_10 | 1.460294 | 1.410705 | -3.40% (better) | OK |
| embedding_squared_error_4 | 0.214089 | 0.201441 | -5.91% (better) | OK |
| mean_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| noise_correlation | 0.979183 | 0.979744 | +0.06% (better) | OK |
| noise_max_relative_error | 2.152798 | 2.140589 | -0.57% (better) | OK |
| noise_mean_relative_error | 0.051816 | 0.049609 | -4.26% (better) | OK |
| noise_median_relative_error | 0.005697 | 0.005676 | -0.37% (better) | OK |
| svd_relative_variance_10 | 0.634522 | 0.640304 | +0.91% (better) | OK |
| svd_relative_variance_4 | 0.632597 | 0.638321 | +0.90% (better) | OK |
| variance_fourier_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |
| variance_spatial_fsc | 0.233456 | 0.233456 | 0.0% (same) | OK |

### SPA Performance

The SPA run used an RTX PRO 6000 Blackwell node, while the extractor selected the available H100 baseline; cross-hardware deltas are included as required but are not attributable comparisons.

| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 136.2s | 98.3s | -27.8% (better) | OK |
| dataset_generation | GPU_memory | 4.9GB | 5.8GB | +17.1% (worse) | **REGRESSED** |
| dataset_generation | CPU_memory | 5.3GB | 5.0GB | -5.0% (better) | OK |
| pipeline | wall_time | 578.5s | 529.1s | -8.5% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.3GB | -0.0% (better) | OK |
| pipeline | CPU_memory | 42.7GB | 39.6GB | -7.3% (better) | OK |
| compute_state | wall_time | 317.3s | 149.9s | -52.8% (better) | OK |
| compute_state | GPU_memory | 0.2GB | 0.1GB | -78.7% (better) | OK |
| compute_state | CPU_memory | 46.7GB | 40.2GB | -13.9% (better) | OK |
| metrics | wall_time | 20.8s | 24.1s | +15.8% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 0.1GB | +65.8% (worse) | OK |
| metrics | CPU_memory | 50.7GB | 45.2GB | -10.8% (better) | OK |

### Cryo-ET Performance
| Stage | Metric | Baseline | Current | Change | Status |
|-------|--------|----------|---------|--------|--------|
| dataset_generation | wall_time | 128.5s | 133.1s | +3.6% (worse) | OK |
| dataset_generation | GPU_memory | 4.5GB | 4.5GB | 0.0% (same) | OK |
| dataset_generation | CPU_memory | 5.1GB | 4.6GB | -9.3% (better) | OK |
| pipeline | wall_time | 1886.7s | 1590.5s | -15.7% (better) | OK |
| pipeline | GPU_memory | 40.4GB | 40.4GB | 0.0% (same) | OK |
| pipeline | CPU_memory | 38.1GB | 40.2GB | +5.4% (worse) | OK |
| compute_state | wall_time | 145.9s | 531.4s | +264.1% (worse) | **REGRESSED** |
| compute_state | GPU_memory | 0.2GB | 2.0GB | +768.1% (worse) | **REGRESSED** |
| compute_state | CPU_memory | 38.2GB | 40.2GB | +5.3% (worse) | OK |
| metrics | wall_time | 19.9s | 41.8s | +109.9% (worse) | **REGRESSED** |
| metrics | GPU_memory | 0.1GB | 2.1GB | +2694.7% (worse) | OK |
| metrics | CPU_memory | 41.6GB | 41.4GB | -0.6% (better) | OK |

The changed path only controls tilt metadata selection and batch accounting; it does not execute in `compute_state` or metrics evaluation. Cryo-ET pipeline quality passed all regression thresholds and pipeline wall time improved by 15.7% on the matched H100 record.
