### PR TITLE
Automatically use the new noise estimator for radial-per-tilt models

### DIFF
--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -25,6 +25,7 @@ _NOISE_UB_GB_PER_IMAGE_AT_GRID_256 = 0.117
 _NOISE_UB_WORKING_FRACTION = 0.15
 _NOISE_UB_MIN_WORKING_GB = 1.0
 _NOISE_UB_MAX_WORKING_GB = 12.0
+_RADIAL_PER_TILT_NOISE_MODELS = ("radial_per_tilt", "radial-per-tilt")
 
 
 def add_args(parser: argparse.ArgumentParser):
@@ -291,7 +292,7 @@ def add_args(parser: argparse.ArgumentParser):
         "--noise-model",
         dest="noise_model",
         default="radial",
-        help="Noise model: radial (default) or white",
+        help="Noise model: radial (default) or radial_per_tilt",
     )
     adv.add_argument(
         "--mean-fn",
@@ -323,7 +324,7 @@ def add_args(parser: argparse.ArgumentParser):
         "--new-noise-est",
         dest="new_noise_est",
         action="store_true",
-        help="Use new noise estimation",
+        help="Use new noise estimation (automatic for premultiplied CTF and radial_per_tilt)",
     )
     adv.add_argument(
         "--use_reg_mean_in_contrast",
@@ -517,7 +518,10 @@ def _estimate_noise(dataset, means, dilated_volume_mask, batch_size, args, noise
 
     Returns a dict with all noise-related quantities needed by the pipeline.
     """
-    use_new_noise_fn = args.new_noise_est or args.premultiplied_ctf
+    radial_per_tilt = noise_model in _RADIAL_PER_TILT_NOISE_MODELS
+    use_new_noise_fn = args.new_noise_est or args.premultiplied_ctf or radial_per_tilt
+    if radial_per_tilt and not (args.new_noise_est or args.premultiplied_ctf):
+        logger.info("Enabling new noise estimation automatically for radial_per_tilt")
     logger.info("Using new noise estimation function?: %s", use_new_noise_fn)
 
     noise_time = time.time()
@@ -550,7 +554,7 @@ def _estimate_noise(dataset, means, dilated_volume_mask, batch_size, args, noise
     radial_noise_var_outside_mask = masked_image_PS
     white_noise_var_outside_mask_val = np.median(masked_image_PS)
 
-    if use_new_noise_fn and noise_model not in ("radial", "radial_per_tilt"):
+    if use_new_noise_fn and noise_model != "radial" and not radial_per_tilt:
         raise ValueError(f"new noise fn only works with radial noise model, got {noise_model}")
 
     logger.info("time to estimate noise is %s", time.time() - noise_time)
@@ -923,7 +927,7 @@ def standard_recovar_pipeline(args):
     if noise_model == "radial":
         ds.set_radial_noise_model(None)
         logger.info("Setting noise model to radial")
-    elif noise_model in ("radial_per_tilt", "radial-per-tilt"):
+    elif noise_model in _RADIAL_PER_TILT_NOISE_MODELS:
         ds.set_variable_radial_noise_model(None)
         logger.info("Setting noise model to radial_per_tilt")
     else:

--- a/tests/unit/test_commands_pipeline.py
+++ b/tests/unit/test_commands_pipeline.py
@@ -8,6 +8,7 @@ import argparse
 import sys
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 pytest.importorskip("jax")  # pipeline.py imports jax at module level
@@ -74,6 +75,37 @@ def test_noise_upper_bound_batch_size_scales_with_grid_and_budget():
 
     assert 1 <= grid_512_large_budget < grid_256_large_budget < requested
     assert 1 <= grid_256_small_budget < grid_256_large_budget
+
+
+@pytest.mark.parametrize("noise_model", ["radial_per_tilt", "radial-per-tilt"])
+def test_radial_per_tilt_automatically_uses_new_noise_estimator(monkeypatch, noise_model):
+    calls = []
+
+    def fake_fit(*args, invert_mask, **kwargs):
+        calls.append(invert_mask)
+        if invert_mask:
+            return np.full((3, 4), 2.0), np.full((3, 4), 10.0)
+        return np.full((3, 4), 3.0), np.full((3, 4), 1.0)
+
+    monkeypatch.setattr(pipeline_cmd.noise, "fit_noise_model_to_images", fake_fit)
+    monkeypatch.setattr(
+        pipeline_cmd.noise,
+        "estimate_radial_noise_statistic_from_outside_mask",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("legacy estimator used")),
+    )
+    monkeypatch.setattr(pipeline_cmd.utils, "report_memory_device", lambda logger=None: None)
+
+    result = pipeline_cmd._estimate_noise(
+        SimpleNamespace(),
+        SimpleNamespace(combined=object()),
+        object(),
+        8,
+        SimpleNamespace(new_noise_est=False, premultiplied_ctf=False, mask="from_halfmaps"),
+        noise_model,
+    )
+
+    assert calls == [True, False]
+    assert result["noise_var_used"].shape == (3, 4)
 
 
 def test_pipeline_registers_poses():


### PR DESCRIPTION
## Summary

- automatically route `radial_per_tilt` and `radial-per-tilt` noise models through the estimator that fits an independent radial spectrum for each tilt position
- preserve the legacy estimator for ordinary `radial` noise unless explicitly requested
- update the CLI help and handle both accepted per-tilt spellings consistently
- add a regression test that verifies the new estimator is selected without `--new-noise-est`

## Motivation

For non-premultiplied cryo-ET data, selecting `radial_per_tilt` previously left the new estimator disabled unless users also supplied `--new-noise-est`. The legacy path estimates one global radial profile and broadcasts it across tilt positions, so the requested model was not independently fitted per tilt.

## Testing

- `tests/unit/test_commands_pipeline.py`
- `tests/unit/test_noise.py`
- 40 passed, 5 GPU-only tests skipped
- Ruff and `git diff --check` pass