### PR TITLE
Remove dead YouTube talk links (dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 RECOVAR analyzes conformational heterogeneity in cryo-EM and cryo-ET datasets. It reconstructs volumes, estimates conformational density in latent space, and identifies the image subsets associated with specific volume features.
 
-**[Full Documentation](https://ma-gilles.github.io/recovar)** | **[Paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122)** | **[Talk](https://www.youtube.com/watch?v=cQBQlCCRp8Q&t=740s)**
+**[Full Documentation](https://ma-gilles.github.io/recovar)** | **[Paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122)**
 
 > **Looking for the older release?** Active development happens on the `dev` branch. If you want the previous stable release (`0.4.5`, possibly more stable but missing recent features like `.cs`/`.star` auto-extraction), install with `pip install recovar==0.4.5` or check out the [`legacy-0.4.5`](https://github.com/ma-gilles/recovar/tree/legacy-0.4.5) branch.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ recovar gui
 
 RECOVAR estimates a regularized 3D covariance from your particle images, extracts principal components to build a low-dimensional latent space, and uses kernel regression to generate volumes at any point in that space.
 
-For the full method, see the [paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122) or [recorded talk](https://www.youtube.com/watch?v=cQBQlCCRp8Q&t=740s).
+For the full method, see the [paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122).
 
 ---
 


### PR DESCRIPTION
Same change as #170 but against `dev`: the recorded-talk link (https://www.youtube.com/watch?v=cQBQlCCRp8Q&t=740s) is dead on YouTube.

This dev PR is required to actually fix the live docs site: `.github/workflows/docs.yml` only deploys on pushes to `dev` (with a `docs/**` path filter), so merging #170 into `main` alone never updates https://ma-gilles.github.io/recovar. Merging this PR (it touches `docs/index.md`) triggers the redeploy. It also prevents the dead link from returning to `main` on the next dev→main merge.

Docs-only change (`README.md` + `docs/index.md`, 2 lines); no code paths touched, so no test suite was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)