### PR TITLE
Fix LICENSE link so it works outside GitHub rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ RECOVAR analyzes conformational heterogeneity in cryo-EM and cryo-ET datasets. I
 **[Full Documentation](https://ma-gilles.github.io/recovar)** | **[Paper](https://www.pnas.org/doi/abs/10.1073/pnas.2419140122)**
 
 
-**License**: RECOVAR is licensed under the MIT License. See [LICENSE](LICENSE).
+**License**: RECOVAR is licensed under the MIT License. See [LICENSE](https://github.com/ma-gilles/recovar/blob/main/LICENSE).
 
 ## Key features
 


### PR DESCRIPTION
Companion to the dev-branch PR fixing Amit's broken-LICENSE-link report. The relative `[LICENSE](LICENSE)` link only resolves when GitHub renders the README; anywhere else (e.g. PyPI long description) it 404s. Use the absolute URL `https://github.com/ma-gilles/recovar/blob/main/LICENSE` (main's LICENSE — MIT — not dev's, which is PU-RL v2.0).

Docs-only one-line change; long-test suite not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)