### PR TITLE
Remove dead YouTube talk links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 RECOVAR analyzes conformational heterogeneity in cryo-EM and cryo-ET datasets. It reconstructs volumes, estimates conformational density in latent space, and identifies the image subsets associated with specific volume features.
 
-**[Full Documentation](https://ma-gilles.github.io/recovar)** | **[Paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122)** | **[Talk](https://www.youtube.com/watch?v=cQBQlCCRp8Q&t=740s)**
+**[Full Documentation](https://ma-gilles.github.io/recovar)** | **[Paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122)**
 
 > **Looking for the older release?** Active development happens on the `dev` branch. If you want the previous stable release (`0.4.5`, possibly more stable but missing recent features like `.cs`/`.star` auto-extraction), install with `pip install recovar==0.4.5` or check out the [`legacy-0.4.5`](https://github.com/ma-gilles/recovar/tree/legacy-0.4.5) branch.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ recovar gui
 
 RECOVAR estimates a regularized 3D covariance from your particle images, extracts principal components to build a low-dimensional latent space, and uses kernel regression to generate volumes at any point in that space.
 
-For the full method, see the [paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122) or [recorded talk](https://www.youtube.com/watch?v=cQBQlCCRp8Q&t=740s).
+For the full method, see the [paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122).
 
 ---
 


### PR DESCRIPTION
The recorded-talk link (https://www.youtube.com/watch?v=cQBQlCCRp8Q&t=740s) now returns "This video isn't available anymore" on YouTube (reported by Amit). This removes all links to the video — one in `README.md` and one in `docs/index.md`. No other YouTube links exist in the repo (`git grep -i youtube` is clean after this change).

Docs-only change; no code paths touched, so no test suite was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)