### PR TITLE
Fix broken LICENSE link on PyPI-rendered README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RECOVAR analyzes conformational heterogeneity in cryo-EM and cryo-ET datasets. I
 
 > **Looking for the older release?** Active development happens on the `dev` branch. If you want the previous stable release (`0.4.5`, possibly more stable but missing recent features like `.cs`/`.star` auto-extraction), install with `pip install recovar==0.4.5` or check out the [`legacy-0.4.5`](https://github.com/ma-gilles/recovar/tree/legacy-0.4.5) branch.
 
-**License**: the code has been modified and is now under the PU-RL v2.0 license, and the code imports libraries that are under non-PU-RL v2.0 (including GPL) licenses. See [LICENSE](LICENSE).
+**License**: the code has been modified and is now under the PU-RL v2.0 license, and the code imports libraries that are under non-PU-RL v2.0 (including GPL) licenses. See [LICENSE](https://github.com/ma-gilles/recovar/blob/dev/LICENSE).
 
 ## Key features
 


### PR DESCRIPTION
Amit reported the LICENSE link in the README is broken. The link works on GitHub (relative links resolve there), but the same README is used as the PyPI long description, where `[LICENSE](LICENSE)` points to a nonexistent `pypi.org` URL — this is where the link is actually dead (https://pypi.org/project/recovar/, v1.0.5).

Fix: use the absolute URL `https://github.com/ma-gilles/recovar/blob/dev/LICENSE`, which resolves everywhere the README is rendered. It deliberately points at `dev`'s LICENSE (PU-RL v2.0) — `main`'s LICENSE is still MIT, so cross-linking branches would show the wrong license.

Docs-only one-line change; long-test suite not run (companion PR for `main` fixes the same pattern there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)