### PR TITLE
Add strict central-tilt selection for tilt-series pipelines

### DIFF
--- a/recovar/commands/pipeline.py
+++ b/recovar/commands/pipeline.py
@@ -32,6 +32,12 @@ def add_args(parser: argparse.ArgumentParser):
     def list_of_ints(arg):
         return list(map(int, arg.split(",")))
 
+    def positive_int(arg):
+        value = int(arg)
+        if value <= 0:
+            raise argparse.ArgumentTypeError("value must be a positive integer")
+        return value
+
     # ── Required / positional ──────────────────────────────────────────────
     parser.add_argument(
         "particles",
@@ -235,11 +241,22 @@ def add_args(parser: argparse.ArgumentParser):
         dest="angle_per_tilt",
         help="Angle per tilt (default: estimated from starfile)",
     )
-    tilt.add_argument(
+    tilt_count = tilt.add_mutually_exclusive_group()
+    tilt_count.add_argument(
         "--ntilts",
         default=None,
         type=int,
         help="Number of tilts per tilt series. Default = all",
+    )
+    tilt_count.add_argument(
+        "--central-tilts",
+        default=None,
+        type=positive_int,
+        help=(
+            "Keep only particles containing the same N nominally central physical tilt positions. "
+            "Positions are chosen per tilt series by smallest absolute nominal stage angle when available, "
+            "otherwise by lowest dose; later available views are never substituted."
+        ),
     )
     tilt.add_argument(
         "--shared_contrast_across_tilts",
@@ -694,6 +711,20 @@ def _compute_embeddings(means, u, s, dataset, volume_mask, options, gpu_memory, 
 # ---------------------------------------------------------------------------
 
 
+def _validate_tilt_selection_args(args):
+    central_tilts = getattr(args, "central_tilts", None)
+    if central_tilts is None:
+        return
+    if not isinstance(central_tilts, (int, np.integer)) or isinstance(central_tilts, (bool, np.bool_)):
+        raise TypeError("central_tilts must be a positive integer")
+    if int(central_tilts) <= 0:
+        raise ValueError("central_tilts must be a positive integer")
+    if not getattr(args, "tilt_series", False):
+        raise ValueError("--central-tilts requires --tilt-series")
+    if getattr(args, "ntilts", None) is not None:
+        raise ValueError("--central-tilts and --ntilts are mutually exclusive")
+
+
 def standard_recovar_pipeline(args):
     st_time = time.time()
 
@@ -713,6 +744,7 @@ def standard_recovar_pipeline(args):
         args.particles = converted_star
         logger.info("Conversion complete. Proceeding with pipeline.")
 
+    _validate_tilt_selection_args(args)
     # --- Validate poses/ctf availability ---
     if args.poses is None or args.ctf is None:
         ext = args.particles.rsplit(".", 1)[-1].lower()

--- a/recovar/data_io/halfsets.py
+++ b/recovar/data_io/halfsets.py
@@ -8,8 +8,8 @@ particle-level splitting.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -174,6 +174,262 @@ def get_split_indices(
 # ---------------------------------------------------------------------------
 
 
+def _select_complete_central_tilts(
+    index_map,
+    particles_file,
+    n_central,
+    candidate_particles,
+    allowed_images,
+):
+    """Select identical nominal positions per tilt series and drop incomplete particles."""
+    if not isinstance(n_central, (int, np.integer)) or isinstance(n_central, (bool, np.bool_)):
+        raise TypeError("central_tilts must be a positive integer")
+    n_central = int(n_central)
+    if n_central <= 0:
+        raise ValueError("central_tilts must be a positive integer")
+
+    from recovar.data_io import starfile
+
+    particles = starfile.StarFile.load(particles_file).df
+    if "_rlnTiltName" in particles.columns:
+        tilt_identity_column = "_rlnTiltName"
+    elif "_rlnMicrographName" in particles.columns:
+        tilt_identity_column = "_rlnMicrographName"
+    else:
+        raise ValueError("--central-tilts requires _rlnTiltName or _rlnMicrographName in the particles STAR file")
+
+    tilt_names = np.asarray(particles[tilt_identity_column], dtype=str)
+    if tilt_names.shape != (index_map.n_images,):
+        raise ValueError(
+            "Particles STAR row count does not match the tilt-series image index map: "
+            f"{tilt_names.size} rows versus {index_map.n_images} images"
+        )
+
+    # Build tilt-series components. A RELION N@stack name whose stack is
+    # shared by all images of a particle supplies an explicit tomogram key.
+    # Per-tilt files legitimately have different stack suffixes, so those
+    # fall back to joining particles through shared physical-tilt names.
+    parents = np.arange(index_map.n_particles, dtype=np.int32)
+
+    def find(particle_idx):
+        particle_idx = int(particle_idx)
+        while parents[particle_idx] != particle_idx:
+            parents[particle_idx] = parents[parents[particle_idx]]
+            particle_idx = int(parents[particle_idx])
+        return particle_idx
+
+    def union(first, second):
+        first_root = find(first)
+        second_root = find(second)
+        if first_root != second_root:
+            parents[second_root] = first_root
+
+    tomo_names = None
+    if "_rlnTomoName" in particles.columns:
+        tomo_names = np.asarray(particles["_rlnTomoName"], dtype=str)
+        if tomo_names.shape != (index_map.n_images,):
+            raise ValueError("_rlnTomoName row count does not match the particles STAR file")
+
+    component_owner = {}
+    for particle_idx, particle_images in enumerate(index_map.particle_to_images):
+        names = tilt_names[particle_images]
+        if tomo_names is not None:
+            particle_tomos = np.unique(tomo_names[particle_images])
+            if particle_tomos.size != 1:
+                raise ValueError("A particle contains images assigned to multiple _rlnTomoName values")
+            merge_keys = [("tomo", str(particle_tomos[0]))]
+        else:
+            parsed_stacks = []
+            for name in names:
+                image_number, separator, stack_name = name.partition("@")
+                if separator and image_number.isdigit() and stack_name:
+                    parsed_stacks.append(stack_name)
+            if len(parsed_stacks) == len(names) and len(set(parsed_stacks)) == 1:
+                merge_keys = [("stack", parsed_stacks[0])]
+            else:
+                merge_keys = [("tilt", str(name)) for name in np.unique(names)]
+        for merge_key in merge_keys:
+            if merge_key in component_owner:
+                union(particle_idx, component_owner[merge_key])
+            else:
+                component_owner[merge_key] = particle_idx
+
+    component_particles = {}
+    for particle_idx in range(index_map.n_particles):
+        component_particles.setdefault(find(particle_idx), []).append(particle_idx)
+
+    # Include the tilt-series component in the physical identity. This keeps
+    # generic names such as tilt_001 distinct across tomograms.
+    image_components = np.full(index_map.n_images, -1, dtype=np.int32)
+    for particle_idx, particle_images in enumerate(index_map.particle_to_images):
+        image_components[particle_images] = find(particle_idx)
+    if np.any(image_components < 0):
+        raise ValueError("Could not assign every particles STAR row to a tilt series")
+
+    physical_tilt_ids = {}
+    image_to_tilt = np.empty(index_map.n_images, dtype=np.int32)
+    for image_idx, (component, tilt_name) in enumerate(zip(image_components, tilt_names, strict=True)):
+        key = (int(component), str(tilt_name))
+        tilt_idx = physical_tilt_ids.setdefault(key, len(physical_tilt_ids))
+        image_to_tilt[image_idx] = tilt_idx
+
+    n_physical_tilts = len(physical_tilt_ids)
+    tilt_counts = np.bincount(image_to_tilt, minlength=n_physical_tilts)
+
+    def aggregate_metadata(column, *, require_consistent=False):
+        if column not in particles.columns:
+            return None
+        values = np.asarray(particles[column], dtype=np.float64)
+        if values.shape != (index_map.n_images,):
+            raise ValueError(f"{column} row count does not match the particles STAR file")
+        finite = np.isfinite(values)
+        finite_counts = np.bincount(image_to_tilt[finite], minlength=n_physical_tilts)
+        sums = np.bincount(
+            image_to_tilt[finite],
+            weights=values[finite],
+            minlength=n_physical_tilts,
+        )
+        result = np.full(n_physical_tilts, np.nan, dtype=np.float64)
+        valid = finite_counts == tilt_counts
+        result[valid] = sums[valid] / finite_counts[valid]
+        if require_consistent:
+            minima = np.full(n_physical_tilts, np.inf, dtype=np.float64)
+            maxima = np.full(n_physical_tilts, -np.inf, dtype=np.float64)
+            np.minimum.at(minima, image_to_tilt[finite], values[finite])
+            np.maximum.at(maxima, image_to_tilt[finite], values[finite])
+            inconsistent = valid & ~np.isclose(minima, maxima, rtol=1e-6, atol=1e-6)
+            if np.any(inconsistent):
+                raise ValueError(f"A physical tilt identity has inconsistent {column} values")
+        return result
+
+    dose_column = "_rlnMicrographPreExposure"
+    tilt_doses = aggregate_metadata(dose_column, require_consistent=True)
+    angle_column = "_rlnTomoNominalStageTiltAngle"
+    tilt_angles = aggregate_metadata(angle_column)
+
+    def expected_angle_offsets(count):
+        offsets = [0]
+        radius = 1
+        while len(offsets) < count:
+            offsets.append(-radius)
+            if len(offsets) < count:
+                offsets.append(radius)
+            radius += 1
+        return np.asarray(offsets, dtype=np.float64)
+
+    def match_regular_positions(values, expected_offsets, *, use_closest_to_zero):
+        """Match a complete central lattice without replacing a missing position."""
+        values = np.asarray(values, dtype=np.float64)
+        if values.size < expected_offsets.size or not np.all(np.isfinite(values)):
+            return None
+
+        spacings = np.diff(np.sort(values))
+        spacings = spacings[spacings > 1e-6]
+        if spacings.size == 0:
+            if expected_offsets.size == 1:
+                candidate = int(np.argmin(np.abs(values)))
+                return np.array([candidate], dtype=np.int32)
+            return None
+
+        step = float(np.median(spacings))
+        tolerance = max(0.35 * step, 1e-3)
+        origin_idx = int(np.argmin(np.abs(values))) if use_closest_to_zero else int(np.argmin(values))
+        origin = float(values[origin_idx])
+        # Nominal angles and RELION pre-exposure both have a zero-origin
+        # central position. If it is absent, do not promote the next view.
+        if abs(origin) > tolerance:
+            return None
+
+        targets = origin + expected_offsets * step
+        matched = []
+        for target in targets:
+            candidate = int(np.argmin(np.abs(values - target)))
+            if abs(float(values[candidate]) - float(target)) > tolerance or candidate in matched:
+                return None
+            matched.append(candidate)
+        return np.asarray(matched, dtype=np.int32)
+
+    target_tilts_by_component = {}
+    angle_selected_components = 0
+    dose_selected_components = 0
+    incomplete_components = 0
+    for root, particle_indices in component_particles.items():
+        component_images = np.concatenate(
+            [index_map.particle_to_images[int(particle_idx)] for particle_idx in particle_indices]
+        )
+        component_tilts = np.unique(image_to_tilt[component_images])
+        if component_tilts.size < n_central:
+            incomplete_components += 1
+            continue
+
+        component_angles = None if tilt_angles is None else tilt_angles[component_tilts]
+        angles_are_informative = (
+            component_angles is not None and np.all(np.isfinite(component_angles)) and np.ptp(component_angles) > 1e-3
+        )
+        if angles_are_informative:
+            matched = match_regular_positions(
+                component_angles,
+                expected_angle_offsets(n_central),
+                use_closest_to_zero=True,
+            )
+            method = "angle"
+        else:
+            component_doses = None if tilt_doses is None else tilt_doses[component_tilts]
+            matched = match_regular_positions(
+                component_doses if component_doses is not None else np.array([], dtype=np.float64),
+                np.arange(n_central, dtype=np.float64),
+                use_closest_to_zero=False,
+            )
+            method = "dose"
+
+        if matched is None:
+            incomplete_components += 1
+            continue
+        if method == "angle":
+            angle_selected_components += 1
+        else:
+            dose_selected_components += 1
+        target_tilts_by_component[root] = component_tilts[matched]
+
+    allowed_mask = np.zeros(index_map.n_images, dtype=bool)
+    allowed_mask[np.asarray(allowed_images, dtype=np.int64)] = True
+
+    complete_particles = []
+    complete_images = []
+    for particle_idx in np.asarray(candidate_particles, dtype=np.int32):
+        target_tilts = target_tilts_by_component.get(find(particle_idx))
+        if target_tilts is None:
+            continue
+        particle_images = index_map.particle_to_images[int(particle_idx)]
+        selected = particle_images[
+            np.isin(image_to_tilt[particle_images], target_tilts) & allowed_mask[particle_images]
+        ]
+        if selected.size != n_central:
+            continue
+        if np.unique(image_to_tilt[selected]).size != n_central:
+            continue
+        complete_particles.append(int(particle_idx))
+        complete_images.extend(selected.tolist())
+
+    if not complete_particles:
+        raise ValueError(f"No particles contain all central_tilts={n_central} nominal positions after applying filters")
+
+    complete_particles = np.asarray(complete_particles, dtype=np.int32)
+    complete_images = np.asarray(complete_images, dtype=np.int32)
+    logger.info(
+        "Central-tilt selection: %d positions per tilt series; %d series selected by angle, %d by dose, "
+        "and %d lacked a complete central lattice; retained %d/%d particles and %d images",
+        n_central,
+        angle_selected_components,
+        dose_selected_components,
+        incomplete_components,
+        complete_particles.size,
+        np.asarray(candidate_particles).size,
+        complete_images.size,
+    )
+    return complete_particles, complete_images
+
+
 def get_split_tilt_indices(
     particles_file,
     ind_file=None,
@@ -181,11 +437,17 @@ def get_split_tilt_indices(
     ntilts=None,
     datadir=None,
     particle_halfset_indices_file=None,
+    central_tilts=None,
 ):
     """Split a tilt-series dataset into two halfsets (image indices).
 
     Supports optional filtering by image/particle indices and precomputed splits.
+    ``central_tilts`` keeps only particles containing the same nominally central
+    physical tilt identities within each tilt series and never substitutes a later view.
     """
+    if central_tilts is not None and ntilts is not None:
+        raise ValueError("central_tilts and ntilts are mutually exclusive")
+
     index_map = TiltSeriesOriginalIndexMap.from_particles_file(
         particles_file,
         datadir=datadir,
@@ -238,6 +500,15 @@ def get_split_tilt_indices(
     if allowed_image_indices.size == 0:
         empty = np.array([], dtype=np.int32)
         return [empty, empty]
+
+    if central_tilts is not None:
+        particle_ind, allowed_image_indices = _select_complete_central_tilts(
+            index_map,
+            particles_file,
+            central_tilts,
+            particle_ind,
+            allowed_image_indices,
+        )
 
     valid_particles = index_map.particle_indices_from_images(allowed_image_indices)
     if valid_particles.size == 0:
@@ -389,7 +660,16 @@ def resolve_halfset_indices(args):
     ind_file = getattr(args, "ind", None)
     tilt_ind_file = getattr(args, "tilt_ind", None)
     ntilts = getattr(args, "ntilts", None)
+    central_tilts = getattr(args, "central_tilts", None)
     n_images = getattr(args, "n_images", None) or -1
+
+    if central_tilts is not None:
+        if not getattr(args, "tilt_series", False):
+            raise ValueError("--central-tilts requires tilt-series data")
+        if ntilts is not None:
+            raise ValueError("--central-tilts and --ntilts are mutually exclusive")
+        if n_images > 0:
+            raise ValueError("--n-images cannot be combined with --central-tilts")
 
     if args.halfsets is None:
         n_total_from_star = None
@@ -413,6 +693,7 @@ def resolve_halfset_indices(args):
                 ind_file=ind_file,
                 tilt_ind_file=tilt_ind_file,
                 ntilts=ntilts,
+                central_tilts=central_tilts,
                 datadir=datadir,
             )
         else:
@@ -432,6 +713,7 @@ def resolve_halfset_indices(args):
                 ind_file=ind_file,
                 tilt_ind_file=tilt_ind_file,
                 ntilts=ntilts,
+                central_tilts=central_tilts,
                 datadir=datadir,
                 particle_halfset_indices_file=args.halfsets,
             )

--- a/tests/unit/test_central_tilts.py
+++ b/tests/unit/test_central_tilts.py
@@ -1,0 +1,448 @@
+"""Focused regressions for strict common-position ``--central-tilts`` selection."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("jax")
+
+from recovar.commands import pipeline as pipeline_cmd
+from recovar.data_io import halfsets, starfile
+
+pytestmark = pytest.mark.unit
+
+
+def _write_mrcs(path: Path, data: np.ndarray) -> None:
+    import mrcfile
+
+    with mrcfile.new(path, overwrite=True) as mrc:
+        mrc.set_data(np.asarray(data, dtype=np.float32))
+
+
+def _make_global_dose_tilt_fixture(tmp_path: Path):
+    """Make four particles over shared doses; gB lacks central dose 6."""
+    rows = [
+        ("gB", 0.0),
+        ("gA", 9.0),
+        ("gC", 12.0),
+        ("gD", 6.0),
+        ("gA", 0.0),
+        ("gB", 3.0),
+        ("gD", 0.0),
+        ("gC", 6.0),
+        ("gB", 9.0),
+        ("gA", 6.0),
+        ("gC", 0.0),
+        ("gD", 12.0),
+        ("gB", 12.0),
+        ("gA", 3.0),
+        ("gC", 3.0),
+        ("gD", 3.0),
+        ("gA", 12.0),
+        ("gB", 15.0),
+        ("gC", 9.0),
+        ("gD", 9.0),
+        ("gA", 15.0),
+        ("gB", 18.0),
+        ("gC", 15.0),
+        ("gD", 15.0),
+    ]
+    n_images = len(rows)
+    box_size = 8
+    mrcs_path = tmp_path / "global_dose_stack.mrcs"
+    _write_mrcs(
+        mrcs_path,
+        np.arange(n_images * box_size * box_size, dtype=np.float32).reshape(n_images, box_size, box_size),
+    )
+
+    particle_df = pd.DataFrame(
+        {
+            "_rlnImageName": [f"{idx + 1}@{mrcs_path.name}" for idx in range(n_images)],
+            "_rlnGroupName": [group for group, _dose in rows],
+            "_rlnTiltName": [f"{int(dose)}@fixture_tomo.mrcs" for _group, dose in rows],
+            "_rlnMicrographPreExposure": [dose for _group, dose in rows],
+            # Some extracted STARs have an uninformative all-zero angle column.
+            # The strict position identity must still work from global dose.
+            "_rlnTomoNominalStageTiltAngle": np.zeros(n_images, dtype=np.float32),
+            "_rlnCtfScalefactor": np.ones(n_images, dtype=np.float32),
+            "_rlnCtfBfactor": -np.ones(n_images, dtype=np.float32),
+        }
+    )
+    star_path = tmp_path / "global_dose_particles.star"
+    starfile.write_star(str(star_path), data=particle_df)
+    return star_path, particle_df
+
+
+def _selected_image_union(split):
+    return np.sort(np.concatenate([np.asarray(half, dtype=np.int32) for half in split]))
+
+
+def _all_particles_in_first_halfset():
+    return [np.arange(4, dtype=np.int32), np.array([], dtype=np.int32)]
+
+
+def _pipeline_parser():
+    parser = argparse.ArgumentParser()
+    pipeline_cmd.add_args(parser)
+    return parser
+
+
+def test_pipeline_parser_registers_central_tilts():
+    parser = _pipeline_parser()
+    action = parser._option_string_actions["--central-tilts"]
+
+    assert action.dest == "central_tilts"
+    assert action.default is None
+    args = parser.parse_args(["particles.star", "--mask", "sphere", "--central-tilts", "5"])
+    assert args.central_tilts == 5
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_pipeline_parser_rejects_nonpositive_central_tilts(value):
+    with pytest.raises(SystemExit):
+        _pipeline_parser().parse_args(["particles.star", "--mask", "sphere", "--central-tilts", value])
+
+
+def test_pipeline_parser_rejects_central_tilts_with_ntilts():
+    with pytest.raises(SystemExit):
+        _pipeline_parser().parse_args(
+            [
+                "particles.star",
+                "--mask",
+                "sphere",
+                "--central-tilts",
+                "5",
+                "--ntilts",
+                "5",
+            ]
+        )
+
+
+def test_pipeline_validation_requires_tilt_series():
+    args = SimpleNamespace(central_tilts=5, ntilts=None, tilt_series=False)
+    with pytest.raises(ValueError, match="requires --tilt-series"):
+        pipeline_cmd._validate_tilt_selection_args(args)
+
+
+def test_pipeline_validation_rejects_programmatic_ntilts_conflict():
+    args = SimpleNamespace(central_tilts=5, ntilts=5, tilt_series=True)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        pipeline_cmd._validate_tilt_selection_args(args)
+
+
+def test_central_tilts_requires_full_global_dose_set_without_substitution(tmp_path):
+    star_path, particle_df = _make_global_dose_tilt_fixture(tmp_path)
+    split = halfsets.get_split_tilt_indices(
+        particles_file=str(star_path),
+        central_tilts=5,
+        datadir=str(tmp_path),
+        particle_halfset_indices_file=_all_particles_in_first_halfset(),
+    )
+
+    kept = _selected_image_union(split)
+    # Global targets are doses 0, 3, 6, 9, 12. gB lacks dose 6 and must be
+    # removed; its later dose-15 image must not substitute for the missing view.
+    expected = np.array([1, 2, 3, 4, 6, 7, 9, 10, 11, 13, 14, 15, 16, 18, 19], dtype=np.int32)
+    np.testing.assert_array_equal(kept, expected)
+    assert set(particle_df.iloc[kept]["_rlnGroupName"]) == {"gA", "gC", "gD"}
+    for _group, particle_rows in particle_df.iloc[kept].groupby("_rlnGroupName"):
+        np.testing.assert_array_equal(
+            np.sort(particle_rows["_rlnMicrographPreExposure"].to_numpy(dtype=float)),
+            np.array([0.0, 3.0, 6.0, 9.0, 12.0]),
+        )
+
+    ordinary_split = halfsets.get_split_tilt_indices(
+        particles_file=str(star_path),
+        ntilts=5,
+        datadir=str(tmp_path),
+        particle_halfset_indices_file=_all_particles_in_first_halfset(),
+    )
+    assert 17 in _selected_image_union(ordinary_split)  # gB's dose-15 substitution under --ntilts.
+
+
+def test_central_tilts_applies_ind_before_particle_completeness(tmp_path):
+    star_path, particle_df = _make_global_dose_tilt_fixture(tmp_path)
+    # Remove gC's central dose-6 image but retain its later dose-15 image.
+    image_ind = np.setdiff1d(np.arange(len(particle_df), dtype=np.int32), np.array([7], dtype=np.int32))
+    split = halfsets.get_split_tilt_indices(
+        particles_file=str(star_path),
+        ind_file=image_ind,
+        central_tilts=5,
+        datadir=str(tmp_path),
+        particle_halfset_indices_file=_all_particles_in_first_halfset(),
+    )
+
+    kept = _selected_image_union(split)
+    assert set(particle_df.iloc[kept]["_rlnGroupName"]) == {"gA", "gD"}
+    assert 22 not in kept
+    assert kept.size == 10
+
+
+def test_central_tilts_composes_with_particle_ind(tmp_path):
+    star_path, particle_df = _make_global_dose_tilt_fixture(tmp_path)
+    split = halfsets.get_split_tilt_indices(
+        particles_file=str(star_path),
+        tilt_ind_file=np.array([1, 2], dtype=np.int32),  # canonical gB and gC
+        central_tilts=5,
+        datadir=str(tmp_path),
+        particle_halfset_indices_file=[np.array([1, 2], dtype=np.int32), np.array([], dtype=np.int32)],
+    )
+
+    kept = _selected_image_union(split)
+    assert set(particle_df.iloc[kept]["_rlnGroupName"]) == {"gC"}
+    assert kept.size == 5
+
+
+def test_central_tilts_allows_different_dose_schedules_per_tomogram(tmp_path):
+    rows = []
+    schedules = {
+        "tomoA": [0.0, 3.0, 6.0, 9.0, 12.0, 15.0],
+        "tomoB": [0.2, 3.1, 6.2, 9.3, 12.4, 15.5],
+    }
+    for tomo_name, doses in schedules.items():
+        for particle_name, frames in (("full", range(6)), ("missing", [0, 1, 3, 4, 5])):
+            for frame in frames:
+                rows.append((f"{tomo_name}/{particle_name}", f"{frame + 1}@{tomo_name}.mrcs", doses[frame]))
+
+    particle_df = pd.DataFrame(
+        {
+            "_rlnImageName": [f"{idx + 1}@variable_schedule.mrcs" for idx in range(len(rows))],
+            "_rlnGroupName": [row[0] for row in rows],
+            "_rlnTiltName": [row[1] for row in rows],
+            "_rlnMicrographPreExposure": [row[2] for row in rows],
+            "_rlnTomoNominalStageTiltAngle": np.zeros(len(rows), dtype=np.float32),
+            "_rlnCtfScalefactor": np.ones(len(rows), dtype=np.float32),
+            "_rlnCtfBfactor": -np.ones(len(rows), dtype=np.float32),
+        }
+    )
+    star_path = tmp_path / "variable_schedule.star"
+    starfile.write_star(str(star_path), data=particle_df)
+
+    split = halfsets.get_split_tilt_indices(
+        particles_file=str(star_path),
+        central_tilts=5,
+        particle_halfset_indices_file=[np.arange(4, dtype=np.int32), np.array([], dtype=np.int32)],
+    )
+    kept = _selected_image_union(split)
+    assert set(particle_df.iloc[kept]["_rlnGroupName"]) == {"tomoA/full", "tomoB/full"}
+    assert kept.size == 10
+
+
+def test_central_tilts_prefers_informative_nominal_angles(tmp_path):
+    angles = [-9.0, -6.0, -3.0, 0.0, 3.0, 6.0]
+    rows = []
+    for particle_name in ("particle1", "particle2"):
+        for frame, angle in enumerate(angles):
+            rows.append((particle_name, f"{frame + 1}@angle_tomo.mrcs", float(frame), angle))
+
+    particle_df = pd.DataFrame(
+        {
+            "_rlnImageName": [f"{idx + 1}@angle_stack.mrcs" for idx in range(len(rows))],
+            "_rlnGroupName": [row[0] for row in rows],
+            "_rlnTiltName": [row[1] for row in rows],
+            "_rlnMicrographPreExposure": [row[2] for row in rows],
+            "_rlnTomoNominalStageTiltAngle": [row[3] for row in rows],
+            "_rlnCtfScalefactor": np.ones(len(rows), dtype=np.float32),
+            "_rlnCtfBfactor": -np.ones(len(rows), dtype=np.float32),
+        }
+    )
+    star_path = tmp_path / "angle_schedule.star"
+    starfile.write_star(str(star_path), data=particle_df)
+
+    split = halfsets.get_split_tilt_indices(
+        particles_file=str(star_path),
+        central_tilts=5,
+        particle_halfset_indices_file=[np.arange(2, dtype=np.int32), np.array([], dtype=np.int32)],
+    )
+    kept = _selected_image_union(split)
+    for _group, particle_rows in particle_df.iloc[kept].groupby("_rlnGroupName"):
+        np.testing.assert_array_equal(
+            np.sort(particle_rows["_rlnTomoNominalStageTiltAngle"].to_numpy(dtype=float)),
+            np.array([-6.0, -3.0, 0.0, 3.0, 6.0]),
+        )
+
+
+@pytest.mark.parametrize("central_tilts", [0, -1, 8])
+def test_get_split_tilt_indices_rejects_invalid_central_tilts(tmp_path, central_tilts):
+    star_path, _particle_df = _make_global_dose_tilt_fixture(tmp_path)
+    with pytest.raises(ValueError, match="central_tilts"):
+        halfsets.get_split_tilt_indices(
+            particles_file=str(star_path),
+            central_tilts=central_tilts,
+            datadir=str(tmp_path),
+        )
+
+
+def test_get_split_tilt_indices_rejects_central_tilts_with_ntilts(tmp_path):
+    star_path, _particle_df = _make_global_dose_tilt_fixture(tmp_path)
+    with pytest.raises(ValueError, match="central_tilts.*ntilts|ntilts.*central_tilts"):
+        halfsets.get_split_tilt_indices(
+            particles_file=str(star_path),
+            central_tilts=5,
+            ntilts=5,
+            datadir=str(tmp_path),
+        )
+
+
+def test_resolve_halfset_indices_propagates_central_tilts(monkeypatch):
+    captured = {}
+
+    def fake_get_split_tilt_indices(*args, **kwargs):
+        captured.update(kwargs)
+        return [np.array([0, 2], dtype=np.int32), np.array([1, 3], dtype=np.int32)]
+
+    args = SimpleNamespace(
+        halfsets=None,
+        tilt_series=True,
+        tilt_series_ctf="relion5",
+        particles="particles.star",
+        ind=None,
+        tilt_ind=None,
+        ntilts=None,
+        central_tilts=5,
+        datadir="/tmp/data",
+        strip_prefix=None,
+        n_images=-1,
+    )
+    monkeypatch.setattr(halfsets, "get_split_tilt_indices", fake_get_split_tilt_indices)
+
+    halfsets.resolve_halfset_indices(args)
+
+    assert captured["central_tilts"] == 5
+
+
+def test_resolve_halfset_indices_rejects_n_images_with_central_tilts(monkeypatch):
+    args = SimpleNamespace(
+        halfsets=None,
+        tilt_series=True,
+        tilt_series_ctf="relion5",
+        particles="particles.star",
+        ind=None,
+        tilt_ind=None,
+        ntilts=None,
+        central_tilts=5,
+        datadir="/tmp/data",
+        strip_prefix=None,
+        n_images=10,
+    )
+    monkeypatch.setattr(
+        halfsets,
+        "get_split_tilt_indices",
+        lambda *args, **kwargs: [np.arange(10, dtype=np.int32), np.arange(10, 20, dtype=np.int32)],
+    )
+
+    with pytest.raises(ValueError, match="n-images.*central-tilts"):
+        halfsets.resolve_halfset_indices(args)
+
+
+def _write_identity_star(tmp_path, name, rows, *, include_dose=True):
+    particle_df = pd.DataFrame(
+        {
+            "_rlnImageName": [f"{idx + 1}@{name}_images.mrcs" for idx in range(len(rows))],
+            "_rlnGroupName": [row["particle"] for row in rows],
+            "_rlnTiltName": [row["tilt_name"] for row in rows],
+            "_rlnTomoNominalStageTiltAngle": [row["angle"] for row in rows],
+            "_rlnCtfScalefactor": np.ones(len(rows), dtype=np.float32),
+            "_rlnCtfBfactor": -np.ones(len(rows), dtype=np.float32),
+        }
+    )
+    if include_dose:
+        particle_df["_rlnMicrographPreExposure"] = [row["dose"] for row in rows]
+    star_path = tmp_path / f"{name}.star"
+    starfile.write_star(str(star_path), data=particle_df)
+    return star_path, particle_df
+
+
+def test_central_tilts_accepts_separate_stack_per_physical_tilt(tmp_path):
+    rows = []
+    angles = [-6.0, -3.0, 0.0, 3.0, 6.0]
+    for particle in ("p0", "p1"):
+        for frame, angle in enumerate(angles):
+            rows.append(
+                {
+                    "particle": particle,
+                    "tilt_name": f"1@physical_tilt_{frame}.mrcs",
+                    "angle": angle,
+                    "dose": float(frame),
+                }
+            )
+    star_path, _particle_df = _write_identity_star(tmp_path, "separate_stacks", rows)
+
+    split = halfsets.get_split_tilt_indices(str(star_path), central_tilts=5)
+    assert _selected_image_union(split).size == 10
+
+
+def test_central_tilts_uses_informative_angles_without_dose_column(tmp_path):
+    rows = []
+    angles = [-6.0, -3.0, 0.0, 3.0, 6.0]
+    for particle in ("p0", "p1"):
+        for frame, angle in enumerate(angles):
+            rows.append(
+                {
+                    "particle": particle,
+                    "tilt_name": f"{frame + 1}@angle_only_tomo.mrcs",
+                    "angle": angle,
+                }
+            )
+    star_path, particle_df = _write_identity_star(tmp_path, "angle_only", rows, include_dose=False)
+
+    split = halfsets.get_split_tilt_indices(str(star_path), central_tilts=5)
+    kept = _selected_image_union(split)
+    assert kept.size == 10
+    assert "_rlnMicrographPreExposure" not in particle_df.columns
+
+
+def test_nan_angle_in_one_tomogram_does_not_disable_other_tomograms(tmp_path):
+    rows = []
+    angles = [-9.0, -6.0, -3.0, 0.0, 3.0, 6.0]
+    for tomo in ("good", "bad"):
+        for frame, angle in enumerate(angles):
+            rows.append(
+                {
+                    "particle": f"{tomo}/particle",
+                    "tilt_name": f"{frame + 1}@{tomo}_tomo.mrcs",
+                    "angle": np.nan if tomo == "bad" and frame == 0 else angle,
+                    "dose": float(frame),
+                }
+            )
+    star_path, particle_df = _write_identity_star(tmp_path, "isolated_nan", rows)
+
+    split = halfsets.get_split_tilt_indices(str(star_path), central_tilts=5)
+    kept_rows = particle_df.iloc[_selected_image_union(split)]
+    good_angles = np.sort(
+        kept_rows.loc[
+            kept_rows["_rlnGroupName"] == "good/particle",
+            "_rlnTomoNominalStageTiltAngle",
+        ].to_numpy(dtype=float)
+    )
+    np.testing.assert_array_equal(good_angles, np.array([-6.0, -3.0, 0.0, 3.0, 6.0]))
+
+
+def test_central_tilts_drops_tomogram_whose_zero_position_is_absent(tmp_path):
+    rows = []
+    schedules = {
+        "complete": [-6.0, -3.0, 0.0, 3.0, 6.0],
+        "missing_zero": [-9.0, -6.0, -3.0, 3.0, 6.0, 9.0],
+    }
+    for tomo, angles in schedules.items():
+        for frame, angle in enumerate(angles):
+            rows.append(
+                {
+                    "particle": f"{tomo}/particle",
+                    "tilt_name": f"{frame + 1}@{tomo}_tomo.mrcs",
+                    "angle": angle,
+                    "dose": float(frame),
+                }
+            )
+    star_path, particle_df = _write_identity_star(tmp_path, "missing_zero", rows)
+
+    split = halfsets.get_split_tilt_indices(str(star_path), central_tilts=5)
+    kept = _selected_image_union(split)
+    assert set(particle_df.iloc[kept]["_rlnGroupName"]) == {"complete/particle"}
+    assert kept.size == 5


### PR DESCRIPTION
## Summary

- add `--central-tilts N` as a tilt-series selection mode, mutually exclusive with `--ntilts`
- identify physical tilt positions within each tilt series using tilt metadata
- select the central nominal angle lattice when stage angles are informative, with a lowest-dose fallback
- retain only particles containing every requested central position, without substituting later available views
- compose the selection with image indices, particle indices, explicit halfsets, and outlier-pipeline rounds
- add focused coverage for multi-tomogram metadata, missing positions, filters, explicit halfsets, and invalid combinations

## Motivation

`--ntilts N` keeps the first N available dose-ranked views independently for each particle. If an early central view is missing, a later view is substituted and the particle remains in the analysis. This option provides a strict common-position cohort for comparisons that require every retained particle to contain the same nominal central tilts.

## Testing

- `tests/unit/test_central_tilts.py`
- `tests/unit/test_cryo_et_subset_io.py`
- `tests/unit/test_commands_pipeline.py`
- `tests/unit/test_pipeline_with_outliers.py`
- 64 passed
- Ruff and `git diff --check` pass