### PR TITLE
docs: add Contributing pointer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,6 @@ The inputs needed to reproduce the experiments in this paper can be access on th
 Marc Aurele Gilles — [gilles@princeton.edu](mailto:gilles@princeton.edu)
 
 Issues and feature requests: [GitHub Issues](https://github.com/ma-gilles/recovar/issues)
+
+<!-- Contributing: see CONTRIBUTING.md for dev setup -->
+


### PR DESCRIPTION
Hello team - docs-only:
- adds Contributing pointer comment to README (see CONTRIBUTING.md)
- helps new contributors find dev setup quickly

No code change.
